### PR TITLE
chore: bump version to 0.1.0-alpha.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security** - Security vulnerability fixes
 - **Performance** - User-facing performance notes
 
+## [0.1.0-alpha.18] - 2026-02-08
+
+### Added
+- **Roxen module LSP support** - Phase 1: Complete LSP support for Roxen WebServer Pike modules
+  - Roxen module detection (inherit "module", #include <module.h>)
+  - defvar variable extraction and symbol grouping
+  - RXML tag function detection (simpletag_*, container_*, RXML.Tag classes)
+  - Lifecycle callback detection (create(), start(), stop(), etc.)
+  - Diagnostics: Missing required callbacks (e.g., query_location for MODULE_LOCATION)
+  - Document symbols: "Roxen Module" container with variables, tags, and callbacks
+  - Completions: MODULE_*, TYPE_*, VAR_* constants with correct bit-shifted values
+  - Real source positions (line/column tracking) instead of hardcoded values
+  - 16 Roxen-specific tests (detect, defvar, tags, integration)
+
+- **Roadmap document** - ROXEN_SUPPORT_ROADMAP.md outlines Phases 2-7 for full framework support (RXML templates, .rjs files, embedded RXML, etc.)
+
+### Fixed
+- TypeScript build errors in Roxen feature (null handling, import paths)
+- Removed unused imports and parameters in roxen/index.ts and symbols.ts
+
+### Changed
+- Removed junk .md files (IMPLEMENTATION_COMPLETE.md, IMPORT_INHERIT_IMPLEMENTATION_SPEC.md, IMPORT_INHERIT_TEST_SUMMARY.md, MODULE_RESOLUTION_AUDIT.md)
+
+**Note:** This is Phase 1 of Roxen framework support, focusing on `.pike` Roxen modules only. Future phases will add RXML template support (.inc, .html, .xml files), Roxen JavaScript (.rjs) support, and advanced features. See ROXEN_SUPPORT_ROADMAP.md for the complete implementation plan.
+
 ## [0.1.0-alpha.17] - 2026-02-07
 
 ### Optimization

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pike-lsp",
-  "version": "0.1.0-alpha.17",
+  "version": "0.1.0-alpha.18",
   "private": true,
   "description": "Pike Language Server Protocol implementation and VSCode extension",
   "author": "Pike LSP Team",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/core",
-  "version": "0.1.0-alpha.17",
+  "version": "0.1.0-alpha.18",
   "description": "Shared utilities for Pike LSP packages",
   "repository": {
     "type": "git",

--- a/packages/pike-bridge/package.json
+++ b/packages/pike-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/pike-bridge",
-  "version": "0.1.0-alpha.17",
+  "version": "0.1.0-alpha.18",
   "description": "TypeScript <-> Pike subprocess communication layer",
   "repository": {
     "type": "git",

--- a/packages/pike-lsp-server/package.json
+++ b/packages/pike-lsp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/pike-lsp-server",
-  "version": "0.1.0-alpha.17",
+  "version": "0.1.0-alpha.18",
   "description": "Pike Language Server Protocol implementation",
   "type": "module",
   "main": "./dist/server.js",

--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-pike",
   "displayName": "Pike Language Support",
   "description": "Complete language support for Pike including IntelliSense, go-to-definition, find references, diagnostics, hover, signature help, code completion, semantic tokens, call hierarchy, and workspace symbols.",
-  "version": "0.1.0-alpha.17",
+  "version": "0.1.0-alpha.18",
   "publisher": "pike-lsp",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
Version bump for Roxen module LSP support (Phase 1).

Changes:
- Add Roxen module LSP support (Phase 1) to CHANGELOG
- Bump version: 0.1.0-alpha.17 → 0.1.0-alpha.18
- Sync version across all workspace packages

This is a release preparation PR.