### PR TITLE
fix: enforce worktree workflow - block workers from editing main directly

### DIFF
--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -45,10 +45,10 @@ if [[ "$TOOL" == "Write" || "$TOOL" == "Edit" || "$TOOL" == "MultiEdit" ]]; then
       # File IS in the main repo. Check if it's a source file.
       REL_PATH="${FILE_PATH#$MAIN_REPO/}"
 
-      # Allow non-source files in main repo
+      # Allow only .omc/, .claude/, scripts/ in main repo (workers must use worktrees)
       case "$REL_PATH" in
-        .omc/*|.claude/*|scripts/*|STATUS.md|CLAUDE.md|*.md|*.json|*.yaml|*.yml|*.sh|*.log|.gitignore|.eslintrc*|tsconfig*|.husky/*)
-          exit 0  # config/doc files are fine in main repo
+        .omc/*|.claude/*|scripts/*)
+          exit 0  # config/scripts are fine in main repo
           ;;
       esac
 


### PR DESCRIPTION
fixes #241

## What
Enforce that workers use worktrees instead of editing main repo directly:
- role-protocol-enforcer.sh: New block for workers trying to edit main repo
- worktree-guard.sh: Removed allowances for .md/.json/.sh files in main repo

## Changes
- Workers on main branch now blocked from ANY edits (Write/Edit tools)
- Clear error message directs to create worktree first
- Only .omc/, .claude/, scripts/ allowed in main repo

## Checklist
- [x] Hooks block worker edits in main
- [x] Clear error messages
- [x] CI passes