### PR TITLE
docs: clarify dual implementation handlers in navigation module

### DIFF
--- a/packages/pike-lsp-server/src/features/navigation/references.ts
+++ b/packages/pike-lsp-server/src/features/navigation/references.ts
@@ -2,6 +2,8 @@
  * References and Implementation Handlers
  *
  * Provides find all references, implementation, and document highlight.
+ *
+ * Note: The class inheritance implementation handler is in implementation.ts
  */
 
 import {
@@ -27,8 +29,8 @@ export function registerReferencesHandlers(
     const log = new Logger('Navigation');
 
     /**
-     * Implementation handler - find where a symbol is used
-     * When on a definition, shows where it's used; otherwise behaves like references
+     * Implementation handler - find where a symbol is used (usages excluding definition)
+     * This is different from the class inheritance handler in implementation.ts
      */
     connection.onImplementation(async (params): Promise<Location[]> => {
         log.debug('Implementation request', { uri: params.textDocument.uri });


### PR DESCRIPTION
## Summary

- Fixed documentation in `references.ts` to clarify the distinction between two different LSP implementation handlers:
  - `references.ts`: finds symbol usages (like "Find References" but excluding the definition position)
  - `implementation.ts`: finds class inheritances (which classes inherit from a given class)
- Added clarifying comments to prevent future confusion about which handler does what

## Test plan

- [x] All tests pass (112 navigation tests, 16 todo, 0 fail)
- [x] Fast test suite passes (pike-compile, bridge, server)