### PR TITLE
chore: add VSCode marketplace metadata

### DIFF
--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -17,6 +17,8 @@
   "bugs": {
     "url": "https://github.com/TheSmuks/pike-lsp/issues"
   },
+  "homepage": "https://github.com/TheSmuks/pike-lsp#readme",
+  "qna": "marketplace",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
## Summary
Add VSCode marketplace metadata (homepage, qna) to the extension package.json.

## Changes
- packages/vscode-pike/package.json: Added homepage and qna fields

Closes #397