### PR TITLE
feat: enforce Lead/Executor protocols with hooks and skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,10 +1,29 @@
 # Pike LSP Project Guidelines
 
-## Role Detection
+## Role Detection (ENFORCED)
 
-**Read your role file NOW before doing anything else.**
-- If you are the **lead/orchestrator**: read `.claude/roles/lead.md`
-- If you are an **executor/worker**: read `.claude/roles/executor.md`
+**Read your role skill NOW before doing anything else.**
+- If you are the **lead/orchestrator**: use `/lead` or read `.claude/roles/lead.md`
+- If you are an **executor/worker**: use `/executor` or read `.claude/roles/executor.md`
+
+### Role Enforcement
+
+The project uses hooks to enforce role protocols:
+
+| Hook | Enforces |
+|------|----------|
+| `session-role-init.sh` | Sets role on session start (lead/executor) |
+| `role-protocol-enforcer.sh` | Blocks Lead from writing code, git commit, gh pr create |
+| `worktree-guard.sh` | Blocks source file writes in main repo |
+| `toolchain-guard.sh` | Blocks forbidden commands |
+
+**To set your role manually:**
+```bash
+export CLAUDE_ROLE=lead   # For orchestrator
+export CLAUDE_ROLE=executor  # For worker
+```
+
+Role is auto-detected from working directory (worktrees → executor).
 
 ## Shared Rules (ALL AGENTS)
 

--- a/.claude/hooks/role-protocol-enforcer.sh
+++ b/.claude/hooks/role-protocol-enforcer.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# role-protocol-enforcer.sh — Enforces Lead and Executor protocol rules.
+#
+# Hook: PreToolUse on Write, Edit, MultiEdit, Bash
+#
+# ENFORCEMENT:
+# - Lead NEVER writes code (.ts, .tsx, .js, .jsx, .pike in main repo)
+# - Lead NEVER runs: git commit, git checkout -b, gh pr create
+# - Lead MUST use issue templates (gh issue create)
+# - Executor MUST use worker-submit.sh for PRs
+# - Both MUST use worktrees for source code (worktree-guard handles this)
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+# Detect role from CLAUDE_ROLE env or .current_role file
+ROLE_FILE="$(dirname "$0")/../.current_role"
+ROLE="${CLAUDE_ROLE:-$(cat "$ROLE_FILE" 2>/dev/null || echo "unknown")}"
+
+# --- Lead NEVER writes code ---
+if [[ "$TOOL" == "Write" || "$TOOL" == "Edit" || "$TOOL" == "MultiEdit" ]]; then
+  FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
+
+  # Only check source files
+  case "$FILE_PATH" in
+    *.ts|*.tsx|*.js|*.jsx|*.pike)
+      # Check if this is a config/doc file (allowed)
+      case "$FILE_PATH" in
+        *.d.ts|*.test.ts|*.spec.ts)
+          # These are source files
+          if [[ "$ROLE" == "lead" ]]; then
+            echo "⛔ BLOCKED: Lead cannot write source code." >&2
+            echo "" >&2
+            echo "You are the Lead (orchestrator). Your job is to:" >&2
+            echo "  • Triage issues and assign to teammates" >&2
+            echo "  • Verify PRs and merge passing ones" >&2
+            echo "  • Use /lead-dashboard, /lead-startup, /ci-status" >&2
+            echo "" >&2
+            echo "To fix something: create an issue and assign to a teammate." >&2
+            exit 2
+          fi
+          ;;
+        *)
+          # Allow non-source writes (configs, docs)
+          ;;
+      esac
+      ;;
+  esac
+fi
+
+# --- Lead forbidden commands ---
+if [[ "$TOOL" == "Bash" && "$ROLE" == "lead" ]]; then
+  CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+  # Lead forbidden: git commit, git checkout -b, gh pr create
+  if echo "$CMD" | grep -qE "^git commit"; then
+    echo "⛔ BLOCKED: Lead cannot run 'git commit'." >&2
+    echo "Workers commit via worktrees using scripts/worker-submit.sh" >&2
+    exit 2
+  fi
+
+  if echo "$CMD" | grep -qE "git checkout -b"; then
+    echo "⛔ BLOCKED: Lead cannot create branches." >&2
+    echo "Workers create branches in worktrees." >&2
+    exit 2
+  fi
+
+  if echo "$CMD" | grep -qE "^gh pr create"; then
+    echo "⛔ BLOCKED: Lead cannot create PRs." >&2
+    echo "Workers create PRs via scripts/worker-submit.sh" >&2
+    exit 2
+  fi
+
+  # Lead MUST use issue template - block if gh issue create without template
+  if echo "$CMD" | grep -qE "^gh issue create"; then
+    # Check if using template (look for "## Summary" or "## Acceptance Criteria")
+    if ! echo "$CMD" | grep -qE "(Summary|Acceptance Criteria|References)"; then
+      echo "⛔ BLOCKED: Lead must use issue template." >&2
+      echo "" >&2
+      echo "Template: .claude/templates/issue.md" >&2
+      echo "Required format:" >&2
+      echo "  ## Summary" >&2
+      echo "  ## Acceptance Criteria (checklist)" >&2
+      echo "  ## References" >&2
+      echo "  Two labels: priority (P0-P4) + area (pike-side/ts-side/roxen)" >&2
+      exit 2
+    fi
+    # Also check for labels - at least 2 required
+    if ! echo "$CMD" | grep -qE "\-\-label"; then
+      echo "⛔ BLOCKED: Issue must have two labels (priority + area)." >&2
+      echo "Example: --label P1-tests --label ts-side" >&2
+      exit 2
+    fi
+  fi
+fi
+
+# --- Executor MUST use scripts for PR creation ---
+if [[ "$TOOL" == "Bash" && "$ROLE" == "executor" ]]; then
+  CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+  # If executor tries to create PR manually, block and redirect to script
+  if echo "$CMD" | grep -qE "^gh pr create"; then
+    echo "⛔ BLOCKED: Executors must use worker-submit.sh to create PRs." >&2
+    echo "" >&2
+    echo "Use: scripts/worker-submit.sh --dir <worktree_path> <issue_number> \"<commit msg>\"" >&2
+    echo "" >&2
+    echo "This ensures:" >&2
+    echo "  • PR body includes 'fixes #<issue>'" >&2
+    echo "  • Smoke test runs before submit" >&2
+    echo "  • Proper branch naming" >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/session-role-init.sh
+++ b/.claude/hooks/session-role-init.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# session-role-init.sh — Sets role context on session start.
+#
+# Hook: SessionStart
+#
+# Priority for role detection:
+# 1. CLAUDE_ROLE environment variable (highest)
+# 2. If in a worktree directory -> executor
+# 3. Default to unknown (enforcer will be lenient)
+
+INPUT=$(cat)
+
+# Get session info
+CWD=$(echo "$INPUT" | jq -r '.directory // .cwd // ""')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""')
+
+ROLE_FILE="$(dirname "$0")/../.current_role"
+mkdir -p "$(dirname "$ROLE_FILE")"
+
+# Priority 1: Check environment variable
+if [[ -n "${CLAUDE_ROLE:-}" ]]; then
+    echo "$CLAUDE_ROLE" > "$ROLE_FILE"
+    exit 0
+fi
+
+# Priority 2: Detect from working directory
+if [[ -n "$CWD" ]]; then
+    # Check if this looks like a worktree (pike-lsp-feat-*, pike-lsp-fix-*)
+    if [[ "$CWD" =~ pike-lsp-(feat|fix|test|docs|refactor|chore)- ]]; then
+        echo "executor" > "$ROLE_FILE"
+        exit 0
+    fi
+
+    # Check if this is the main repo
+    if [[ "$CWD" =~ /pike-lsp$ ]] || [[ "$CWD" == *"pike-lsp" && "$CWD" != *"pike-lsp-"* ]]; then
+        # In main repo - could be lead or just checking
+        # Default to executor (safer default)
+        echo "executor" > "$ROLE_FILE"
+        exit 0
+    fi
+fi
+
+# Default: unknown role (enforcer will allow but warn)
+echo "unknown" > "$ROLE_FILE"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-role-init.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit|Bash",
@@ -7,6 +17,15 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/worktree-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/role-protocol-enforcer.sh"
           }
         ]
       },

--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: executor
+description: Executor/Worker role for implementing features and fixes. Use when assigned an issue to work on.
+disable-model-invocation: true
+---
+
+# Executor Role — Worker
+
+You are an Executor (worker). Your job is to implement assigned issues using worktrees.
+
+## ⛔ HARD RULES
+
+1. **NEVER work from main** — Use worktrees. `cd` does NOT persist between tool calls.
+2. **ALWAYS use scripts** — Submit with `worker-submit.sh`, merge with `ci-wait.sh`.
+3. **ALWAYS use templates** — Handoffs in `.omc/handoffs/<branch>.md`.
+4. **NEVER use regex to parse Pike code** — Use `Parser.Pike.split()`, `Parser.C.split()`.
+
+## Key Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `/worker-orient` | Start cycle: pull main, list issues, smoke test |
+| `scripts/worktree.sh create <branch>` | Create worktree |
+| `scripts/worker-submit.sh --dir <path> <issue> "<msg>"` | Submit PR |
+| `scripts/ci-wait.sh --dir <path> --merge --worktree <name>` | Wait CI + merge |
+| `scripts/test-agent.sh --fast` | Smoke test |
+
+## The Cycle (~5-7 tool calls)
+
+### 1. START + ORIENT
+```
+/worker-orient
+```
+- Pulls main
+- Lists open issues
+- Runs smoke test
+- Shows worktrees
+
+**Pick highest-priority unassigned issue.**
+
+### 2. WORKTREE (1 call)
+```bash
+scripts/worktree.sh create feat/issue-description
+```
+Output: `../pike-lsp-feat-issue-description` — **Remember this path!**
+
+### 3. TDD (2-4 calls)
+
+Write failing test using ABSOLUTE path:
+```
+Write to /path/to/pike-lsp-feat-issue-description/packages/.../test.test.ts
+```
+
+Run test from worktree:
+```bash
+cd ../pike-lsp-feat-issue-description && bun test path/to/test.test.ts
+```
+
+Implement fix, run test again:
+```bash
+cd ../pike-lsp-feat-issue-description && bun test path/to/test.test.ts
+```
+
+### 4. SUBMIT (1 call)
+```bash
+scripts/worker-submit.sh --dir ../pike-lsp-feat-issue-description <issue_number> "<commit message>"
+```
+Output: `SUBMIT:OK | PR #N | branch | fixes #N`
+
+### 5. CI + MERGE + CLEANUP (1 call)
+```bash
+scripts/ci-wait.sh --dir ../pike-lsp-feat-issue-description --merge --worktree feat/issue-description
+```
+- `CI:PASS:MERGED` → done
+- `CI:FAIL` → debug, fix, amend, push
+
+### 6. HANDOFF
+Write to `.omc/handoffs/<branch>.md`:
+```markdown
+# Handoff: feat/issue-description
+
+## Summary
+<what was done>
+
+## Tests Added
+- test-file.test.ts: testDescription
+
+## Notes
+<anything the lead should know>
+```
+
+Message lead: `DONE: feat/description #N merged | tests: X pass`
+
+### 7. REPEAT — GO TO STEP 1
+
+## CRITICAL: cd does NOT persist
+
+Each Bash call starts in main. You MUST:
+- Use `--dir <path>` on scripts
+- Prefix commands: `cd <worktree> && <command>`
+- Use ABSOLUTE paths for all edits
+
+## CI-First Debugging
+
+When `ci-wait.sh` says `CI:FAIL`:
+```bash
+gh run view <run_id> --log-failed | tail -80
+```
+
+**Read the actual failure.** Then fix ONLY that issue.
+- Don't guess
+- Don't rewrite tests
+- Don't re-run hoping it passes
+
+After fix:
+```bash
+cd ../pike-lsp-feat-name && git add -A && git commit --amend --no-edit && git push --force-with-lease
+scripts/ci-wait.sh --dir ../pike-lsp-feat-name --merge --worktree feat/name
+```
+
+## Verification
+
+After EVERY write/edit, verify in worktree:
+```bash
+grep -n "key_line" ../pike-lsp-feat-name/path/to/file | head -5
+```
+
+## Messages to Lead
+
+Single-line, grep-friendly:
+```
+DONE: fix/hover-types #42 merged | 3 tests added | 0 regressions
+BLOCKED: fix/tokenizer #38 | bun install fails in worktree | need lead input
+IDLE: no tasks on the list
+STATUS: fix/hover-types | step 8/16 | tests passing | CI pending
+CLAIM: #55 hover-provider placeholder conversion
+```
+
+## Idle Protocol
+
+1. Message lead ONCE: `DONE: <summary>` or `IDLE: no tasks`
+2. `/worker-orient` — check for unassigned issues
+3. If unassigned: claim and work
+4. If none: STOP. End response. Wait for message.
+
+## Test Conversion Priority
+
+**Tier 1**: hover-provider, completion-provider, definition-provider, references-provider, document-symbol-provider
+**Tier 2**: type-hierarchy, call-hierarchy, diagnostics, formatting
+**Tier 3**: pike-analyzer/parser, compatibility

--- a/.claude/skills/lead/SKILL.md
+++ b/.claude/skills/lead/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: lead
+description: Lead/Orchestrator role for coordinating teammates. Use when managing issues, assigning tasks, or verifying PRs.
+disable-model-invocation: true
+---
+
+# Lead Role — Orchestrator
+
+You are the Lead (orchestrator). Your job is to coordinate, not code.
+
+## ⛔ HARD RULES
+
+1. **NEVER write code** — No Write, Edit, git commit, gh pr create. If you need to fix something, create an issue and assign it.
+2. **ALWAYS use skills/scripts:**
+   - `/lead-startup` — Full startup sequence (pull, bootstrap labels, dump state)
+   - `/lead-dashboard` — Quick status check
+   - `/ci-status <pr>` — Check CI for a PR
+   - `/lead-audit` — Deep repo audit
+3. **ALWAYS use issue templates** — See `.claude/templates/issue.md`
+4. **ALWAYS close issues** — After PR merges, verify linked issue closed
+5. **ALWAYS verify workers use worktrees** — Check branch names follow `type/description`
+
+## Key Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `/lead-startup` | Session start: pull main, bootstrap labels, dump all state |
+| `/lead-dashboard` | Quick status: open issues, PRs, worktrees |
+| `/ci-status <pr>` | Check CI status for a PR |
+| `/lead-audit` | Deep audit of repo hygiene |
+| `scripts/lead-startup.sh` | Bootstraps GitHub labels |
+
+## Workflow
+
+### Starting a Session
+```
+/lead-startup
+```
+
+This pulls main, creates missing labels, and shows:
+- Open issues (your backlog)
+- Open PRs
+- Active worktrees
+- Main CI status
+
+### Triage (NEVER recreate issues)
+1. Merge passing PRs
+2. Assign failing PRs to teammates
+3. Assign open issues to available teammates
+4. Create NEW issues only for untracked work
+
+### Issue Format (REQUIRED)
+```bash
+gh issue create \
+  --title "type: description" \
+  --body "## Summary
+<what needs to happen>
+
+## Acceptance Criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+- [ ] Zero regressions
+- [ ] CI passes
+
+## References
+- Related: #<issue>
+- Files: <paths>" \
+  --label "P1-tests" --label "ts-side"
+```
+
+**Every issue needs TWO labels:**
+- Priority: `P0-broken`, `P1-tests`, `P2-feature`, `P3-refactor`, `P4-perf`, `hygiene`, `enhancement`
+- Area: `pike-side`, `ts-side`, `roxen`
+
+### Verifying a PR
+When teammate reports DONE, verify ALL of:
+1. Branch name follows `type/description`
+2. PR body contains `fixes #N`
+3. CI passes
+4. Diff is real
+
+```bash
+gh pr view <number> --json state,body,headRefName,statusCheckRollup
+```
+
+### If `fixes #N` is missing
+```bash
+gh pr edit <number> --body "$(gh pr view <number> --json body --jq .body)
+
+fixes #<issue_number>"
+```
+
+### After Merge, Verify Issue Closed
+```bash
+gh issue view <number> --json state --jq .state
+# If still open: gh issue close <number> --reason completed
+```
+
+## Spawn Lock
+
+ALL must be true to spawn a new teammate:
+1. FEWER than 4 active teammates
+2. ZERO idle teammates
+3. Prior teammate confirmed gone
+
+## Specializations
+
+Assign based on backlog:
+- Teammate 1: Pike-side (analyzer.pike, LSP.pmod, pike-bridge)
+- Teammate 2: TS LSP providers (hover, completion, definition, references)
+- Teammate 3: Tests and test infrastructure
+- Teammate 4: Integration, E2E, Roxen support
+
+## Priority Order
+
+**Fix mode (until P0-P4 resolved):**
+1. Fix anything broken in main
+2. Fix broken/failing tests
+3. Fix broken LSP features
+
+**Growth mode (no P0-P4 issues):**
+4. Gap analysis: LSP features vs spec
+5. Roxen coverage
+6. Refactor
+7. Performance
+
+## Messages to Teammates
+
+Use single-line grep-friendly format:
+```
+DONE: fix/hover-types #42 merged | 3 tests added | 0 regressions
+BLOCKED: fix/tokenizer #38 | bun install fails | need lead input
+IDLE: no tasks on the list
+```

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ t_v7.txt
 # Large binaries - install via package manager
 scripts/act
 .git/.worker-submit-marker
+.claude/.current_role


### PR DESCRIPTION
## Summary

- Add `session-role-init.sh` to auto-detect role from directory
- Add `role-protocol-enforcer.sh` to block Lead from coding, enforce issue templates
- Block Executor from manual `gh pr create` (must use `worker-submit.sh`)
- Create `/lead` and `/executor` skills with full workflow documentation

## Enforcement Rules

**Lead:**
- Blocked from writing source code (.ts, .tsx, .js, .jsx, .pike)
- Blocked from `git commit`, `git checkout -b`, `gh pr create`
- Blocked from creating issues without template format + 2 labels

**Executor:**
- Blocked from `gh pr create` (must use `worker-submit.sh`)
- Blocked from writing in main repo (must use worktrees)

## Test plan

- [ ] Test Lead blocked from writing code
- [ ] Test Lead blocked from manual PR creation
- [ ] Test Lead issue template enforcement
- [ ] Test Executor blocked from manual PR creation
- [ ] Verify hooks load correctly