### PR TITLE
fix: Convert bridge tests from node:test to bun:test

### DIFF
--- a/packages/pike-bridge/src/bridge.test.ts
+++ b/packages/pike-bridge/src/bridge.test.ts
@@ -4,14 +4,15 @@
  * Tests the core IPC communication with Pike subprocess
  */
 
-import { describe, it, before, after } from 'node:test';
+// @ts-ignore - Bun test types
+import { describe, it, beforeAll, afterAll } from 'bun:test';
 import assert from 'node:assert/strict';
 import { PikeBridge } from './bridge.js';
 
 describe('PikeBridge', () => {
     let bridge: PikeBridge;
 
-    before(async () => {
+    beforeAll(async () => {
         bridge = new PikeBridge();
         const available = await bridge.checkPike();
         if (!available) {
@@ -25,7 +26,7 @@ describe('PikeBridge', () => {
         await new Promise(resolve => setTimeout(resolve, 200));
     });
 
-    after(async () => {
+    afterAll(async () => {
         if (bridge) {
             await bridge.stop();
         }

--- a/packages/pike-bridge/src/corpus.test.ts
+++ b/packages/pike-bridge/src/corpus.test.ts
@@ -11,7 +11,8 @@
  * Run with: cd packages/pike-bridge && bun run test:corpus
  */
 
-import { describe, it, before, after } from 'node:test';
+// @ts-ignore - Bun test types
+import { describe, it, beforeAll, afterAll } from 'bun:test';
 import assert from 'node:assert/strict';
 import { PikeBridge } from './bridge.js';
 import * as path from 'node:path';
@@ -236,7 +237,7 @@ describeSuite('Pike Stdlib Corpus Validation', { timeout: 1800_000 }, () => {
     let pikeFiles: string[] = []; // Initialize empty for environments without Pike source
     const results: CorpusResult[] = [];
 
-    before(async () => {
+    beforeAll(async () => {
         // 1. Check that Pike source tree exists
         if (!fs.existsSync(PIKE_SOURCE_ROOT)) {
             console.log('\nSKIP: Pike source tree not found at', PIKE_SOURCE_ROOT);
@@ -259,7 +260,7 @@ describeSuite('Pike Stdlib Corpus Validation', { timeout: 1800_000 }, () => {
         console.log('Bridge started\n');
     });
 
-    after(async () => {
+    afterAll(async () => {
         if (bridge) {
             console.log('\nStopping bridge...');
             await bridge.stop();

--- a/packages/pike-bridge/src/get-pike-paths.test.ts
+++ b/packages/pike-bridge/src/get-pike-paths.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, before, after } from 'node:test';
+// @ts-ignore - Bun test types
+import { describe, it, beforeAll, afterAll } from 'bun:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { PikeBridge } from './bridge.js';
@@ -6,13 +7,13 @@ import { PikeBridge } from './bridge.js';
 describe('getPikePaths', () => {
     let bridge: PikeBridge;
 
-    before(async () => {
+    beforeAll(async () => {
         bridge = new PikeBridge();
         await bridge.start();
         await new Promise(resolve => setTimeout(resolve, 200));
     });
 
-    after(async () => {
+    afterAll(async () => {
         if (bridge) {
             await bridge.stop();
         }

--- a/packages/pike-bridge/src/process.test.ts
+++ b/packages/pike-bridge/src/process.test.ts
@@ -5,7 +5,8 @@
  * Uses a mock process pattern to test without requiring actual Pike installation.
  */
 
-import { describe, it } from 'node:test';
+// @ts-ignore - Bun test types
+import { describe, it } from 'bun:test';
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'events';
 import { PikeProcess } from './process.js';

--- a/packages/pike-bridge/src/response-validator.test.ts
+++ b/packages/pike-bridge/src/response-validator.test.ts
@@ -1,4 +1,5 @@
-import { describe, it } from 'node:test';
+// @ts-ignore - Bun test types
+import { describe, it } from 'bun:test';
 import assert from 'node:assert/strict';
 import {
     BridgeResponseError,

--- a/packages/pike-bridge/src/roxen.test.ts
+++ b/packages/pike-bridge/src/roxen.test.ts
@@ -2,7 +2,8 @@
  * Roxen Module Analysis Tests
  */
 
-import { describe, it, before, after } from 'node:test';
+// @ts-ignore - Bun test types
+import { describe, it, beforeAll, afterAll } from 'bun:test';
 import assert from 'node:assert/strict';
 import { PikeBridge } from './bridge.js';
 import type { RXMLTag, ModuleVariable } from './types.js';
@@ -10,7 +11,7 @@ import type { RXMLTag, ModuleVariable } from './types.js';
 describe('Roxen', () => {
     let bridge: PikeBridge;
 
-    before(async () => {
+    beforeAll(async () => {
         bridge = new PikeBridge();
         const available = await bridge.checkPike();
         if (!available) {
@@ -20,7 +21,7 @@ describe('Roxen', () => {
         await new Promise(resolve => setTimeout(resolve, 200));
     });
 
-    after(async () => {
+    afterAll(async () => {
         if (bridge) {
             await bridge.stop();
         }


### PR DESCRIPTION
## Summary

Fixes P0 Issue #152 - Bridge test failures (54 failing tests).

Converted all 6 bridge test files from `node:test` to `bun:test` imports to fix compatibility issues with Bun test runner.

## Changes

- Converted test imports: `node:test` → `bun:test`
- Updated lifecycle hooks: `before/after` → `beforeAll/afterAll` (Bun API)
- Added `@ts-ignore` for Bun test types (not in TypeScript definitions)

## Files Modified

- `packages/pike-bridge/src/bridge.test.ts`
- `packages/pike-bridge/src/corpus.test.ts`
- `packages/pike-bridge/src/get-pike-paths.test.ts`
- `packages/pike-bridge/src/process.test.ts`
- `packages/pike-bridge/src/response-validator.test.ts`
- `packages/pike-bridge/src/roxen.test.ts`

## Test Results

**Before:** 34 pass, 54 fail
**After:** 91 pass, 8 skip, 0 fail

All pre-commit hooks passing:
- ✅ TypeScript build
- ✅ Pike compile check  
- ✅ Fast smoke tests (bridge, server, pike-compile)
- ✅ Test quality check

## Related

- Issue #152 - Fix Pike bridge test instability (P0)