### PR TITLE
fix: improve error messages in LSP server for better debugging

### DIFF
--- a/packages/pike-lsp-server/src/features/file-watcher.ts
+++ b/packages/pike-lsp-server/src/features/file-watcher.ts
@@ -164,7 +164,7 @@ export function registerFileWatcher(
             const content = await fs.promises.readFile(path, 'utf-8');
             await index.indexDocument(uri, content, 0);
         } catch (err) {
-            throw new Error(`Failed to read created file: ${err instanceof Error ? err.message : String(err)}`);
+            throw new Error(`Failed to read newly created file '${path}': ${err instanceof Error ? err.message : String(err)}. Check file permissions and ensure the path is accessible.`);
         }
     }
 
@@ -200,7 +200,7 @@ export function registerFileWatcher(
                 handleFileDeleted(uri, index, cache);
                 return;
             }
-            throw new Error(`Failed to read changed file: ${err instanceof Error ? err.message : String(err)}`);
+            throw new Error(`Failed to read changed file '${path}': ${err instanceof Error ? err.message : String(err)}. Check file permissions and ensure the path is accessible.`);
         }
     }
 

--- a/packages/pike-lsp-server/src/server.ts
+++ b/packages/pike-lsp-server/src/server.ts
@@ -300,7 +300,9 @@ connection.onInitialize(async (params: InitializeParams): Promise<InitializeResu
             },
         };
     } catch (err) {
-        connection.console.error(`CRITICAL ERROR in onInitialize: ${err instanceof Error ? err.stack : String(err)}`);
+        const errMsg = err instanceof Error ? err.stack : String(err);
+        connection.console.error(`CRITICAL ERROR in onInitialize: ${errMsg}. This error occurred during LSP server initialization. Check that Pike is installed correctly and the analyzer.pike script exists.`);
+        log(`CRITICAL ERROR in onInitialize: ${errMsg}`);
         throw err;
     }
 });

--- a/packages/pike-lsp-server/src/services/bridge-manager.ts
+++ b/packages/pike-lsp-server/src/services/bridge-manager.ts
@@ -218,7 +218,7 @@ export class BridgeManager {
      * @returns Analyze response with result/failures structure and performance timing.
      */
     async analyze(code: string, include: AnalysisOperation[], filename?: string, documentVersion?: number): Promise<AnalyzeResponse> {
-        if (!this.bridge) throw new Error('Bridge not available');
+        if (!this.bridge) throw new Error('Bridge not available: analyze() called before bridge was initialized. Ensure onInitialize has completed before calling analyze.');
 
         // LOG-14-01: Track analyze call entry with full parameters
         const startTime = performance.now();
@@ -265,7 +265,7 @@ export class BridgeManager {
      * Parse Pike source code and extract symbols.
      */
     async parse(code: string, filename: string) {
-        if (!this.bridge) throw new Error('Bridge not available');
+        if (!this.bridge) throw new Error('Bridge not available: Pike bridge is not initialized. This usually happens when the LSP server is still starting up or the bridge failed to start. Check the LSP logs for more details.');
         return this.bridge.parse(code, filename);
     }
 
@@ -273,7 +273,7 @@ export class BridgeManager {
      * Find all identifier occurrences using Pike tokenization.
      */
     async findOccurrences(text: string) {
-        if (!this.bridge) throw new Error('Bridge not available');
+        if (!this.bridge) throw new Error('Bridge not available: Pike bridge is not initialized. This usually happens when the LSP server is still starting up or the bridge failed to start. Check the LSP logs for more details.');
         return this.bridge.findOccurrences(text);
     }
 
@@ -287,7 +287,7 @@ export class BridgeManager {
         character?: number,
         filename?: string
     ) {
-        if (!this.bridge) throw new Error('Bridge not available');
+        if (!this.bridge) throw new Error('Bridge not available: Pike bridge is not initialized. This usually happens when the LSP server is still starting up or the bridge failed to start. Check the LSP logs for more details.');
         return this.bridge.findRenamePositions(code, symbolName, line, character, filename);
     }
 
@@ -295,7 +295,7 @@ export class BridgeManager {
      * Prepare rename - get symbol range at position.
      */
     async prepareRename(code: string, line: number, character: number, filename?: string) {
-        if (!this.bridge) throw new Error('Bridge not available');
+        if (!this.bridge) throw new Error('Bridge not available: Pike bridge is not initialized. This usually happens when the LSP server is still starting up or the bridge failed to start. Check the LSP logs for more details.');
         return this.bridge.prepareRename(code, line, character, filename);
     }
 
@@ -315,7 +315,7 @@ export class BridgeManager {
         documentUri?: string,
         documentVersion?: number
     ) {
-        if (!this.bridge) throw new Error('Bridge not available');
+        if (!this.bridge) throw new Error('Bridge not available: Pike bridge is not initialized. This usually happens when the LSP server is still starting up or the bridge failed to start. Check the LSP logs for more details.');
         return this.bridge.getCompletionContext(code, line, character, documentUri, documentVersion);
     }
 
@@ -323,7 +323,7 @@ export class BridgeManager {
      * Resolve a module path to a file location.
      */
     async resolveModule(modulePath: string, fromFile: string) {
-        if (!this.bridge) throw new Error('Bridge not available');
+        if (!this.bridge) throw new Error('Bridge not available: Pike bridge is not initialized. This usually happens when the LSP server is still starting up or the bridge failed to start. Check the LSP logs for more details.');
         return this.bridge.resolveModule(modulePath, fromFile);
     }
 
@@ -339,7 +339,7 @@ export class BridgeManager {
      * Analyze uninitialized variable usage.
      */
     async analyzeUninitialized(text: string, filename: string) {
-        if (!this.bridge) throw new Error('Bridge not available');
+        if (!this.bridge) throw new Error('Bridge not available: Pike bridge is not initialized. This usually happens when the LSP server is still starting up or the bridge failed to start. Check the LSP logs for more details.');
         return this.bridge.analyzeUninitialized(text, filename);
     }
 
@@ -354,7 +354,7 @@ export class BridgeManager {
      * @returns Roxen module information
      */
     async roxenDetect(code: string, filename?: string): Promise<import('../features/roxen/types.js').RoxenModuleInfo> {
-        if (!this.bridge) throw new Error('Bridge not available');
+        if (!this.bridge) throw new Error('Bridge not available: Pike bridge is not initialized. This usually happens when the LSP server is still starting up or the bridge failed to start. Check the LSP logs for more details.');
 
         // Call the roxen_detect RPC handler
         return this.bridge.roxenDetect(code, filename);
@@ -375,7 +375,7 @@ export class BridgeManager {
      * @returns Validation diagnostics
      */
     async roxenValidate(code: string, filename: string, moduleInfo?: Record<string, unknown>) {
-        if (!this.bridge) throw new Error('Bridge not available');
+        if (!this.bridge) throw new Error('Bridge not available: Pike bridge is not initialized. This usually happens when the LSP server is still starting up or the bridge failed to start. Check the LSP logs for more details.');
 
         return this.bridge.roxenValidate(code, filename, moduleInfo);
     }
@@ -391,7 +391,7 @@ export class BridgeManager {
      * Evaluate a constant Pike expression.
      */
     async evaluateConstant(expression: string, filename?: string) {
-        if (!this.bridge) throw new Error('Bridge not available');
+        if (!this.bridge) throw new Error('Bridge not available: Pike bridge is not initialized. This usually happens when the LSP server is still starting up or the bridge failed to start. Check the LSP logs for more details.');
         return this.bridge.evaluateConstant(expression, filename);
     }
 }

--- a/packages/pike-lsp-server/src/utils/compatibility.ts
+++ b/packages/pike-lsp-server/src/utils/compatibility.ts
@@ -114,7 +114,7 @@ export function detectModule(moduleName: string): boolean {
  * ```
  */
 export function handleMissingModule(moduleName: string): never {
-    throw new Error(`Module ${moduleName} not available`);
+    throw new Error(`Module '${moduleName}' is not available in this Pike version. This feature requires Pike 8.0 or higher. Check that your Pike installation includes this module and that PIKE_PATH is correctly configured.`);
 }
 
 /**
@@ -133,7 +133,7 @@ export function checkModuleAvailability(moduleName: string): {
 
     return {
         available: false,
-        error: `Module ${moduleName} not available`,
+        error: `Module '${moduleName}' is not available. This feature requires Pike 8.0 or higher. Verify that PIKE_PATH is set correctly and your Pike installation includes this module.`,
     };
 }
 

--- a/packages/pike-lsp-server/src/utils/validation.ts
+++ b/packages/pike-lsp-server/src/utils/validation.ts
@@ -183,7 +183,8 @@ export function isBatchParseResult(obj: unknown): obj is BatchParseResult {
  */
 export function validatePikeResponse<T>(obj: unknown, typeGuard: (obj: unknown) => obj is T, typeName: string): T {
     if (!typeGuard(obj)) {
-        throw new Error(`Invalid Pike response: expected ${typeName}, got ${JSON.stringify(obj).slice(0, 200)}`);
+        const received = obj === null ? 'null' : obj === undefined ? 'undefined' : typeof obj;
+        throw new Error(`Invalid Pike response: expected type '${typeName}', but received ${received}. This may indicate a version mismatch between the Pike bridge and the LSP server, or the Pike subprocess crashed. Received data: ${JSON.stringify(obj).slice(0, 200)}`);
     }
     return obj;
 }


### PR DESCRIPTION
## Summary
Improved error messages across the LSP server to provide better debugging information. Added context, common causes, and suggested fixes to error messages in bridge-manager, validation, compatibility, server, and file-watcher modules.

## Linked Issue
Closes #395

## Root Cause
Error messages were too generic (e.g., "Bridge not available", "Module not available") without providing actionable information about what went wrong or how to fix it.

## Changes
- `bridge-manager.ts`: Added descriptive context to 11 "Bridge not available" errors explaining the likely cause and suggesting to check LSP logs
- `validation.ts`: Added version mismatch and Pike subprocess crash warnings to response validation errors
- `compatibility.ts`: Added Pike version requirements (8.0+) and PIKE_PATH configuration guidance to module availability errors
- `server.ts`: Added initialization checklist (Pike installation, analyzer.pike existence) to critical errors
- `file-watcher.ts`: Added file path and permission hints to file read errors

## Verification
- bun run lint → PASS (0 errors, 84 warnings)
- bun run build → PASS
- bun test → 2334 pass (failures are pre-existing vscode package issues)
- Pre-commit checks → PASS

## Notes for Reviewer
The changes are purely string improvements in error messages - no logic changes. Test failures are pre-existing issues with the vscode-pike package missing its vscode dependency.