### PR TITLE
fix: RXML Tag Catalog Cache test failure (#140)

### DIFF
--- a/packages/pike-lsp-server/src/features/rxml/cache.ts
+++ b/packages/pike-lsp-server/src/features/rxml/cache.ts
@@ -164,19 +164,19 @@ export class RXMLTagCatalogCache {
     }
 
     /**
-     * Create a cache key from server identifier and timestamp
+     * Create a cache key from server identifier
      *
-     * The key combines server info with timestamp to enable
-     * automatic expiration and change detection.
+     * The key combines PID and server name for unique identification.
+     * TTL expiration is handled separately via the entry timestamp.
      *
      * @param serverPid - Server process ID
      * @param serverName - Server identifier string
      * @returns Unique cache key
      */
     private createCacheKey(serverPid: number | string, serverName: string): string {
-        // Combine PID and name with timestamp for cache invalidation
-        // Format: "{serverName}:{serverPid}:{timestamp}"
-        return `${serverName}:${serverPid}:${Date.now()}`;
+        // Combine PID and name for unique identification
+        // TTL is handled via entry.timestamp in isExpired()
+        return `${serverName}:${serverPid}`;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Fixed `createCacheKey` method in RXML tag catalog cache by removing `Date.now()` from key generation
- The previous implementation included `Date.now()` in the cache key, causing `set()` and `get()` to generate different keys on each call
- TTL expiration is already handled via the entry timestamp in `isExpired()` method

## Root Cause
The `createCacheKey` method was returning `${serverName}:${serverPid}:${Date.now()}`, which created a new unique key on every call. This meant:
- `cache.set(12345, 'test-server', catalog)` stored with key like `"test-server:12345:1739635849000"`
- `cache.get(12345, 'test-server')` looked up with key like `"test-server:12345:1739635849001"` (different!)
- Result: cache entries were never found

## Fix
Changed key format to `${serverName}:${serverPid}` - deterministic and unique per server/PID combination.

## Test Plan
- [x] Run `bun test src/tests/features/rxml/cache.test.ts` - 12 tests pass
- [x] Run `scripts/test-agent.sh --fast` - all 3 suites pass
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass