### PR TITLE
fix: enforce worker-submit.sh for PR creation

### DIFF
--- a/scripts/worker-submit.sh
+++ b/scripts/worker-submit.sh
@@ -119,8 +119,8 @@ if [[ -n "$NOTES" ]]; then
 ${NOTES}"
 fi
 
-# --- Create PR ---
-gh pr create \
+# --- Create PR (bypass hook) ---
+WORKER_SUBMIT_MODE=1 gh pr create \
   --base main \
   --title "$COMMIT_MSG" \
   --body "$PR_BODY" 2>/dev/null


### PR DESCRIPTION
fixes #241

## What
Enforce worker-submit.sh workflow - block direct gh pr create

## Why
Workers were completing tasks but not creating PRs via worker-submit.sh

## Changes
- toolchain-guard.sh: block direct gh pr create unless WORKER_SUBMIT_MODE=1
- worker-submit.sh: set WORKER_SUBMIT_MODE=1 before gh pr create

## Checklist
- [x] TDD: failing test → implementation → passing test
- [x] Smoke test passed pre-submit
- [ ] CI passes