### PR TITLE
feat: improve release skill and scripts

### DIFF
--- a/.claude/hooks/git-workflow-gate.sh
+++ b/.claude/hooks/git-workflow-gate.sh
@@ -19,6 +19,7 @@ if [ -z "$COMMAND" ]; then
 fi
 
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+echo "[git-workflow-gate] DEBUG: Current branch: $CURRENT_BRANCH"
 should_block=false
 block_message=""
 
@@ -26,11 +27,14 @@ block_message=""
 if [ -f ".omc/state/pike-lsp-release.json" ]; then
   # Check marker age - bypass only valid for 1 hour
   MARKER_AGE=$(($(date +%s) - $(stat -c %Y ".omc/state/pike-lsp-release.json" 2>/dev/null || echo 0)))
+  echo "[git-workflow-gate] DEBUG: Release marker age: ${MARKER_AGE}s"
   if [ "$MARKER_AGE" -lt 3600 ]; then
     # Release skill is active and marker is fresh - bypass all workflow restrictions
+    echo "[git-workflow-gate] RELEASE BYPASS: Release skill active, allowing command"
     exit 0
   fi
   # Marker expired (>1 hour) - treat as if not present
+  echo "[git-workflow-gate] DEBUG: Release marker expired, continuing gate checks"
 fi
 
 # --- 0. Block --no-verify and --admin bypass attempts ---
@@ -172,6 +176,8 @@ if [ "$should_block" = true ]; then
   echo ""
   echo "DEBUG: Command was: $COMMAND"
   echo "DEBUG: Current branch: $CURRENT_BRANCH"
+  echo "DEBUG: Script location: $(pwd)/${BASH_SOURCE[0]}"
+  echo "DEBUG: Timestamp: $(date -Iseconds)"
   exit 2
 fi
 

--- a/.claude/skills/pike-lsp-release/scripts/check-release.sh
+++ b/.claude/skills/pike-lsp-release/scripts/check-release.sh
@@ -12,10 +12,32 @@ NC='\033[0m' # No Color
 
 echo "🔍 Checking release readiness..."
 
-# Get project root
+# Get project root (script is at .claude/skills/pike-lsp-release/scripts/check-release.sh)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 cd "$PROJECT_ROOT"
+
+# Edge case: Check if we're in a git repo (either .git directory or .git file for worktrees)
+if [ ! -d ".git" ] && [ ! -f ".git" ]; then
+    echo -e "${RED}❌ Not in a git repository${NC}" >&2
+    exit 1
+fi
+
+# Edge case: Check for required files
+for f in package.json packages/vscode-pike/package.json CHANGELOG.md; do
+    if [ ! -f "$f" ]; then
+        echo -e "${RED}❌ Missing required file: $f${NC}" >&2
+        exit 1
+    fi
+done
+
+# Edge case: Check for required commands
+for cmd in node git; do
+    if ! command -v "$cmd" &> /dev/null; then
+        echo -e "${RED}❌ Required command not found: $cmd${NC}" >&2
+        exit 1
+    fi
+done
 
 # 1. Check for uncommitted changes
 if [ -n "$(git status --porcelain)" ]; then

--- a/.claude/skills/pike-lsp-release/scripts/prepare-release.sh
+++ b/.claude/skills/pike-lsp-release/scripts/prepare-release.sh
@@ -21,10 +21,32 @@ if [ "$2" = "--dry-run" ] || [ "$1" = "--dry-run" ]; then
     echo ""
 fi
 
-# Get project root
+# Get project root (script is at .claude/skills/pike-lsp-release/scripts/prepare-release.sh)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 cd "$PROJECT_ROOT"
+
+# Edge case: Check if we're in a git repo (either .git directory or .git file for worktrees)
+if [ ! -d ".git" ] && [ ! -f ".git" ]; then
+    echo -e "${RED}❌ Not in a git repository${NC}" >&2
+    exit 1
+fi
+
+# Edge case: Check for required files
+for f in package.json packages/vscode-pike/package.json CHANGELOG.md; do
+    if [ ! -f "$f" ]; then
+        echo -e "${RED}❌ Missing required file: $f${NC}" >&2
+        exit 1
+    fi
+done
+
+# Edge case: Check for required commands
+for cmd in node git jq; do
+    if ! command -v "$cmd" &> /dev/null; then
+        echo -e "${RED}❌ Required command not found: $cmd${NC}" >&2
+        exit 1
+    fi
+done
 
 # Get current version
 CURRENT=$(node -p "require('./packages/vscode-pike/package.json').version")


### PR DESCRIPTION
## Summary
- Fix check-release.sh and prepare-release.sh path (goes up 4 levels instead of 3 for .claude/skills location)
- Add git repo detection for worktrees (.git file check instead of just directory)
- Add required file/command validation with clear error messages
- Add debug output to git-workflow-gate.sh for better agent visibility

## Test plan
- [x] Run check-release.sh from worktree - works
- [x] Run build - passes
- [x] Run test suite (fast) - passes

Fixes #284