### PR TITLE
feat: Add implementation provider for Pike interfaces (#117)

### DIFF
--- a/packages/pike-lsp-server/src/features/navigation/implementation.ts
+++ b/packages/pike-lsp-server/src/features/navigation/implementation.ts
@@ -1,0 +1,187 @@
+/**
+ * Implementation Handler
+ *
+ * Provides implementation navigation for Pike classes/interfaces.
+ * When invoked on a class/interface, finds all classes that inherit from it.
+ *
+ * Per LSP spec:
+ * - textDocument/implementation should find all implementations of an interface
+ * - For Pike, this means finding all classes with "inherit TargetClass"
+ * - Returns empty array for non-class symbols
+ * - Returns empty array when on an implementation (shows usages instead)
+ */
+
+import {
+    Connection,
+    Location,
+} from 'vscode-languageserver/node.js';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { TextDocuments } from 'vscode-languageserver/node.js';
+import type { Services } from '../../services/index.js';
+import { Logger } from '@pike-lsp/core';
+import type { PikeSymbol } from '@pike-lsp/pike-bridge';
+
+export function registerImplementationHandler(
+    connection: Connection,
+    services: Services,
+    documents: TextDocuments<TextDocument>
+): void {
+    const { documentCache } = services;
+    const log = new Logger('Navigation');
+
+    connection.onImplementation(async (params): Promise<Location[]> => {
+        log.debug('Implementation request', { uri: params.textDocument.uri, position: params.position });
+        try {
+            const uri = params.textDocument.uri;
+            const cached = documentCache.get(uri);
+            const document = documents.get(uri);
+
+            if (!cached || !document) {
+                return [];
+            }
+
+            const symbol = findSymbolAtPosition(cached.symbols, params.position, document);
+            if (!symbol) {
+                log.debug('Implementation: no symbol at position');
+                return [];
+            }
+
+            if (symbol.kind !== 'class') {
+                log.debug('Implementation: symbol is not a class/interface', { kind: symbol.kind });
+                return [];
+            }
+
+            const className = symbol.name;
+            const implementations: Location[] = [];
+
+            const currentDocImplementations = findInheritancesInDocument(
+                className,
+                uri,
+                cached.symbols
+            );
+            implementations.push(...currentDocImplementations);
+
+            for (const otherUri of Array.from(documentCache.keys())) {
+                if (otherUri === uri || !otherUri) continue;
+
+                const otherCached = documentCache.get(otherUri);
+                const otherDoc = documents.get(otherUri);
+                if (!otherCached || !otherDoc) continue;
+
+                const otherDocImplementations = findInheritancesInDocument(
+                        className,
+                        otherUri,
+                        otherCached.symbols
+                    );
+                implementations.push(...otherDocImplementations);
+            }
+
+            log.debug('Implementation: found', {
+                className,
+                count: implementations.length,
+                implementations: implementations.map(loc => ({ uri: loc.uri, range: loc.range }))
+            });
+
+            return implementations;
+        } catch (err) {
+            log.error('Implementation failed', { error: err instanceof Error ? err.message : String(err) });
+            return [];
+        }
+    });
+}
+
+function findSymbolAtPosition(
+    symbols: PikeSymbol[],
+    position: { line: number; character: number },
+    document: TextDocument
+): PikeSymbol | null {
+    const text = document.getText();
+    const offset = document.offsetAt(position);
+
+    let start = offset;
+    let end = offset;
+    while (start > 0 && text[start - 1] && /\w/.test(text[start - 1]!)) {
+        start--;
+    }
+    while (end < text.length && text[end] && /\w/.test(text[end]!)) {
+        end++;
+    }
+
+    const word = text.slice(start, end);
+    if (!word) {
+        return null;
+    }
+
+    for (const sym of symbols) {
+        if (sym.name === word) {
+            if (sym.position) {
+                const symbolLine = (sym.position.line ?? 1) - 1;
+                if (symbolLine === position.line) {
+                    return sym;
+                }
+            }
+        }
+    }
+
+    return null;
+}
+
+function findInheritancesInDocument(
+    className: string,
+    uri: string,
+    symbols: PikeSymbol[]
+): Location[] {
+    const implementations: Location[] = [];
+
+    for (const symbol of symbols) {
+        if (symbol.kind === 'inherit') {
+            const inheritClassName = (symbol as { classname?: string }).classname || symbol.name;
+            const normalizedInherit = (inheritClassName || '').replace(/["']/g, '').trim();
+            const normalizedTarget = className.replace(/["']/g, '').trim();
+
+            if (normalizedInherit === normalizedTarget) {
+                const classLocation = findClassContainingInherit(symbol, symbols, uri);
+                if (classLocation) {
+                    implementations.push(classLocation);
+                }
+            }
+        }
+    }
+
+    return implementations;
+}
+
+function findClassContainingInherit(
+    inheritSymbol: PikeSymbol,
+    symbols: PikeSymbol[],
+    uri: string
+): Location | null {
+    if (!inheritSymbol.position) return null;
+
+    const inheritLine = (inheritSymbol.position.line ?? 1) - 1;
+    let bestClass: PikeSymbol | null = null;
+
+    for (const symbol of symbols) {
+        if (symbol.kind === 'class' && symbol.position) {
+            const classLine = (symbol.position.line ?? 1) - 1;
+
+            if (classLine <= inheritLine) {
+                if (!bestClass || classLine > ((bestClass.position?.line ?? 1) - 1)) {
+                    bestClass = symbol;
+                }
+            }
+        }
+    }
+
+    if (bestClass && bestClass.position) {
+        return {
+            uri,
+            range: {
+                start: { line: (bestClass.position.line ?? 1) - 1, character: 0 },
+                end: { line: (bestClass.position.line ?? 1) - 1, character: (bestClass.name || '').length },
+            },
+        };
+    }
+
+    return null;
+}

--- a/packages/pike-lsp-server/src/features/navigation/index.ts
+++ b/packages/pike-lsp-server/src/features/navigation/index.ts
@@ -22,10 +22,12 @@ import type { Services } from '../../services/index.js';
 import { registerHoverHandler } from './hover.js';
 import { registerDefinitionHandlers } from './definition.js';
 import { registerReferencesHandlers } from './references.js';
+import { registerImplementationHandler } from './implementation.js';
 
 export { registerHoverHandler } from './hover.js';
 export { registerDefinitionHandlers } from './definition.js';
 export { registerReferencesHandlers } from './references.js';
+export { registerImplementationHandler } from './implementation.js';
 export { extractExpressionAtPosition } from './expression-utils.js';
 
 /**
@@ -43,4 +45,5 @@ export function registerNavigationHandlers(
     registerHoverHandler(connection, services, documents);
     registerDefinitionHandlers(connection, services, documents);
     registerReferencesHandlers(connection, services, documents);
+    registerImplementationHandler(connection, services, documents);
 }

--- a/packages/pike-lsp-server/src/tests/navigation/implementation-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/navigation/implementation-provider.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Implementation Provider Tests
+ *
+ * TDD tests for textDocument/implementation LSP handler.
+ * Tests finding implementations of Pike classes/interfaces.
+ *
+ * Per LSP spec:
+ * - textDocument/implementation finds all implementations of an interface
+ * - For Pike, this means finding all classes with "inherit TargetClass"
+ */
+
+import { describe, it, beforeEach } from 'bun:test';
+import assert from 'node:assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Location } from 'vscode-languageserver/node.js';
+import { registerImplementationHandler } from '../../features/navigation/implementation.js';
+
+class MockConnection {
+    constructor() {
+        this.handler = null;
+    }
+
+    onImplementation(callback) {
+        this.handler = callback;
+    }
+
+    implementationHandler(params) {
+        if (!this.handler) return Promise.resolve([]);
+        return this.handler(params);
+    }
+}
+
+class MockDocumentCache {
+    constructor() {
+        this.documents = new Map();
+    }
+
+    set(uri, data) {
+        this.documents.set(uri, data);
+    }
+
+    get(uri) {
+        return this.documents.get(uri);
+    }
+
+    keys() {
+        return Array.from(this.documents.keys());
+    }
+}
+
+class MockTextDocuments {
+    constructor() {
+        this.docs = new Map();
+    }
+
+    set(uri, doc) {
+        this.docs.set(uri, doc);
+    }
+
+    get(uri) {
+        return this.docs.get(uri);
+    }
+}
+
+describe('Implementation Provider', () => {
+    let mockConnection;
+    let mockCache;
+    let mockDocuments;
+
+    beforeEach(() => {
+        mockConnection = new MockConnection();
+        mockCache = new MockDocumentCache();
+        mockDocuments = new MockTextDocuments();
+    });
+
+    describe('Scenario 1: Find implementations of base class', () => {
+        it('should find all classes that inherit from base class', async () => {
+            const baseClassUri = 'file:///base.pike';
+            const impl1Uri = 'file:///impl1.pike';
+            const impl2Uri = 'file:///impl2.pike';
+
+            const baseClassCode = 'class BaseClass { }\n';
+            const baseClassDoc = TextDocument.create(baseClassUri, 'pike', 1, baseClassCode);
+            mockDocuments.set(baseClassUri, baseClassDoc);
+            mockCache.set(baseClassUri, {
+                symbols: [
+                    { name: 'BaseClass', kind: 'class', position: { line: 1 } }
+                ]
+            });
+
+            const impl1Code = 'class Impl1 { inherit BaseClass; }\n';
+            const impl1Doc = TextDocument.create(impl1Uri, 'pike', 1, impl1Code);
+            mockDocuments.set(impl1Uri, impl1Doc);
+            mockCache.set(impl1Uri, {
+                symbols: [
+                    { name: 'Impl1', kind: 'class', position: { line: 1 } },
+                    { name: 'BaseClass', kind: 'inherit', classname: 'BaseClass', position: { line: 1 } }
+                ]
+            });
+
+            const impl2Code = 'class Impl2 { inherit BaseClass; }\n';
+            const impl2Doc = TextDocument.create(impl2Uri, 'pike', 1, impl2Code);
+            mockDocuments.set(impl2Uri, impl2Doc);
+            mockCache.set(impl2Uri, {
+                symbols: [
+                    { name: 'Impl2', kind: 'class', position: { line: 1 } },
+                    { name: 'BaseClass', kind: 'inherit', classname: 'BaseClass', position: { line: 1 } }
+                ]
+            });
+
+            const mockServices = {
+                documentCache: mockCache,
+                bridge: null,
+                logger: { debug: () => {}, error: () => {} },
+                stdlibIndex: null
+            };
+
+            registerImplementationHandler(
+                mockConnection,
+                mockServices,
+                mockDocuments
+            );
+
+            const result = await mockConnection.implementationHandler({
+                textDocument: { uri: baseClassUri },
+                position: { line: 0, character: 10 }
+            });
+
+            assert.ok(Array.isArray(result), 'Should return array of locations');
+            assert.ok(result.length >= 2, `Should find at least 2 implementations, found ${result.length}`);
+
+            const uris = result.map((loc) => loc.uri);
+            assert.ok(uris.includes(impl1Uri), 'Should include Impl1');
+            assert.ok(uris.includes(impl2Uri), 'Should include Impl2');
+        });
+    });
+
+    describe('Scenario 2: Return empty for non-class symbols', () => {
+        it('should return empty array for variables', async () => {
+            const uri = 'file:///test.pike';
+            const code = 'int myVar = 42;\n';
+            const doc = TextDocument.create(uri, 'pike', 1, code);
+            mockDocuments.set(uri, doc);
+            mockCache.set(uri, {
+                symbols: [
+                    { name: 'myVar', kind: 'variable', position: { line: 1 } }
+                ]
+            });
+
+            const mockServices = {
+                documentCache: mockCache,
+                bridge: null,
+                logger: { debug: () => {}, error: () => {} },
+                stdlibIndex: null
+            };
+
+            registerImplementationHandler(
+                mockConnection,
+                mockServices,
+                mockDocuments
+            );
+
+            const result = await mockConnection.implementationHandler({
+                textDocument: { uri },
+                position: { line: 0, character: 5 }
+            });
+
+            assert.ok(Array.isArray(result), 'Should return array');
+            assert.strictEqual(result.length, 0, 'Should return empty for variables');
+        });
+    });
+
+    describe('Scenario 4: Handle inherit with string literals', () => {
+        it('should normalize quotes in inherit statements', async () => {
+            const baseUri = 'file:///base.pike';
+            const implUri = 'file:///impl.pike';
+
+            const baseCode = 'class Target { }\n';
+            const baseDoc = TextDocument.create(baseUri, 'pike', 1, baseCode);
+            mockDocuments.set(baseUri, baseDoc);
+            mockCache.set(baseUri, {
+                symbols: [
+                    { name: 'Target', kind: 'class', position: { line: 1 } }
+                ]
+            });
+
+            const implCode = 'class MyImpl { inherit "Target"; }\n';
+            const implDoc = TextDocument.create(implUri, 'pike', 1, implCode);
+            mockDocuments.set(implUri, implDoc);
+            mockCache.set(implUri, {
+                symbols: [
+                    { name: 'MyImpl', kind: 'class', position: { line: 1 } },
+                    { name: 'Target', kind: 'inherit', classname: '"Target"', position: { line: 1 } }
+                ]
+            });
+
+            const mockServices = {
+                documentCache: mockCache,
+                bridge: null,
+                logger: { debug: () => {}, error: () => {} },
+                stdlibIndex: null
+            };
+
+            registerImplementationHandler(
+                mockConnection,
+                mockServices,
+                mockDocuments
+            );
+
+            const result = await mockConnection.implementationHandler({
+                textDocument: { uri: baseUri },
+                position: { line: 0, character: 8 }
+            });
+
+            assert.ok(Array.isArray(result), 'Should return array');
+            assert.ok(result.length >= 1, 'Should find implementation with quoted inherit');
+        });
+    });
+
+    describe('Scenario 5: No implementations returns empty', () => {
+        it('should return empty array when class has no implementations', async () => {
+            const uri = 'file:///test.pike';
+            const code = 'class OrphanClass { }\n';
+            const doc = TextDocument.create(uri, 'pike', 1, code);
+            mockDocuments.set(uri, doc);
+            mockCache.set(uri, {
+                symbols: [
+                    { name: 'OrphanClass', kind: 'class', position: { line: 1 } }
+                ]
+            });
+
+            const mockServices = {
+                documentCache: mockCache,
+                bridge: null,
+                logger: { debug: () => {}, error: () => {} },
+                stdlibIndex: null
+            };
+
+            registerImplementationHandler(
+                mockConnection,
+                mockServices,
+                mockDocuments
+            );
+
+            const result = await mockConnection.implementationHandler({
+                textDocument: { uri },
+                position: { line: 0, character: 10 }
+            });
+
+            assert.ok(Array.isArray(result), 'Should return array');
+            assert.strictEqual(result.length, 0, 'Should return empty for unimplemented class');
+        });
+    });
+
+    describe('Scenario 7: Handle error conditions', () => {
+        it('should return empty array when document not found', async () => {
+            const mockServices = {
+                documentCache: mockCache,
+                bridge: null,
+                logger: { debug: () => {}, error: () => {} },
+                stdlibIndex: null
+            };
+
+            registerImplementationHandler(
+                mockConnection,
+                mockServices,
+                mockDocuments
+            );
+
+            const result = await mockConnection.implementationHandler({
+                textDocument: { uri: 'file:///nonexistent.pike' },
+                position: { line: 0, character: 0 }
+            });
+
+            assert.ok(Array.isArray(result), 'Should return array');
+            assert.strictEqual(result.length, 0, 'Should return empty for missing document');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Implements textDocument/implementation LSP handler for finding all classes that inherit from a given base class/interface.

## Changes
- Add `src/features/navigation/implementation.ts` handler
- Register handler in `navigation/index.ts`
- Add TDD tests in `src/tests/navigation/implementation-provider.test.ts`

## Implementation Details
The handler:
- Finds all classes with `inherit TargetClass` statements
- Handles quoted inherit names (`"Target"` -> `Target`)
- Returns empty for non-class symbols
- Returns empty when no implementations exist
- Searches across all cached documents

## Test Plan
- [x] Unit tests pass (5 tests in implementation-provider.test.ts)
- [x] TDD workflow followed (RED -> GREEN -> REFACTOR)
- [x] No regressions in existing tests
- [ ] CI checks passing

fixes #117