### PR TITLE
feat: add docker support for remote development and production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,13 +53,16 @@ RUN curl -fsSL https://bun.sh/install | bash
 ENV BUN_INSTALL="/root/.bun"
 ENV PATH="$BUN_INSTALL/bin:$PATH"
 
-# Install Claude CLI
-RUN curl -fsSL https://claude.ai/install.sh | bash
-ENV CLAUDE_HOME="/root/.claude"
-ENV PATH="$CLAUDE_HOME/bin:$PATH"
+# Install Claude CLI and oh-my-claudecode
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+    export PATH="$HOME/.local/bin:$PATH" && \
+    bunx install -g @anthropic-ai/claude-code
 
-# Install oh-my-claudecode using bun
-RUN bunx install -g @anthropic-ai/claude-code
+# Clone Pike and Roxen source trees
+ENV PIKE_SRC=/workspace/pike
+ENV ROXEN_SRC=/workspace/roxen
+RUN git clone --depth 1 --branch v8.0.1116 https://github.com/pikelang/Pike.git ${PIKE_SRC} && \
+    git clone --depth 1 --branch rxnpatch/6.1 https://github.com/pikelang/Roxen.git ${ROXEN_SRC}
 
 # Note: oh-my-claudecode setup should be done inside container with claude --setup
 
@@ -85,7 +88,7 @@ WORKDIR /workspace
 # Copy dependency files first for better caching
 COPY package.json bun.lock* ./
 COPY tsconfig*.json ./
-COPY packages/*/package.json packages/ 2>/dev/null || true
+COPY packages packages/
 
 # Install dependencies
 RUN bun install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,15 @@ services:
       dockerfile: Dockerfile
     container_name: pike-lsp-dev
     ports:
-      - "2222:22"
+      - "2222:22"    # SSH
+      - "3033:3033"  # LSP server port
     volumes:
       - .:/workspace
     environment:
       - CI=true
       - NODE_ENV=development
+      - PIKE_SRC=/workspace/pike
+      - ROXEN_SRC=/workspace/roxen
     working_dir: /workspace
     tty: true
     stdin_open: true
@@ -27,3 +30,21 @@ services:
     command: bun run test
     profiles:
       - test
+
+  # Production LSP server (headless)
+  pike-lsp-prod:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: pike-lsp-prod
+    ports:
+      - "3033:3033"
+    environment:
+      - PIKE_SRC=/workspace/pike
+      - ROXEN_SRC=/workspace/roxen
+    volumes:
+      - .:/workspace
+    command: ["bun", "run", "packages/pike-lsp-server/src/server.ts"]
+    profiles:
+      - prod
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Fix Dockerfile COPY command (invalid shell redirect syntax)
- Fix oh-my-claudecode installation PATH issue
- Clone Pike v8.0.1116 and Roxen rxnpatch/6.1 as PIKE_SRC/ROXEN_SRC
- Add production LSP server docker-compose profile
- Expose LSP port 3033 for remote IDE connections

## Linked Issue
Closes #402

## Verification
- [x] bun run lint passes
- [x] bun test passes
- [x] bun run build passes