### PR TITLE
feat(agents): add seed-based test subsampling

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -543,7 +543,12 @@ scripts/test-agent.sh --fast       # Quick smoke test (<30s)
 scripts/test-agent.sh              # Full suite
 scripts/test-agent.sh --summary    # Last run's results
 scripts/test-agent.sh --suite X    # Specific: bridge|server|e2e|pike
+scripts/test-agent.sh --fast --seed feat/hover   # Deterministic subset (40% of server tests)
+scripts/test-agent.sh --seed X --seed-fraction 60  # Custom fraction (60%)
+scripts/test-agent.sh --seed X --dry-run           # Preview file selection
 ```
+
+**Seed-based subsampling:** When `--seed` is provided, only a deterministic subset of server test files runs. Different seeds select different files, so parallel agents exercise different slices. Bridge tests and pike-compile always run regardless of seed.
 
 Output is agent-optimized:
 - `ERROR: [suite] message` prefix on every failure (grep-friendly)


### PR DESCRIPTION
## Summary
- Add `--seed <value>` flag to `scripts/test-agent.sh` for deterministic per-agent test file selection
- Add `--seed-fraction <N>` flag (default 40%) to control subset size
- Add `--dry-run` flag to preview file selection without running tests
- Bridge tests and pike-compile always run (never subsampled)
- Document new flags in `.claude/CLAUDE.md`

Different seeds select different server test files via md5sum hashing, so parallel agents exercise different slices of the test suite.

## Test plan
- [x] `--dry-run` with `feat/hover` seed selects 26/63 files
- [x] `--dry-run` with `fix/crash` seed selects different 26/63 files
- [x] `--dry-run` without seed shows all 63 files
- [x] `--fast --seed test-verify` runs and passes (3 suites)
- [x] `--fast` (no seed) backward compatible, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)