### PR TITLE
fix: read source file instead of dist in showReferences test

### DIFF
--- a/packages/vscode-pike/src/test/extension-features.test.ts
+++ b/packages/vscode-pike/src/test/extension-features.test.ts
@@ -164,14 +164,14 @@ describe('Phase 7: VSCode Extension Features (Categories 31-34)', () => {
         });
 
         test('33.4 should register pike.showReferences command', async () => {
-            // Verify command is registered in extension code
-            const extensionJsPath = path.join(__dirname, '..', '..', 'dist', 'extension.js');
-            const extensionJs = fs.readFileSync(extensionJsPath, 'utf-8');
+            // Verify command is registered in extension source code
+            const extensionTsPath = path.join(__dirname, '..', 'extension.ts');
+            const extensionTs = fs.readFileSync(extensionTsPath, 'utf-8');
 
             // Check for showReferences command registration
             expect(
-                extensionJs.includes('pike.showReferences') &&
-                extensionJs.includes('registerCommand')
+                extensionTs.includes('pike.showReferences') &&
+                extensionTs.includes('registerCommand')
             ).toBe(true);
         });
     });


### PR DESCRIPTION
Closes #317

## Summary
- Test 33.4 (`should register pike.showReferences command`) was reading `dist/extension.js` which requires a build step to exist
- Changed to read `src/extension.ts` source file directly, consistent with how other tests in the same file work

## Test plan
- [x] Test 33.4 passes: verified `pike.showReferences` and `registerCommand` found in source
- [x] All 17 tests in `extension-features.test.ts` pass (0 failures)
- [x] Build passes (`bun run build`)