### PR TITLE
chore: add VSCode marketplace metadata (closes #397)

### DIFF
--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -14,6 +14,11 @@
     "type": "git",
     "url": "https://github.com/TheSmuks/pike-lsp.git"
   },
+  "bugs": {
+    "url": "https://github.com/TheSmuks/pike-lsp/issues"
+  },
+  "homepage": "https://github.com/TheSmuks/pike-lsp#readme",
+  "qna": "marketplace",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
## Summary
Added missing VSCode marketplace metadata fields to the extension's package.json: bugs URL, homepage link, and qna setting.

## Linked Issue
Closes #397

## Root Cause
The package.json was missing several recommended fields for VSCode marketplace visibility and support link functionality.

## Changes
- packages/vscode-pike/package.json: Added bugs.url, homepage, and qna fields

## Verification
bun run lint → PASS (0 errors, 84 warnings)
bun run typecheck → PASS
bun run build → PASS

## Notes for Reviewer
These are standard marketplace metadata fields that improve the extension's listing and user support experience.