### PR TITLE
perf: index symbols for O(1) hover lookups

### DIFF
--- a/packages/pike-lsp-server/src/core/types.ts
+++ b/packages/pike-lsp-server/src/core/types.ts
@@ -104,6 +104,8 @@ export interface DocumentCacheEntry {
     diagnostics: Diagnostic[];
     /** Symbol position index for O(1) lookups: symbol_name -> positions[] */
     symbolPositions: Map<string, Position[]>;
+    /** Symbol name index for O(1) lookups: symbol_name -> PikeSymbol */
+    symbolNames: Map<string, PikeSymbol>;
     /** Include and import dependencies (optional, populated lazily) */
     dependencies?: DocumentDependencies;
     /** Inheritance information from introspection */

--- a/packages/pike-lsp-server/src/features/diagnostics.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics.ts
@@ -25,6 +25,7 @@ import { Logger } from '@pike-lsp/core';
 import { DIAGNOSTIC_DELAY_DEFAULT, DEFAULT_MAX_PROBLEMS } from '../constants/index.js';
 import { computeContentHash, computeLineHashes } from '../services/document-cache.js';
 import { detectRoxenModule, provideRoxenDiagnostics } from '../features/roxen/index.js';
+import { buildSymbolNameIndex } from './diagnostics/symbol-index.js';
 
 /**
  * Extract deprecated status from parsed symbols recursively.
@@ -887,6 +888,8 @@ export function registerDiagnosticsHandlers(
                     symbols: hierarchicalSymbols,  // Use hierarchical symbols with children preserved
                     diagnostics,
                     symbolPositions: await buildSymbolPositionIndex(text, legacySymbols, tokenizeData),  // Use flat for indexing
+                    // PERF-005: Build symbol name index for O(1) hover lookups
+                    symbolNames: buildSymbolNameIndex(hierarchicalSymbols),
                     // INC-002: Store hashes for incremental change detection
                     contentHash,
                     lineHashes,
@@ -925,6 +928,8 @@ export function registerDiagnosticsHandlers(
                     symbols: symbolsWithDeprecated,  // Use symbols with deprecated extracted from source
                     diagnostics,
                     symbolPositions: await buildSymbolPositionIndex(text, symbolsWithDeprecated, tokenizeData),
+                    // PERF-005: Build symbol name index for O(1) hover lookups
+                    symbolNames: buildSymbolNameIndex(symbolsWithDeprecated),
                     // INC-002: Store hashes for incremental change detection
                     contentHash,
                     lineHashes,

--- a/packages/pike-lsp-server/src/features/diagnostics/index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/index.ts
@@ -28,6 +28,7 @@ import { detectRoxenModule, provideRoxenDiagnostics } from '../roxen/index.js';
 
 // Import from split modules
 export { convertDiagnostic, isDeprecatedSymbolDiagnostic, extractDeprecatedFromSymbols } from './utils.js';
+export { buildSymbolNameIndex } from './symbol-index.js';
 export { buildSymbolPositionIndex, buildSymbolPositionIndexRegex, flattenSymbols } from './symbol-index.js';
 export { classifyChange, stripLineComments, type ChangeClassification } from './change-detection.js';
 
@@ -45,7 +46,7 @@ export function registerDiagnosticsHandlers(
 ): void {
     // Import functions from split modules
     const { convertDiagnostic, isDeprecatedSymbolDiagnostic, extractDeprecatedFromSymbols } = require('./utils.js');
-    const { buildSymbolPositionIndex, flattenSymbols } = require('./symbol-index.js');
+    const { buildSymbolPositionIndex, buildSymbolNameIndex, flattenSymbols } = require('./symbol-index.js');
     const { classifyChange } = require('./change-detection.js');
 
     // NOTE: We access services.bridge dynamically instead of destructuring,
@@ -373,6 +374,8 @@ export function registerDiagnosticsHandlers(
                     symbols: hierarchicalSymbols,  // Use hierarchical symbols with children preserved
                     diagnostics,
                     symbolPositions: await buildSymbolPositionIndex(text, legacySymbols, tokenizeData, bridge),
+                    // PERF-005: Build symbol name index for O(1) hover lookups
+                    symbolNames: buildSymbolNameIndex(hierarchicalSymbols),
                     // INC-002: Store hashes for incremental change detection
                     contentHash,
                     lineHashes,
@@ -411,6 +414,8 @@ export function registerDiagnosticsHandlers(
                     symbols: symbolsWithDeprecated,  // Use symbols with deprecated extracted from source
                     diagnostics,
                     symbolPositions: await buildSymbolPositionIndex(text, symbolsWithDeprecated, tokenizeData, bridge),
+                    // PERF-005: Build symbol name index for O(1) hover lookups
+                    symbolNames: buildSymbolNameIndex(symbolsWithDeprecated),
                     // INC-002: Store hashes for incremental change detection
                     contentHash,
                     lineHashes,

--- a/packages/pike-lsp-server/src/features/navigation/hover.ts
+++ b/packages/pike-lsp-server/src/features/navigation/hover.ts
@@ -57,8 +57,8 @@ export function registerHoverHandler(
 
             const { word, range } = wordResult;
 
-            // 1. Try to find symbol in local document
-            let symbol = findSymbolInCollection(cached.symbols, word);
+            // 1. Try to find symbol in local document (O(1) lookup using symbolNames index)
+            let symbol = cached.symbolNames?.get(word) ?? null;
             let parentScope: string | undefined;
 
             // 2. If not found, try to find in stdlib
@@ -245,36 +245,4 @@ function hasDocumentation(symbol: PikeSymbol): boolean {
     }
 
     return false;
-}
-
-/**
- * Find symbol with matching name in collection.
- * Prioritizes non-variant symbols over variant symbols.
- */
-function findSymbolInCollection(symbols: PikeSymbol[], name: string): PikeSymbol | null {
-    // First pass: find non-variant symbols
-    for (const symbol of symbols) {
-        if (symbol.name === name && !symbol.modifiers?.includes('variant')) {
-            return symbol;
-        }
-        if (symbol.children) {
-            const found = findSymbolInCollection(symbol.children, name);
-            if (found && !found.modifiers?.includes('variant')) {
-                return found;
-            }
-        }
-    }
-
-    // Second pass: if no non-variant found, return variant (for completeness)
-    for (const symbol of symbols) {
-        if (symbol.name === name) {
-            return symbol;
-        }
-        if (symbol.children) {
-            const found = findSymbolInCollection(symbol.children, name);
-            if (found) return found;
-        }
-    }
-
-    return null;
 }

--- a/packages/pike-lsp-server/src/tests/helpers/mock-services.ts
+++ b/packages/pike-lsp-server/src/tests/helpers/mock-services.ts
@@ -238,6 +238,7 @@ export function makeCacheEntry(overrides: Partial<DocumentCacheEntry> & { symbol
         version: 1,
         diagnostics: [],
         symbolPositions: new Map(),
+        symbolNames: new Map(),
         ...overrides,
     };
 }


### PR DESCRIPTION
## Summary
- Add `symbolNames` Map to `DocumentCacheEntry` for O(1) symbol lookups in hover provider
- Previously used O(n) recursive tree traversal to find symbols by name
- Now builds index at cache time and uses direct Map lookup

## Test plan
- [x] Run fast test suite (`scripts/test-agent.sh --fast`) - PASS
- [x] Run hover provider tests - PASS

fixes #210