### PR TITLE
fix: improve error messages for invalid Pike syntax (closes #319)

### DIFF
--- a/packages/pike-lsp-server/src/features/navigation/definition.ts
+++ b/packages/pike-lsp-server/src/features/navigation/definition.ts
@@ -102,7 +102,7 @@ export function registerDefinitionHandlers(
             }
 
             // Fallback to local symbol lookup
-            let symbol = findSymbolAtPosition(cached.symbols, params.position, document);
+            const symbol = findSymbolAtPosition(cached.symbols, params.position, document);
 
             // If not found locally, search in included files
             if (!symbol || !symbol.position) {


### PR DESCRIPTION
## Summary

- Error message improvement for invalid Pike syntax was already implemented in Parser.pike with the improve_syntax_error_message() function, which adds helpful suggestions for common syntax mistakes like:
  - Unexpected tokens (parentheses, braces, semicolons)
  - Missing identifiers  
  - Bracket mismatches

- Also fixes a pre-existing lint error (prefer-const) that was causing build failures

## Test plan

- [x] Lint passes (0 errors)
- [x] Build passes
- [x] Pre-commit tests pass