### PR TITLE
docs: add architecture overview link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [Known Limitations](#known-limitations)
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
+- [Architecture](docs/architecture.md)
 - [API Reference](docs/api.md)
 
 ---


### PR DESCRIPTION
Closes #354