### PR TITLE
chore: Optimize CI workflow (#276)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,8 +3,28 @@ name: Performance Benchmarks
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.claude/**'
+      - '.omc/**'
+      - 'docusaurus.config.ts'
+      - 'sidebars.ts'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.claude/**'
+      - '.omc/**'
+      - 'docusaurus.config.ts'
+      - 'sidebars.ts'
+
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   benchmark:
@@ -17,6 +37,14 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install Pike
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 0 * * 0' # Run weekly
 
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   gitleaks:
     name: Gitleaks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,28 @@ name: Test
 on:
   push:
     branches: [main, master]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.claude/**'
+      - '.omc/**'
+      - 'docusaurus.config.ts'
+      - 'sidebars.ts'
   pull_request:
     branches: [main, master]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.claude/**'
+      - '.omc/**'
+      - 'docusaurus.config.ts'
+      - 'sidebars.ts'
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:
@@ -22,6 +42,14 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install
@@ -100,7 +128,7 @@ jobs:
           else
             # Install latest Pike from repository
             sudo apt-get update
-            # Try to get latest from pike的开发 PPA or build from latest
+            # Try to get latest from pike PPA or build from latest
             sudo apt-get install -y pike8.0 || {
               # If pike8.0 fails, try to build latest from git
               sudo apt-get install -y build-essential libgmp-dev bison flex make git
@@ -135,13 +163,9 @@ jobs:
   build-extension:
     runs-on: ubuntu-24.04
     needs: [test, pike-test]
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
 
     steps:
-      - name: Skip for PRs
-        if: |
-          github.event_name != 'push' ||
-          (github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master')
-        run: echo "Skipping build-extension (only runs on main/master pushes)"
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -149,6 +173,14 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install Pike
         run: |
@@ -185,6 +217,14 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
## Summary
- Add `paths-ignore` filters to test and benchmark workflows — docs-only and config-only changes no longer trigger full test/bench runs
- Add concurrency groups to test, bench, and security workflows — redundant PR runs are auto-cancelled
- Add bun dependency caching (`actions/cache@v4`) to test, build-extension, vscode-e2e, and benchmark jobs
- Fix `build-extension` job: replaced step-level skip with job-level `if` condition so all steps are properly skipped on PRs

## Optimizations

| Optimization | Workflows affected | Impact |
|---|---|---|
| `paths-ignore` (docs, .md, .claude, .omc, docusaurus) | test, bench | Skip full CI for docs/config PRs |
| Concurrency groups with `cancel-in-progress` on PRs | test, bench, security | Cancel stale runs on force-push |
| Bun install cache (`actions/cache@v4`) | test, build-extension, vscode-e2e, bench | Faster dependency install |
| Job-level `if` on build-extension | test | Skip entire job on PRs (was running all steps then echoing "skip") |

## Test plan
- [ ] Push a docs-only change and verify test/bench workflows are skipped
- [ ] Push two rapid commits to a PR and verify the first run is cancelled
- [ ] Verify full CI passes on a code change PR

Closes #276