### PR TITLE
fix: lead/executor protocol for autonomous OMC team operation

### DIFF
--- a/.claude/hooks/session-role-init.sh
+++ b/.claude/hooks/session-role-init.sh
@@ -34,8 +34,8 @@ if [[ -n "$CWD" ]]; then
     # Check if this is the main repo
     if [[ "$CWD" =~ /pike-lsp$ ]] || [[ "$CWD" == *"pike-lsp" && "$CWD" != *"pike-lsp-"* ]]; then
         # In main repo - could be lead or just checking
-        # Default to executor (safer default)
-        echo "executor" > "$ROLE_FILE"
+        # Default to unknown (permissive — worktree-guard still blocks source writes)
+        echo "unknown" > "$ROLE_FILE"
         exit 0
     fi
 fi

--- a/.claude/hooks/stall-guard.sh
+++ b/.claude/hooks/stall-guard.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# stall-guard.sh — Block sleep/watch/polling in Bash commands.
+#
+# Hook: PreToolUse (Bash)
+#
+# Workers must use SendMessage for coordination, not sleep/poll loops.
+# Legitimate waits (ci-wait.sh, gh pr checks --watch, test-agent.sh) are allowed.
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Only check Bash commands
+if [[ "$TOOL" != "Bash" ]]; then
+  exit 0
+fi
+
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# --- Allowlist: legitimate long-running commands ---
+if echo "$CMD" | grep -qE "ci-wait\.sh"; then
+  exit 0
+fi
+if echo "$CMD" | grep -qE "gh pr checks.*--watch"; then
+  exit 0
+fi
+if echo "$CMD" | grep -qE "test-agent\.sh"; then
+  exit 0
+fi
+if echo "$CMD" | grep -qE "gh run watch"; then
+  exit 0
+fi
+
+# --- Block stalling patterns ---
+REASON=""
+if echo "$CMD" | grep -qE "(^|\s|;|&&|\|)sleep\s"; then
+  REASON="sleep"
+elif echo "$CMD" | grep -qE "(^|\s|;|&&|\|)watch\s"; then
+  REASON="watch"
+elif echo "$CMD" | grep -qE "while\s+(true|:)\s*;?\s*(do)?"; then
+  REASON="infinite-loop"
+elif echo "$CMD" | grep -qE "for\s*\(\(\s*;;\s*\)\)"; then
+  REASON="infinite-loop"
+elif echo "$CMD" | grep -qE "while.*sleep|until.*sleep"; then
+  REASON="poll-loop"
+fi
+
+if [[ -n "$REASON" ]]; then
+  echo "BLOCKED: stall-guard | ${REASON} | Use SendMessage instead" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,15 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stall-guard.sh"
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write",
         "hooks": [
           {

--- a/.claude/skills/lead-startup/SKILL.md
+++ b/.claude/skills/lead-startup/SKILL.md
@@ -22,3 +22,5 @@ You are the lead starting a new session. From the data above:
 3. Assign teammates by specialization (see role file).
 4. Ensure at least 8 open issues exist for the team.
 5. Only create NEW issues for work not already tracked.
+6. **Check for orphaned OMC tasks:** Run `TaskList` and verify each task references a valid open GitHub issue. Delete tasks for closed/non-existent issues.
+7. **Issue-first workflow:** For every new task, create a GitHub issue FIRST, then run `scripts/create-task.sh <N>` to generate the OMC task description. NEVER create a TaskCreate without a corresponding GitHub issue.

--- a/.claude/skills/worker-orient/SKILL.md
+++ b/.claude/skills/worker-orient/SKILL.md
@@ -30,6 +30,8 @@ description: Orient at cycle start. Pulls main, shows issues, runs smoke test, s
 You are a worker starting a new cycle. From the data above:
 1. Note the MAIN_REPO and WORKTREES_AT paths — you need these for the entire cycle.
 2. Identify the highest-priority unassigned issue (no assignee, lowest P-number label).
-3. Claim it and create a worktree: `scripts/worktree.sh create feat/description`
-4. The worktree path will be at WORKTREES_AT/pike-lsp-feat-description — use this ABSOLUTE path for ALL subsequent file operations.
-5. Start the TDD cycle. Remember: `cd` does not persist. Every command needs `cd <worktree> &&` or `--dir <worktree>`.
+3. **Use `scripts/worker-setup.sh <issue_number>`** to bootstrap the worktree from the issue. This handles branch naming and worktree creation in a single call.
+4. The output gives you `SETUP:OK | WT:<abs_path> | BRANCH:<branch> | ISSUE:#<N>`. Use the WT path for ALL subsequent file operations.
+5. Start the TDD cycle. Remember: `cd` does not persist. Every command needs `cd <WT> &&` or `--dir <WT>`.
+
+**DO NOT LOOP.** If there are no unassigned issues, send `IDLE: no tasks` to the lead and END YOUR RESPONSE. Do not poll or sleep.

--- a/scripts/create-task.sh
+++ b/scripts/create-task.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+# create-task.sh — Generate structured OMC task description from a GitHub issue.
+#
+# Usage:
+#   scripts/create-task.sh <issue_number>
+#
+# Output: structured task description ready for TaskCreate.
+
+if [[ $# -lt 1 ]]; then
+  echo "ERROR: Usage: create-task.sh <issue_number>" >&2
+  exit 1
+fi
+
+ISSUE_NUM="$1"
+REPO_ROOT=$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel)
+REPO_NAME=$(basename "$REPO_ROOT")
+
+# Fetch issue
+ISSUE_JSON=$(gh issue view "$ISSUE_NUM" --json number,title,labels,body 2>&1) || {
+  echo "ERROR: Issue #${ISSUE_NUM} not found: ${ISSUE_JSON}" >&2
+  exit 1
+}
+
+TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
+LABELS=$(echo "$ISSUE_JSON" | jq -r '[.labels[].name] | join(", ")')
+BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""')
+
+# Validate labels (warn if fewer than 2)
+LABEL_COUNT=$(echo "$ISSUE_JSON" | jq '[.labels[].name] | length')
+if [[ "$LABEL_COUNT" -lt 2 ]]; then
+  echo "WARNING: Issue #${ISSUE_NUM} has fewer than 2 labels (${LABELS}). Add priority + area labels." >&2
+fi
+
+# Derive branch name
+if echo "$TITLE" | grep -qE "^(fix|feat|test|docs|refactor|chore):"; then
+  TYPE=$(echo "$TITLE" | sed -E 's/^(fix|feat|test|docs|refactor|chore):.*/\1/')
+  DESC=$(echo "$TITLE" | sed -E 's/^(fix|feat|test|docs|refactor|chore):\s*//')
+else
+  TYPE="feat"
+  DESC="$TITLE"
+fi
+DESC_SANITIZED=$(echo "$DESC" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 -]//g' | sed 's/ \+/-/g' | sed 's/^-//;s/-$//' | cut -c1-40)
+BRANCH="${TYPE}/${DESC_SANITIZED}"
+SANITIZED_BRANCH=$(echo "$BRANCH" | sed 's|/|-|g')
+WT_REL="../${REPO_NAME}-${SANITIZED_BRANCH}"
+
+# Extract acceptance criteria from body (lines starting with "- [ ]")
+AC=$(echo "$BODY" | grep -E "^\s*-\s*\[[ x]\]" || echo "- [ ] (no criteria found in issue body)")
+
+echo "TASK_SUBJECT: ${TITLE} (#${ISSUE_NUM})"
+echo "TASK_ISSUE: #${ISSUE_NUM}"
+echo "TASK_BRANCH: ${BRANCH}"
+echo "TASK_WT: ${WT_REL}"
+echo "TASK_SETUP: scripts/worker-setup.sh ${ISSUE_NUM}"
+echo "TASK_SUBMIT: scripts/worker-submit.sh --dir ${WT_REL} ${ISSUE_NUM} \"${TYPE}: ${DESC_SANITIZED}\""
+echo "TASK_AC:"
+echo "$AC" | while IFS= read -r line; do echo "  $line"; done
+echo "  - [ ] Zero regressions"
+echo "  - [ ] CI passes"

--- a/scripts/worker-setup.sh
+++ b/scripts/worker-setup.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euo pipefail
+# worker-setup.sh — Single-call bootstrap: issue → worktree.
+#
+# Usage:
+#   scripts/worker-setup.sh <issue_number>
+#
+# Output (grep-friendly):
+#   SETUP:OK | WT:<abs_path> | BRANCH:<branch> | ISSUE:#<N>
+#   SETUP:FAIL | <reason>
+
+if [[ $# -lt 1 ]]; then
+  echo "SETUP:FAIL | Usage: worker-setup.sh <issue_number>" >&2
+  exit 1
+fi
+
+ISSUE_NUM="$1"
+REPO_ROOT=$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel)
+
+# Step 1: Validate issue exists and fetch metadata
+ISSUE_JSON=$(gh issue view "$ISSUE_NUM" --json title,labels,body,state 2>&1) || {
+  echo "SETUP:FAIL | Issue #${ISSUE_NUM} not found or gh error: ${ISSUE_JSON}" >&2
+  exit 1
+}
+
+STATE=$(echo "$ISSUE_JSON" | jq -r '.state')
+if [[ "$STATE" == "CLOSED" ]]; then
+  echo "SETUP:FAIL | Issue #${ISSUE_NUM} is closed" >&2
+  exit 1
+fi
+
+TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
+
+# Step 2: Derive branch name from issue title
+# "fix: hover crash on null" → "fix/hover-crash-on-null"
+# "feat: add completion" → "feat/add-completion"
+# If no type prefix, default to "feat/"
+BRANCH=""
+if echo "$TITLE" | grep -qE "^(fix|feat|test|docs|refactor|chore):"; then
+  TYPE=$(echo "$TITLE" | sed -E 's/^(fix|feat|test|docs|refactor|chore):.*/\1/')
+  DESC=$(echo "$TITLE" | sed -E 's/^(fix|feat|test|docs|refactor|chore):\s*//')
+else
+  TYPE="feat"
+  DESC="$TITLE"
+fi
+
+# Sanitize description: lowercase, spaces→dashes, remove special chars, trim length
+DESC=$(echo "$DESC" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 -]//g' | sed 's/ \+/-/g' | sed 's/^-//;s/-$//' | cut -c1-40)
+BRANCH="${TYPE}/${DESC}"
+
+# Step 3: Create worktree
+WT_OUTPUT=$("$REPO_ROOT/scripts/worktree.sh" create "$BRANCH" 2>&1) || {
+  echo "SETUP:FAIL | worktree.sh failed: ${WT_OUTPUT}" >&2
+  exit 1
+}
+
+# Extract worktree path from output
+# worktree.sh prints the path — look for the sibling directory
+SANITIZED=$(echo "$BRANCH" | sed 's|/|-|g')
+PARENT_DIR=$(dirname "$REPO_ROOT")
+REPO_NAME=$(basename "$REPO_ROOT")
+WT_PATH="${PARENT_DIR}/${REPO_NAME}-${SANITIZED}"
+
+if [[ ! -d "$WT_PATH" ]]; then
+  echo "SETUP:FAIL | Worktree directory not found at ${WT_PATH}" >&2
+  exit 1
+fi
+
+ABS_PATH=$(cd "$WT_PATH" && pwd)
+
+echo "SETUP:OK | WT:${ABS_PATH} | BRANCH:${BRANCH} | ISSUE:#${ISSUE_NUM}"


### PR DESCRIPTION
fixes #230

## Summary
- Add `stall-guard.sh` hook — blocks `sleep`, `watch`, infinite loops, poll patterns in worker Bash calls
- Fix role detection — main repo defaults to `unknown` instead of `executor`
- Add `scripts/worker-setup.sh` — single-call bootstrap: issue number → validated worktree
- Add `scripts/create-task.sh` — generates grep-friendly `TASK_*` prefixed OMC task descriptions from GitHub issues
- Add `--notes` flag to `worker-submit.sh` — workers report unexpected problems directly on PRs
- Rewrite lead role/skill — issue-first mandatory workflow, OMC team pipeline stage mapping
- Rewrite executor role/skill — `worker-setup.sh` bootstrap, strict idle protocol
- Update `worker-orient` and `lead-startup` skills — reference new scripts, enforce no-loop

## Test plan
- [x] stall-guard blocks sleep/watch/loops (exit 2), allows ci-wait/test-agent (exit 0)
- [x] role-init returns "unknown" for main repo without CLAUDE_ROLE set
- [x] All pre-commit and pre-push hooks pass
- [ ] End-to-end: lead creates issue → create-task.sh → worker uses worker-setup.sh → submit with --notes