### PR TITLE
fix: EPIPE crash in VSCode Remote due to wrong analyzer.pike path

### DIFF
--- a/packages/vscode-pike/src/extension.ts
+++ b/packages/vscode-pike/src/extension.ts
@@ -331,15 +331,15 @@ async function restartClient(showMessage: boolean): Promise<void> {
     const normalizedIncludePaths = expandedIncludePaths.map(normalizePath);
 
     // Determine the analyzer path relative to the server module
-    // When bundled: server/server.js with pike-scripts in same directory
-    // When developing: dist/server.js with pike-scripts in monorepo root (3 levels up)
+    // The server is at: extension-root/server/server.js
+    // The analyzer is at: extension-root/server/pike-scripts/analyzer.pike
     if (!serverModulePath) {
         throw new Error('Server module path not set');
     }
-    // Go up 3 levels from dist/ to monorepo root, then find pike-scripts
+    // Go up 1 level from server/ to extension root, then to pike-scripts
     const serverDir = path.dirname(serverModulePath);
-    const monorepoRoot = path.resolve(serverDir, '..', '..', '..');
-    const analyzerPath = path.join(monorepoRoot, 'pike-scripts', 'analyzer.pike');
+    const extensionRoot = path.resolve(serverDir, '..');
+    const analyzerPath = path.join(extensionRoot, 'server', 'pike-scripts', 'analyzer.pike');
 
     const clientOptions: LanguageClientOptions = {
         documentSelector: [


### PR DESCRIPTION
## Summary
- Fixes the EPIPE crash when opening Pike files in VSCode Remote
- Corrects analyzer.pike path calculation from 3 levels up to 1 level up

## Test Plan
- [x] Build passes
- [x] Smoke tests pass

Fixes #294