### PR TITLE
feat: add Lead start script and retrospective skill

### DIFF
--- a/.claude/skills/lead-retrospective/SKILL.md
+++ b/.claude/skills/lead-retrospective/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: lead-retrospective
+description: Lead retrospective after each iteration. Analyzes handoffs, identifies improvements for next cycle.
+disable-model-invocation: true
+---
+
+# Lead Retrospective
+
+After each iteration (when all teammates report DONE or IDLE), run this retrospective.
+
+## Step 1: Collect Handoffs
+
+Read all handoff files from previous iteration:
+```bash
+ls -la .omc/handoffs/
+```
+
+For each handoff, read:
+```bash
+cat .omc/handoffs/<branch>.md
+```
+
+## Step 2: Analyze Each Handoff
+
+For each completed task, note:
+- **What worked well?**
+- **What was difficult?**
+- **Any blockers encountered?**
+- **Tests added?**
+
+## Step 3: Aggregate Patterns
+
+Search for common patterns in handoffs:
+```bash
+grep -r "BLOCKED\|ISSUE\|ERROR\|difficult\|complex\|slow" .omc/handoffs/
+```
+
+## Step 4: Check Failed Approaches
+
+```bash
+cat .claude/status/failed-approaches.log 2>/dev/null || echo "(no failures)"
+```
+
+## Step 5: Output Retrospective
+
+Create a retrospective summary in `.omc/retrospectives/iteration-N.md`:
+
+```markdown
+# Retrospective - Iteration N
+
+## Completed
+- feat/description #42 | 3 tests | 0 regressions
+- fix/issue #43 | 1 test | resolved blocker
+
+## Patterns Identified
+- 2/5 tasks had X difficulty → consider breaking into smaller issues
+- 1/5 tasks hit Y blocker → need to add to checklist
+
+## Improvements for Next Iteration
+1. Add more specific acceptance criteria for type/Z issues
+2. Pre-check Pike stdlib availability before assigning parser tasks
+3. Increase test coverage requirement for pike-side features
+
+## Team Performance
+- Tasks completed: X
+- Tests added: Y
+- Blockers: Z
+```
+
+## Step 6: Adjust Workflow
+
+Based on retrospective, consider:
+1. **Issue refinement** — Are issues too large? Add breakdown notes
+2. **Skill gaps** — Should teammates read additional docs?
+3. **Tooling issues** — Any scripts that need fixing?
+4. **Communication** — Any unclear expectations?
+
+## Step 7: Continue
+
+After retrospective:
+1. Run `/worker-orient` to pick new issues
+2. Assign based on learnings
+3. Start next iteration
+
+**Tip:** Run this after each wave of teammate completions, not after every single task.

--- a/.claude/skills/lead/SKILL.md
+++ b/.claude/skills/lead/SKILL.md
@@ -124,6 +124,30 @@ Assign based on backlog:
 6. Refactor
 7. Performance
 
+## Iteration Loop
+
+The Lead runs in continuous iterations. Each iteration:
+
+### Iteration Steps
+1. **Triage** — Run `/lead-startup` or `/lead-dashboard`
+2. **Assign** — Spawn teammates for open issues (max 4)
+3. **Monitor** — Wait for teammates to report DONE or IDLE
+4. **Verify** — Check each PR, merge if passing
+5. **Retrospective** — Run `/lead-retrospective` to analyze
+6. **Repeat** — Go back to step 1
+
+### When to Run Retrospective
+Run `/lead-retrospective` when:
+- All teammates report DONE or IDLE
+- A wave of PRs has been merged
+- Backlog is empty or nearly empty
+
+### Iteration Counter
+Track iterations in `.omc/state/iteration`:
+```bash
+echo $(( $(cat .omc/state/iteration 2>/dev/null || echo 0) + 1 )) > .omc/state/iteration
+```
+
 ## Messages to Teammates
 
 Use single-line grep-friendly format:

--- a/scripts/start-lead.sh
+++ b/scripts/start-lead.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# start-lead.sh — Start Lead orchestration session
+#
+# Usage:
+#   ./scripts/start-lead.sh              # Start fresh
+#   ./scripts/start-lead.sh --continue   # Continue from where left off
+#
+# This sets CLAUDE_ROLE=lead and starts Claude Code in the project.
+# The Lead will:
+#   1. Run /lead-startup
+#   2. Spawn teammates for open issues
+#   3. Monitor progress
+#   4. Run retrospectives after each wave
+
+set -euo pipefail
+
+CONTINUE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --continue|-c) CONTINUE=true; shift ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+cd "$(dirname "$0")/.."
+
+echo "=== Starting Lead Orchestration ==="
+echo "Role: lead"
+echo ""
+
+if [[ "$CONTINUE" == true ]]; then
+  echo "Continuing from previous session..."
+  claude --add-dir . --print-only "Continue as Lead. Run /lead-dashboard to see current state."
+else
+  echo "Starting fresh Lead session..."
+  echo ""
+  echo "The Lead will:"
+  echo "  1. Run /lead-startup to pull main and triage"
+  echo "  2. Assign open issues to teammates"
+  echo "  3. Monitor PRs and verify merges"
+  echo "  4. Run retrospective after each iteration"
+  echo ""
+  echo "Use /lead-dashboard for status, /lead-audit for deep reviews"
+
+  # Start Claude Code with Lead role
+  CLAUDE_ROLE=lead claude --add-dir .
+fi


### PR DESCRIPTION
## Summary

- Add `scripts/start-lead.sh` to start Lead from CLI
- Add `/lead-retrospective` skill for iteration analysis
- Update Lead skill with iteration loop documentation

## New Workflow

```bash
./scripts/start-lead.sh
```

This sets `CLAUDE_ROLE=lead` and starts Claude Code.

## Retrospective

After each iteration, run `/lead-retrospective` to:
- Analyze handoffs from teammates
- Identify patterns and improvements
- Document learnings in `.omc/retrospectives/iteration-N.md`

## Test plan

- [ ] Test start-lead.sh launches Lead correctly
- [ ] Verify retrospective skill runs after iteration