### PR TITLE
refactor: clean up server startup

### DIFF
--- a/packages/pike-lsp-server/src/utils/debug-logger.ts
+++ b/packages/pike-lsp-server/src/utils/debug-logger.ts
@@ -1,0 +1,25 @@
+/**
+ * Debug Logging Utility
+ *
+ * Provides debug logging functionality for the LSP server.
+ */
+
+import * as fsSync from 'fs';
+
+const DEFAULT_LOG_FILE = '/tmp/pike-lsp-debug.log';
+
+/**
+ * Create a debug logger function.
+ *
+ * @param logFile - Optional custom log file path
+ * @returns Logger function
+ */
+export function createLogger(logFile: string = DEFAULT_LOG_FILE): (msg: string) => void {
+    return (msg: string) => {
+        try {
+            fsSync.appendFileSync(logFile, `[${new Date().toISOString()}] ${msg}\n`);
+        } catch {
+            // Silently ignore logging failures to prevent cascading errors
+        }
+    };
+}


### PR DESCRIPTION
Refactor: Clean up server startup (closes #388)

- Extract debug logger into reusable utility (utils/debug-logger.ts)
- Simplifies server.ts by using shared utilities
- Improves code organization and maintainability

Closes #388