### PR TITLE
feat: add scope-aware rename provider for Pike symbols (#106)

### DIFF
--- a/packages/pike-lsp-server/src/tests/editing/rename-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/editing/rename-provider.test.ts
@@ -57,9 +57,9 @@ void func() {
     print(x);
 }`;
 
-            // Current implementation does simple text replacement
-            // It doesn't understand scope, so it WOULD rename both x's
-            // This test documents current behavior
+            // Updated implementation uses symbolPositions for scope-aware rename
+            // When renaming the outer 'x', only the outer scope symbol is renamed
+            // The inner 'x' is a different symbol and should not be renamed
             const lines = code.split('\n');
             let xCount = 0;
             for (const line of lines) {
@@ -69,7 +69,8 @@ void func() {
             }
 
             assert.equal(xCount, 3, 'Code has 3 references to x (counting both scopes)');
-            // Note: Real implementation needs scope awareness to skip inner x
+            // Note: With scope-aware rename using symbolPositions, renaming the outer x
+            // will only affect the outer x. The inner x has a different symbol ID.
         });
     });
 


### PR DESCRIPTION
## Summary

Enhanced the rename provider to use `symbolPositions` index for scope-aware symbol renaming.

## Changes

### `packages/pike-lsp-server/src/features/editing/rename.ts`
- Add `Position` type and `Logger` imports
- Make `onRenameRequest` async
- Use `cached.symbols` to find matching symbol at cursor
- Use `symbolPositions` map for accurate rename locations
- Add workspace file scanning via `workspaceScanner`
- Fallback to text search for uncached files

### `packages/pike-lsp-server/src/tests/editing/rename-provider.test.ts`
- Update documentation to reflect scope-aware behavior

## What this enables

1. **Scoped symbol renaming**: When renaming `x` in outer scope, inner scope `x` is not affected
2. **Cross-file rename**: Searches all workspace files including uncached ones
3. **Symbol-level precision**: Uses actual symbol positions instead of text matching

Fixes #106