### PR TITLE
fix: add variable and constant to code lens reference counts

### DIFF
--- a/packages/pike-lsp-server/src/features/advanced/code-lens.ts
+++ b/packages/pike-lsp-server/src/features/advanced/code-lens.ts
@@ -57,7 +57,9 @@ export function registerCodeLensHandlers(
             const lenses: CodeLens[] = [];
 
             for (const symbol of cache.symbols) {
-                if (symbol.kind === 'method' || symbol.kind === 'class') {
+                // Show reference counts for classes, methods, variables, and constants
+                if (symbol.kind === 'method' || symbol.kind === 'class' ||
+                    symbol.kind === 'variable' || symbol.kind === 'constant') {
                     const line = Math.max(0, (symbol.position?.line ?? 1) - 1);
                     const char = Math.max(0, (symbol.position?.column ?? 1) - 1);
                     const symbolName = symbol.name ?? '';


### PR DESCRIPTION
fixes #261

## What
fix: add variable and constant to code lens reference counts

## Checklist
- [x] TDD: failing test → implementation → passing test
- [x] Smoke test passed pre-submit
- [ ] CI passes