### PR TITLE
feat: add Roxen E2E test coverage

### DIFF
--- a/packages/vscode-pike/test-workspace/test-roxen-location.pike
+++ b/packages/vscode-pike/test-workspace/test-roxen-location.pike
@@ -1,0 +1,37 @@
+// Test file for Roxen MODULE_LOCATION
+// This file tests MODULE_LOCATION pattern and query_location callback
+
+inherit "module";
+constant module_type = MODULE_LOCATION;
+constant module_name = "Test Location Module";
+constant module_doc = "Test location module for LSP features";
+
+string base_path = "/test/";
+
+// Required for MODULE_LOCATION - must have find_file or query_location
+string find_file(string filename, object id) {
+    if (filename == "/") {
+        return "index.html";
+    }
+    return filename;
+}
+
+// Alternative to find_file - query_location style
+mapping(string:string) query_location() {
+    return ([
+        "": "root.html",
+        "about": "about.html",
+        "contact": "contact.html",
+    ]);
+}
+
+// Configuration variables
+void create() {
+    defvar("root", "/var/www/html", TYPE_STRING, "Document root");
+    defvar("index_file", "index.html", TYPE_STRING, "Index file name");
+}
+
+// Required callbacks
+string query_name() { return module_name; }
+string query_doc() { return module_doc; }
+array(string) query_type() { return ({ "Location", "Filesystem" }); }

--- a/packages/vscode-pike/test-workspace/test-roxen-module.pike
+++ b/packages/vscode-pike/test-workspace/test-roxen-module.pike
@@ -1,0 +1,35 @@
+// Test file for Roxen module detection and features
+// This file tests Roxen module patterns
+
+inherit "module";
+constant module_type = MODULE_TAG;
+constant module_name = "Test Roxen Module";
+constant module_doc = "Test module for LSP features";
+
+// Define configuration variables using defvar
+void create() {
+    // Required for module to be valid
+    defvar("title", "Default Title", TYPE_STRING, "Page title");
+    defvar("enabled", 1, TYPE_FLAG, "Enable this module");
+    defvar("max_items", 10, TYPE_INT, "Maximum number of items");
+    defvar("styles", ({ "default.css" }), TYPE_ARRAY, "CSS files");
+}
+
+// RXML tag handlers - these appear as symbols
+string simpletag_hello(string tag_args) {
+    return "Hello, World!";
+}
+
+string simpletag_greeting(mapping args) {
+    return "Hello, " + (args["name"] || "anonymous");
+}
+
+string simpletag_iframe(string tag_args) {
+    // Example: <emit source="roxentime"> produces the emit tag
+    return "<iframe></iframe>";
+}
+
+// Required Roxen callbacks
+string query_name() { return module_name; }
+string query_doc() { return module_doc; }
+array(string) query_type() { return ({ "Dynamic", "Pages" }); }

--- a/packages/vscode-pike/test-workspace/test-roxen-rxml.pike
+++ b/packages/vscode-pike/test-workspace/test-roxen-rxml.pike
@@ -1,0 +1,46 @@
+// Test file for RXML mixed content patterns
+// This file tests RXML tags inside Pike strings
+
+inherit "module";
+constant module_type = MODULE_TAG;
+constant module_name = "RXML Test Module";
+
+void create() {
+    defvar("template", "default", TYPE_STRING, "Template name");
+}
+
+// Example of RXML in string literals - the analyzer should handle these
+string get_page_template() {
+    return #"
+<!DOCTYPE html>
+<html>
+<head><title>&var.title;</title></head>
+<body>
+    <ul>
+        &emit.list-items:
+        <li>&item.value;</li>
+        &/emit;
+    </ul>
+    &if cond='&var.enabled;':
+    <p>Content is enabled</p>
+    &else:
+    <p>Content is disabled</p>
+    &/if;
+</body>
+</html>
+"#;
+}
+
+// RXML in SQL queries
+string get_sql_query() {
+    return "SELECT * FROM users WHERE active = 1 AND role = '&var.role;'";
+}
+
+// Multiple RXML tags on single line
+string complex_rxml() {
+    return "&var.header; - &var.title; - &var.footer;";
+}
+
+// Required callbacks
+string query_name() { return module_name; }
+array(string) query_type() { return ({ "Dynamic", "Pages" }); }


### PR DESCRIPTION
## Summary
- Add 3 Roxen test workspace files for testing Roxen module patterns
- Add 4 Roxen-specific E2E tests to verify file handling
- Tests confirm Roxen files can be opened and analyzed without crashes
- Diagnostics test verifies valid Roxen modules have no parse errors

## Test plan
- [x] Fast tests pass (bridge, server, pike-compile)
- [x] Build passes
- [x] Unit tests pass (1868 server, 182 bridge)

Generated with AI

Co-Authored-By: MiniMax-M2.5