### PR TITLE
chore: bump version to 0.1.0-alpha.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security** - Security vulnerability fixes
 - **Performance** - User-facing performance notes
 
+## [0.1.0-alpha.17] - 2026-02-07
+
+### Optimization
+- **Hash-based cache eviction** - Replace LRU tracking with hash-based eviction for zero overhead (7.2% faster on cache-intensive workloads)
+
+### Added
+- **Agent workflow automation** - Carlini Protocol for parallel agent coordination with worktrees
+- **Branch protection** - GitHub ruleset enforcing PR workflow and required status checks
+- **Seed-based test subsampling** - Deterministic test subset selection for parallel agent testing
+
+### Fixed
+- **ParamOrder performance** - Replace O(n²) array append with O(1) mapping insert
+- **Benchmark accuracy** - Improve regression detection with rolling averages
+- **Test infrastructure** - Enhanced test-agent script with quality reporting
+
+### Changed
+- **Test coverage** - Converted 286 placeholder tests to real assertions (symbols, config, hierarchy, diagnostics, advanced features)
+- **Agent protocols** - Standardized workflow, TDD, and Pike code style guidelines
+
 ## [0.1.0-alpha.13] - 2026-02-01
 
 ### Optimization

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pike-lsp",
-  "version": "0.1.0-alpha.16",
+  "version": "0.1.0-alpha.17",
   "private": true,
   "description": "Pike Language Server Protocol implementation and VSCode extension",
   "author": "Pike LSP Team",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/core",
-  "version": "0.1.0-alpha.14",
+  "version": "0.1.0-alpha.17",
   "description": "Shared utilities for Pike LSP packages",
   "repository": {
     "type": "git",

--- a/packages/pike-bridge/package.json
+++ b/packages/pike-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/pike-bridge",
-  "version": "0.1.0-alpha.14",
+  "version": "0.1.0-alpha.17",
   "description": "TypeScript <-> Pike subprocess communication layer",
   "repository": {
     "type": "git",

--- a/packages/pike-lsp-server/package.json
+++ b/packages/pike-lsp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/pike-lsp-server",
-  "version": "0.1.0-alpha.14",
+  "version": "0.1.0-alpha.17",
   "description": "Pike Language Server Protocol implementation",
   "type": "module",
   "main": "./dist/server.js",

--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-pike",
   "displayName": "Pike Language Support",
   "description": "Complete language support for Pike including IntelliSense, go-to-definition, find references, diagnostics, hover, signature help, code completion, semantic tokens, call hierarchy, and workspace symbols.",
-  "version": "0.1.0-alpha.16",
+  "version": "0.1.0-alpha.17",
   "publisher": "pike-lsp",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
## Version Bump: v0.1.0-alpha.17

### Changes

- **Optimization**: Hash-based cache eviction (7.2% faster on cache-intensive workloads)
- **Added**: Agent workflow automation (Carlini Protocol), branch protection, seed-based test subsampling
- **Fixed**: ParamOrder performance (O(n²) → O(1)), benchmark accuracy, test infrastructure
- **Changed**: Converted 286 placeholder tests to real assertions

### Checklist

- [x] All package.json files updated to 0.1.0-alpha.17
- [x] CHANGELOG.md entry added
- [x] All tests passing (4/4 suites)
- [x] Pre-commit and pre-push hooks passed