### PR TITLE
docs: add Pike API reference documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,10 +8,17 @@ The TypeScript API documentation is auto-generated from source code using [TypeD
 
 - **[TypeScript API Docs](./api/typescript/)** - Auto-generated API reference for `@pike-lsp/core`, `@pike-lsp/pike-bridge`, and `@pike-lsp/pike-lsp-server`
 
+## Pike API Reference
+
+The Pike-side API documentation covers the core Pike modules that power the LSP analysis:
+
+- **[Pike API Docs](./api/pike/)** - Pike source code documentation for `LSP.pmod`, analysis, diagnostics, and Roxen support modules
+
 ## Table of Contents
 
 - [Feature Modules](#feature-modules)
 - [LSP Providers](#lsp-providers)
+- [Pike API Reference](#pike-api-reference)
 - [Services](#services)
 - [Type Definitions](#type-definitions)
 


### PR DESCRIPTION
## Summary
Adds a new section in the API reference documentation that links to the Pike-side API documentation covering LSP.pmod, analysis, diagnostics, and Roxen support modules.

## Linked Issue
Closes #418

## Root Cause
The main API documentation page (docs/api.md) already had TypeScript API documentation links but was missing references to the Pike-side API documentation that already existed in docs/api/pike/.

## Changes
- docs/api.md: Added new "Pike API Reference" section linking to docs/api/pike/ with description of the modules covered

## Verification
bun run lint → PASS (0 errors, 85 warnings pre-existing)
bun run typecheck → PASS
bun run build → PASS
cd packages/pike-bridge && bun test → PASS (182 tests)
cd packages/pike-lsp-server && bun test → PASS (2089 tests)

## Notes for Reviewer
The Pike API documentation was already generated and existed in docs/api/pike/, but wasn't linked from the main API reference page. This change adds the missing reference.