### PR TITLE
feat: use documentChanges format for workspaceEdit in rename (#211)

### DIFF
--- a/packages/vscode-pike/test-workspace/test-large-completion.pike
+++ b/packages/vscode-pike/test-workspace/test-large-completion.pike
@@ -1,0 +1,364 @@
+//! Auto-generated large Pike file for performance testing
+
+int main() {
+    write("Performance test file\n");
+    return 0;
+}
+
+int test_function_0(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_1(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_2(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_3(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_4(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_5(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_6(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_7(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_8(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_9(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_10(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_11(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_12(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_13(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_14(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_15(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_16(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_17(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_18(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_19(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_20(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_21(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_22(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_23(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_24(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_25(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_26(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_27(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_28(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_29(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_30(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_31(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_32(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_33(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_34(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_35(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_36(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_37(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_38(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_39(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_40(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_41(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_42(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_43(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_44(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_45(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_46(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_47(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_48(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+int test_function_49(int x, int y) {
+    int result = x + y;
+    result = result * 2;
+    result = result - 5;
+    return result;
+}
+
+class PerformanceTestClass {
+    int member_variable;
+
+    void test_method(int param) {
+        member_variable = param;
+    }
+}


### PR DESCRIPTION
## Summary
- Convert rename handler from deprecated `changes` format to `documentChanges` format
- Uses OptionalVersionedTextDocumentIdentifier with TextDocumentEdit[] for better LSP compliance

## Test plan
- [x] Build passes
- [x] Fast tests pass (bridge, server, pike-compile)

fixes #211