### PR TITLE
feat: Add Roxen configuration file support (Issue #181)

### DIFF
--- a/packages/pike-lsp-server/src/features/roxen/config.ts
+++ b/packages/pike-lsp-server/src/features/roxen/config.ts
@@ -1,0 +1,259 @@
+/**
+ * Roxen Configuration File Support
+ *
+ * Provides parsing, validation, and completion for Roxen module configuration files.
+ * Roxen modules use defvar() calls to define configuration variables with TYPE_* constants.
+ *
+ * Key patterns:
+ * - defvar("name", "Display Name", TYPE_*, "Documentation", flags)
+ * - inherit "module" or inherit "roxen"
+ * - constant module_type = MODULE_*
+ */
+
+import type { CompletionItem, Diagnostic, Position } from 'vscode-languageserver';
+import { CompletionItemKind, DiagnosticSeverity } from 'vscode-languageserver/node.js';
+import { TYPE_CONSTANTS, MODULE_CONSTANTS, VAR_FLAGS } from './constants.js';
+
+/**
+ * Parsed defvar declaration
+ */
+export interface DefvarDeclaration {
+    name: string;
+    displayName: string;
+    type: string;
+    documentation: string;
+    flags: number;
+    line: number;
+    column: number;
+}
+
+/**
+ * Parsed Roxen module configuration
+ */
+export interface RoxenConfig {
+    isInheritModule: boolean;
+    moduleType: string | null;
+    defvars: DefvarDeclaration[];
+    errors: ConfigError[];
+}
+
+/**
+ * Configuration validation error
+ */
+export interface ConfigError {
+    line: number;
+    column: number;
+    message: string;
+    severity: 'error' | 'warning' | 'info';
+}
+
+/**
+ * Regex patterns for parsing Roxen config
+ */
+const PATTERNS = {
+    // inherit "module" or inherit 'module'
+    inheritModule: /inherit\s+["']module["']/i,
+    inheritRoxen: /inherit\s+["']roxen["']/i,
+    // constant module_type = MODULE_*
+    moduleType: /constant\s+(?:int\s+)?module_type\s*=\s*(MODULE_\w+)/i,
+    // defvar("name", "Display Name", TYPE_*, "Documentation", flags)
+    // Flags can be numeric (0, 1) or named (VAR_EXPERT, VAR_EXPERT | VAR_MORE)
+    defvar: /defvar\s*\(\s*["']([^"']+)["']\s*,\s*["']([^"']*)["']\s*,\s*(TYPE_\w+)\s*,\s*["']([^"']*)["']\s*,\s*([^)]+)\s*\)/gi,
+    // Partial defvar for completion - simplified pattern
+    defvarPartial: /defvar\s*\(\s*["']?[^"']*/,
+};
+
+/**
+ * Get line number from position in code
+ */
+function getLineNumber(code: string, position: number): number {
+    const before = code.slice(0, position);
+    return before.split('\n').length - 1;
+}
+
+/**
+ * Get column number from position in code
+ */
+function getColumnNumber(code: string, position: number): number {
+    const before = code.slice(0, position);
+    const lastNewline = before.lastIndexOf('\n');
+    return position - lastNewline - 1;
+}
+
+/**
+ * Parse Roxen configuration from code
+ */
+export function parseRoxenConfig(code: string): RoxenConfig {
+    const result: RoxenConfig = {
+        isInheritModule: false,
+        moduleType: null,
+        defvars: [],
+        errors: [],
+    };
+
+    // Check for inherit patterns in entire code
+    result.isInheritModule = PATTERNS.inheritModule.test(code) || PATTERNS.inheritRoxen.test(code);
+
+    // Check for module_type constant
+    const moduleMatch = code.match(PATTERNS.moduleType);
+    if (moduleMatch && moduleMatch[1]) {
+        result.moduleType = moduleMatch[1];
+    }
+
+    // Check for defvar declarations - process on full code to handle multi-line
+    PATTERNS.defvar.lastIndex = 0;
+    let defvarMatch;
+    while ((defvarMatch = PATTERNS.defvar.exec(code)) !== null) {
+        const matchStart = defvarMatch.index;
+        const [, name, displayName, type, documentation, flagsStr] = defvarMatch;
+
+        // Parse flags - handle numeric and named constants
+        let flags = 0;
+        const trimmedFlags = flagsStr.trim();
+        if (/^\d+$/.test(trimmedFlags)) {
+            flags = parseInt(trimmedFlags, 10);
+        } else {
+            // Handle named constants like VAR_EXPERT or VAR_EXPERT | VAR_MORE
+            const flagNames = trimmedFlags.split('|').map(f => f.trim());
+            for (const flagName of flagNames) {
+                const flagInfo = VAR_FLAGS[flagName as keyof typeof VAR_FLAGS];
+                if (flagInfo) {
+                    flags |= flagInfo.value;
+                }
+            }
+        }
+
+        // Validate defvar components
+        if (!TYPE_CONSTANTS[type as keyof typeof TYPE_CONSTANTS]) {
+            const typeIndex = code.indexOf(type, matchStart);
+            result.errors.push({
+                line: getLineNumber(code, typeIndex),
+                column: getColumnNumber(code, typeIndex),
+                message: `Unknown TYPE constant: ${type}. Valid values are: ${Object.keys(TYPE_CONSTANTS).join(', ')}`,
+                severity: 'error',
+            });
+        }
+
+        result.defvars.push({
+            name,
+            displayName: displayName || name,
+            type,
+            documentation,
+            flags,
+            line: getLineNumber(code, matchStart),
+            column: getColumnNumber(code, matchStart),
+        });
+    }
+
+    return result;
+}
+
+/**
+ * Validate Roxen configuration and return LSP diagnostics
+ */
+export function validateRoxenConfig(code: string): Diagnostic[] {
+    const config = parseRoxenConfig(code);
+    const diagnostics: Diagnostic[] = [];
+
+    // Convert config errors to LSP diagnostics
+    for (const error of config.errors) {
+        diagnostics.push({
+            range: {
+                start: { line: error.line, character: error.column },
+                end: { line: error.line, character: error.column + 10 },
+            },
+            severity: error.severity === 'error' ? DiagnosticSeverity.Error :
+                      error.severity === 'warning' ? DiagnosticSeverity.Warning :
+                      DiagnosticSeverity.Information,
+            message: error.message,
+            source: 'roxen-config',
+        });
+    }
+
+    // Check for module inherit without module_type
+    if (config.isInheritModule && !config.moduleType) {
+        diagnostics.push({
+            range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 10 },
+            },
+            severity: DiagnosticSeverity.Warning,
+            message: 'Roxen module inherits "module" but does not define module_type constant',
+            source: 'roxen-config',
+        });
+    }
+
+    return diagnostics;
+}
+
+/**
+ * Get defvar snippet completions
+ */
+export function getDefvarCompletions(): CompletionItem[] {
+    const typeChoices = Object.keys(TYPE_CONSTANTS).filter(k => k.startsWith('TYPE_'));
+
+    return [
+        {
+            label: 'defvar',
+            kind: CompletionItemKind.Snippet,
+            detail: 'Roxen module variable definition',
+            documentation: 'Define a configuration variable for a Roxen module',
+            insertTextFormat: 2,
+            insertText: `defvar("\${1:varname}", "\${2:Display Name}", \${3|${typeChoices.join(',')}|}, "\${4:Documentation}", \${5:0});`,
+        },
+    ];
+}
+
+/**
+ * Get completions for Roxen configuration context
+ */
+export function getRoxenConfigCompletions(
+    line: string,
+    _position: Position
+): CompletionItem[] | null {
+    // defvar(...) snippet
+    if (/\bdefvar\s*\(\s*$/.test(line)) {
+        return getDefvarCompletions();
+    }
+
+    // TYPE_* completions
+    if (/\bTYPE_\w*$/.test(line)) {
+        return Object.entries(TYPE_CONSTANTS).map(([name, info]) => ({
+            label: name,
+            kind: CompletionItemKind.Constant,
+            detail: `${info.value} - ${info.description}`,
+            documentation: info.description,
+        }));
+    }
+
+    // MODULE_* completions
+    if (/\bMODULE_\w*$/.test(line)) {
+        return Object.entries(MODULE_CONSTANTS).map(([name, info]) => ({
+            label: name,
+            kind: CompletionItemKind.Constant,
+            detail: `${info.value} - ${info.description}`,
+            documentation: info.description,
+        }));
+    }
+
+    // VAR_* completions
+    if (/\bVAR_\w*$/.test(line)) {
+        return Object.entries(VAR_FLAGS).map(([name, info]) => ({
+            label: name,
+            kind: CompletionItemKind.Constant,
+            detail: `${info.value} - ${info.description}`,
+            documentation: info.description,
+        }));
+    }
+
+    return null;
+}
+
+/**
+ * Check if a line is within a defvar call
+ */
+export function isInDefvarContext(line: string, column: number): boolean {
+    // Simple check: is "defvar" on the line and cursor is after it
+    const defvarIndex = line.indexOf('defvar');
+    return defvarIndex >= 0 && defvarIndex < column;
+}

--- a/packages/pike-lsp-server/src/features/roxen/index.ts
+++ b/packages/pike-lsp-server/src/features/roxen/index.ts
@@ -64,5 +64,17 @@ export { getRequestIDCompletions } from './completion.js';
 // Re-export diagnostics helper
 export { provideRoxenDiagnostics } from './diagnostics.js';
 
+// Re-export config helpers
+export {
+    parseRoxenConfig,
+    validateRoxenConfig,
+    getRoxenConfigCompletions,
+    getDefvarCompletions,
+    isInDefvarContext,
+    type DefvarDeclaration,
+    type RoxenConfig,
+    type ConfigError
+} from './config.js';
+
 // Re-export types
 export * from './types.js';

--- a/packages/pike-lsp-server/src/tests/features/roxen/config.test.ts
+++ b/packages/pike-lsp-server/src/tests/features/roxen/config.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Roxen Configuration File Support Tests
+ *
+ * Tests for parsing, validation, and completion of Roxen module configuration.
+ * Roxen modules use defvar() calls to define configuration variables.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    parseRoxenConfig,
+    validateRoxenConfig,
+    getRoxenConfigCompletions,
+    getDefvarCompletions,
+    isInDefvarContext,
+    type DefvarDeclaration,
+    type RoxenConfig,
+} from '../../../features/roxen/config.js';
+
+describe('Roxen Configuration Parser', () => {
+    it('should detect inherit "module" pattern', () => {
+        const code = 'inherit "module";';
+        const result = parseRoxenConfig(code);
+        assert.strictEqual(result.isInheritModule, true, 'Should detect module inherit');
+    });
+
+    it('should detect inherit "roxen" pattern', () => {
+        const code = 'inherit "roxen";';
+        const result = parseRoxenConfig(code);
+        assert.strictEqual(result.isInheritModule, true, 'Should detect roxen inherit');
+    });
+
+    it('should detect inherit with single quotes', () => {
+        const code = "inherit 'module';";
+        const result = parseRoxenConfig(code);
+        assert.strictEqual(result.isInheritModule, true, 'Should detect single quote inherit');
+    });
+
+    it('should parse constant module_type = MODULE_TAG', () => {
+        const code = 'constant module_type = MODULE_TAG;';
+        const result = parseRoxenConfig(code);
+        assert.strictEqual(result.moduleType, 'MODULE_TAG', 'Should extract module type');
+    });
+
+    it('should parse constant int module_type = MODULE_LOCATION', () => {
+        const code = 'constant int module_type = MODULE_LOCATION;';
+        const result = parseRoxenConfig(code);
+        assert.strictEqual(result.moduleType, 'MODULE_LOCATION', 'Should extract module type with int');
+    });
+
+    it('should parse defvar with all components', () => {
+        const code = 'defvar("myvar", "My Variable", TYPE_STRING, "Documentation", 0);';
+        const result = parseRoxenConfig(code);
+        assert.strictEqual(result.defvars.length, 1, 'Should parse one defvar');
+
+        const defvar = result.defvars[0]!;
+        assert.strictEqual(defvar.name, 'myvar');
+        assert.strictEqual(defvar.displayName, 'My Variable');
+        assert.strictEqual(defvar.type, 'TYPE_STRING');
+        assert.strictEqual(defvar.documentation, 'Documentation');
+        assert.strictEqual(defvar.flags, 0);
+    });
+
+    it('should parse multiple defvar declarations', () => {
+        const code = `
+defvar("var1", "Variable 1", TYPE_STRING, "Doc 1", 0);
+defvar("var2", "Variable 2", TYPE_INT, "Doc 2", VAR_EXPERT);
+defvar("var3", "Variable 3", TYPE_FLAG, "Doc 3", VAR_MORE);
+`;
+        const result = parseRoxenConfig(code);
+        assert.strictEqual(result.defvars.length, 3, 'Should parse three defvars');
+        assert.strictEqual(result.defvars[0]!.name, 'var1');
+        assert.strictEqual(result.defvars[1]!.name, 'var2');
+        assert.strictEqual(result.defvars[2]!.name, 'var3');
+    });
+
+    it('should parse defvar with VAR_* flags', () => {
+        const code = 'defvar("secret", "Secret", TYPE_PASSWORD, "Hidden", VAR_EXPERT | VAR_MORE);';
+        const result = parseRoxenConfig(code);
+        assert.strictEqual(result.defvars.length, 1, 'Should parse defvar with flags');
+        // Note: the regex doesn't capture complex flag expressions, just simple numbers
+        // This is expected - the bridge handles full validation
+    });
+
+    it('should parse complete Roxen module structure', () => {
+        const code = `
+inherit "module";
+
+constant module_type = MODULE_TAG;
+constant module_name = "My Tag";
+
+defvar("enabled", "Enabled", TYPE_FLAG, "Enable this tag", 0);
+defvar("timeout", "Timeout", TYPE_INT, "Timeout in seconds", VAR_EXPERT);
+`;
+        const result = parseRoxenConfig(code);
+
+        assert.strictEqual(result.isInheritModule, true, 'Should detect inherit');
+        assert.strictEqual(result.moduleType, 'MODULE_TAG', 'Should extract module type');
+        assert.strictEqual(result.defvars.length, 2, 'Should parse two defvars');
+    });
+});
+
+describe('Roxen Configuration Validation', () => {
+    it('should return empty diagnostics for valid config', () => {
+        const code = 'defvar("x", "X", TYPE_STRING, "Doc", 0);';
+        const result = validateRoxenConfig(code);
+        assert.strictEqual(result.length, 0, 'Should have no errors');
+    });
+
+    it('should error on unknown TYPE constant', () => {
+        const code = 'defvar("x", "X", TYPE_INVALID, "Doc", 0);';
+        const result = validateRoxenConfig(code);
+        assert.ok(result.length > 0, 'Should have errors');
+        assert.ok(result[0]!.message.includes('TYPE_INVALID'), 'Should mention invalid type');
+    });
+
+    it('should warn when module has inherit but no module_type', () => {
+        const code = 'inherit "module";\ndefvar("x", "X", TYPE_STRING, "Doc", 0);';
+        const result = validateRoxenConfig(code);
+        assert.ok(result.some(d => d.message.includes('module_type')),
+            'Should warn about missing module_type');
+    });
+
+    it('should not warn when module has both inherit and module_type', () => {
+        const code = `
+inherit "module";
+constant module_type = MODULE_TAG;
+defvar("x", "X", TYPE_STRING, "Doc", 0);
+`;
+        const result = validateRoxenConfig(code);
+        assert.ok(!result.some(d => d.message.includes('module_type')),
+            'Should not warn about module_type when present');
+    });
+});
+
+describe('Roxen Configuration Completions', () => {
+    it('should return defvar snippet when typing defvar(', () => {
+        const line = 'defvar(';
+        const result = getRoxenConfigCompletions(line, { line: 0, character: 7 });
+        assert.ok(result !== null, 'Should return completions');
+        assert.ok(result!.some(item => item.label === 'defvar'), 'Should include defvar snippet');
+    });
+
+    it('should return TYPE_* completions after TYPE_ prefix', () => {
+        const line = 'defvar("x", "X", TYPE_';
+        const result = getRoxenConfigCompletions(line, { line: 0, character: 20 });
+        assert.ok(result !== null, 'Should return completions');
+        assert.ok(result!.some(item => item.label === 'TYPE_STRING'), 'Should include TYPE_STRING');
+        assert.ok(result!.some(item => item.label === 'TYPE_INT'), 'Should include TYPE_INT');
+        assert.ok(result!.some(item => item.label === 'TYPE_FLAG'), 'Should include TYPE_FLAG');
+    });
+
+    it('should return MODULE_* completions after MODULE_ prefix', () => {
+        const line = 'constant module_type = MODULE_';
+        const result = getRoxenConfigCompletions(line, { line: 0, character: 28 });
+        assert.ok(result !== null, 'Should return completions');
+        assert.ok(result!.some(item => item.label === 'MODULE_TAG'), 'Should include MODULE_TAG');
+        assert.ok(result!.some(item => item.label === 'MODULE_LOCATION'), 'Should include MODULE_LOCATION');
+        assert.ok(result!.some(item => item.label === 'MODULE_FILTER'), 'Should include MODULE_FILTER');
+    });
+
+    it('should return VAR_* completions after VAR_ prefix', () => {
+        const line = 'defvar("x", "X", TYPE_STRING, "Doc", VAR_';
+        const result = getRoxenConfigCompletions(line, { line: 0, character: 40 });
+        assert.ok(result !== null, 'Should return completions');
+        assert.ok(result!.some(item => item.label === 'VAR_EXPERT'), 'Should include VAR_EXPERT');
+        assert.ok(result!.some(item => item.label === 'VAR_MORE'), 'Should include VAR_MORE');
+        assert.ok(result!.some(item => item.label === 'VAR_DEVELOPER'), 'Should include VAR_DEVELOPER');
+    });
+
+    it('should return null for non-Roxen context', () => {
+        const line = 'int x = 42;';
+        const result = getRoxenConfigCompletions(line, { line: 0, character: 10 });
+        assert.strictEqual(result, null, 'Should return null for non-Roxen code');
+    });
+
+    it('defvar snippet should include TYPE choices', () => {
+        const completions = getDefvarCompletions();
+        const defvarSnippet = completions.find(c => c.label === 'defvar');
+        assert.ok(defvarSnippet, 'Should have defvar snippet');
+        assert.ok(defvarSnippet!.insertText!.includes('${3|'), 'Should include snippet choices for TYPE');
+    });
+});
+
+describe('Context Detection', () => {
+    it('should detect defvar context when cursor after defvar', () => {
+        const line = 'defvar("x", "X", TYPE_';
+        assert.strictEqual(isInDefvarContext(line, 20), true, 'Should be in defvar context');
+    });
+
+    it('should not detect defvar context when defvar not present', () => {
+        const line = 'int x = 42;';
+        assert.strictEqual(isInDefvarContext(line, 5), false, 'Should not be in defvar context');
+    });
+
+    it('should not detect defvar context when cursor before defvar', () => {
+        const line = '  defvar("x"';
+        assert.strictEqual(isInDefvarContext(line, 2), false, 'Should not be in defvar context before keyword');
+    });
+});
+
+describe('Integration: Complete Module Parsing', () => {
+    it('should parse a realistic Roxen tag module', () => {
+        const code = `
+inherit "module";
+#include <module.h>
+
+constant module_type = MODULE_TAG;
+constant module_name = "Custom Tag";
+constant module_doc = "A custom RXML tag";
+
+void create() {
+    defvar("attr1", "Attribute 1", TYPE_STRING,
+           "Description of attribute 1", 0);
+    defvar("attr2", "Attribute 2", TYPE_INT,
+           "Description of attribute 2", VAR_EXPERT);
+    defvar("enabled", "Enable", TYPE_FLAG,
+           "Enable this tag", 0);
+}
+
+string simpletag_custom(mapping args) {
+    return "Hello";
+}
+`;
+        const result = parseRoxenConfig(code);
+
+        assert.strictEqual(result.isInheritModule, true);
+        assert.strictEqual(result.moduleType, 'MODULE_TAG');
+        assert.strictEqual(result.defvars.length, 3);
+
+        // Verify defvar details
+        const attr1 = result.defvars.find(d => d.name === 'attr1');
+        assert.ok(attr1, 'Should find attr1');
+        assert.strictEqual(attr1!.type, 'TYPE_STRING');
+        assert.strictEqual(attr1!.flags, 0);
+
+        const attr2 = result.defvars.find(d => d.name === 'attr2');
+        assert.ok(attr2, 'Should find attr2');
+        assert.strictEqual(attr2!.type, 'TYPE_INT');
+    });
+
+    it('should parse a Roxen filesystem module', () => {
+        const code = `
+inherit "module";
+inherit "filesystem";
+
+constant module_type = MODULE_LOCATION;
+constant module_name = "Custom FS";
+
+void create() {
+    defvar("mountpoint", "Mount Point", TYPE_STRING,
+           "Where to mount this filesystem", 0);
+    defvar("root", "Root Directory", TYPE_DIR,
+           "Root directory for files", VAR_EXPERT);
+}
+`;
+        const result = parseRoxenConfig(code);
+
+        assert.strictEqual(result.isInheritModule, true);
+        assert.strictEqual(result.moduleType, 'MODULE_LOCATION');
+        assert.strictEqual(result.defvars.length, 2);
+
+        const mountpoint = result.defvars.find(d => d.name === 'mountpoint');
+        assert.ok(mountpoint, 'Should find mountpoint');
+        assert.strictEqual(mountpoint!.type, 'TYPE_STRING');
+
+        const root = result.defvars.find(d => d.name === 'root');
+        assert.ok(root, 'Should find root');
+        assert.strictEqual(root!.type, 'TYPE_DIR');
+    });
+
+    it('should parse a Roxen filter module', () => {
+        const code = `
+inherit "module";
+
+constant module_type = MODULE_FILTER;
+constant module_name = "Content Filter";
+
+void create() {
+    defvar("pattern", "Pattern", TYPE_STRING,
+           "Regex pattern to match", 0);
+    defvar("replacement", "Replacement", TYPE_STRING,
+           "Replacement text", 0);
+    defvar("case_sensitive", "Case Sensitive", TYPE_FLAG,
+           "Match case", 0);
+}
+`;
+        const result = parseRoxenConfig(code);
+
+        assert.strictEqual(result.moduleType, 'MODULE_FILTER');
+        assert.strictEqual(result.defvars.length, 3);
+    });
+});
+
+describe('Error Cases', () => {
+    it('should handle empty code gracefully', () => {
+        const code = '';
+        const result = parseRoxenConfig(code);
+        assert.strictEqual(result.isInheritModule, false);
+        assert.strictEqual(result.moduleType, null);
+        assert.strictEqual(result.defvars.length, 0);
+        assert.strictEqual(result.errors.length, 0);
+    });
+
+    it('should handle code with only comments', () => {
+        const code = `
+// This is a comment
+/* Multi-line
+   comment */
+`;
+        const result = parseRoxenConfig(code);
+        assert.strictEqual(result.defvars.length, 0);
+    });
+
+    it('should handle malformed defvar gracefully', () => {
+        const code = 'defvar(unclosed';
+        const result = parseRoxenConfig(code);
+        assert.strictEqual(result.defvars.length, 0, 'Should not crash on malformed input');
+    });
+
+    it('should handle defvar with missing components', () => {
+        const code = 'defvar("name")';  // Missing type and doc
+        const result = parseRoxenConfig(code);
+        // The regex requires full pattern, so this won't match
+        assert.strictEqual(result.defvars.length, 0);
+    });
+});
+
+describe('Validation Error Reporting', () => {
+    it('should provide correct line and column for errors', () => {
+        const code = 'defvar("x", "X", TYPE_BAD, "Doc", 0);';
+        const result = validateRoxenConfig(code);
+        assert.ok(result.length > 0, 'Should have errors');
+        assert.strictEqual(result[0]!.range.start.line, 0, 'Error should be on line 0');
+    });
+
+    it('should have correct source in diagnostics', () => {
+        const code = 'inherit "module";\ndefvar("x", "X", TYPE_BAD, "Doc", 0);';
+        const result = validateRoxenConfig(code);
+        const configDiags = result.filter(d => d.source === 'roxen-config');
+        assert.ok(configDiags.length > 0, 'Should have roxen-config source diagnostics');
+    });
+
+    it('should distinguish between error and warning severity', () => {
+        const code = 'defvar("x", "X", TYPE_BAD, "Doc", 0);';
+        const result = validateRoxenConfig(code);
+        const errorDiag = result.find(d => d.message.includes('TYPE_BAD'));
+        assert.ok(errorDiag, 'Should have TYPE_BAD error');
+        assert.strictEqual(errorDiag!.severity, 1, 'Should be error severity (1)');
+    });
+});


### PR DESCRIPTION
## Summary
- Implements parsing, validation, and completion for Roxen module configuration files
- Roxen modules use \`defvar()\` calls to define configuration variables with TYPE_*, MODULE_*, and VAR_* constants

## Changes
- **config.ts**: New parser for Roxen module patterns
  - Parse \`inherit "module"\` and \`constant module_type = MODULE_*\`
  - Parse multi-line \`defvar()\` declarations in function bodies
  - Validate TYPE_* constants and produce LSP diagnostics
  - Provide completions for MODULE_*, TYPE_*, VAR_* constants
  - Handle both numeric flags (0, 1) and named constants (VAR_EXPERT | VAR_MORE)
- **index.ts**: Export new config functions
- **config.test.ts**: 32 comprehensive tests covering realistic Roxen module patterns

## Test plan
- [x] Unit tests pass (32/32 tests)
- [x] TypeScript compilation succeeds
- [x] Parses Roxen tag modules, filesystem modules, and filter modules
- [x] Validates unknown TYPE constants
- [x] Provides completions for defvar snippet and all constant types