### PR TITLE
perf: optimize diagnostic performance for large files

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics/utils.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/utils.ts
@@ -65,18 +65,29 @@ export function convertSeverity(severity: string): DiagnosticSeverity {
  * Adds Diagnostic.code and Diagnostic.tags:
  * - code: Error code identifier (e.g., "uninitialized-var", "syntax-error")
  * - tags: DiagnosticTag.Deprecated for deprecated symbol usage
+ *
+ * PERF-420: Optimized to accept pre-split lines instead of re-splitting document text
+ * for each diagnostic - significant improvement for large files with many diagnostics.
  */
 export function convertDiagnostic(
     pikeDiag: PikeDiagnostic,
     document: TextDocument,
-    options?: { deprecated?: boolean; code?: string }
+    options?: { deprecated?: boolean; code?: string },
+    linesArg?: string[]  // PERF-420: Optional pre-split lines for performance
 ): Diagnostic {
     const line = Math.max(0, (pikeDiag.position.line ?? 1) - 1);
 
-    // Get the line text to determine range
-    const text = document.getText();
-    const lines = text.split('\n');
-    const lineText = lines[line] ?? '';
+    // PERF-420: Use pre-split lines if provided, otherwise split once
+    let lineText: string;
+    let lines: string[];
+    if (linesArg) {
+        lines = linesArg;
+        lineText = linesArg[line] ?? '';
+    } else {
+        const text = document.getText();
+        lines = text.split('\n');
+        lineText = lines[line] ?? '';
+    }
 
     // Find meaningful range within the line (skip whitespace and comments)
     let startChar = pikeDiag.position.column ? pikeDiag.position.column - 1 : 0;


### PR DESCRIPTION
## Summary
Optimized diagnostic generation performance for large files by splitting document text into lines once instead of per-diagnostic. For files with many diagnostics (e.g., 100+), this avoids redundant string splitting operations.

## Linked Issue
Closes #420

## Root Cause
The `convertDiagnostic` function was calling `document.getText()` and `text.split('\n')` for each diagnostic. With large files containing many diagnostics, this resulted in redundant string splitting operations - O(n) splits for n diagnostics instead of O(1).

## Changes
- `packages/pike-lsp-server/src/features/diagnostics.ts`: Added optional `lines` parameter to `convertDiagnostic` function and split lines once in `validateDocument` before processing diagnostics
- `packages/pike-lsp-server/src/features/diagnostics/utils.ts`: Updated duplicate `convertDiagnostic` function with same optimization

## Verification
bun run lint → PASS (0 errors, 84 warnings)
bun run build → PASS
cd packages/pike-bridge && bun test → PASS (182 tests)
cd packages/pike-lsp-server && bun test → PASS (2089 tests)
smoke tests → PASS
integration tests → PASS

## Notes for Reviewer
This is a backward-compatible change - the optional `lines` parameter defaults to splitting the text if not provided, maintaining existing behavior for callers that don't pass the parameter.