### PR TITLE
fix: enforce issue templates, block npm references, fix worker tracking

### DIFF
--- a/.github/workflows/enforce-issue-template.yml
+++ b/.github/workflows/enforce-issue-template.yml
@@ -1,0 +1,88 @@
+name: Enforce Issue Template
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  check-issue-format:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Enforce issue template
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Only enforce on safe issues
+            const labels = issue.labels.map(l => l.name);
+            if (!labels.includes('safe')) {
+              console.log(`Issue #${issue.number} not labeled safe, skipping`);
+              return;
+            }
+
+            const required = [
+              '## Description',
+              '## Problem',
+              '## Expected Behavior',
+              '## Suggested Approach',
+              '## Affected Files',
+              '## Acceptance'
+            ];
+
+            const missing = required.filter(section => {
+              const idx = body.indexOf(section);
+              if (idx === -1) return true;
+              const after = body.slice(idx + section.length).trim();
+              const nextSection = after.search(/^##\s/m);
+              const content = nextSection === -1
+                ? after
+                : after.slice(0, nextSection);
+              return !content.replace(/<!--[\s\S]*?-->/g, '').trim();
+            });
+
+            if (missing.length > 0) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner, repo,
+                  issue_number: issue.number,
+                  labels: ['needs-template']
+                });
+              } catch (e) {}
+
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: issue.number,
+                body:
+                  `⚠️ This issue is missing required sections or has empty content:\n\n` +
+                  missing.map(s => `- \`${s}\``).join('\n') +
+                  `\n\nAll sections must have substantive content — not placeholders ` +
+                  `or HTML comments.\n\n` +
+                  `Agents will not pick up issues labeled \`needs-template\`. ` +
+                  `Update the issue body to remove this label.`
+              });
+
+              core.setFailed(
+                `Issue #${issue.number} missing sections: ${missing.join(', ')}`
+              );
+              return;
+            }
+
+            // All sections present — remove needs-template if exists
+            try {
+              await github.rest.issues.removeLabel({
+                owner, repo,
+                issue_number: issue.number,
+                name: 'needs-template'
+              });
+              console.log(`Issue #${issue.number}: template OK, removed needs-template`);
+            } catch (e) {}
+
+            console.log(`Issue #${issue.number}: template format OK`);
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Three fixes: (1) Issue creation now enforced at hook and workflow level — agents cannot create lazy or empty issues. Issues labeled needs-template are blocked from pickup. (2) npm references in issue titles are blocked by hook and bun toolchain warning added prominently to CLAUDE.md. (3) Lead now calculates AVAILABLE = N - BUSY before each cycle instead of blindly spawning N workers every time.

## Linked Issue
Closes #5549

## Root Cause
Hook only checked for section headings not content, so agents wrote empty sections. No title validation existed for npm references. Lead Step 1 treated N as spawn count rather than maximum cap, causing duplicate workers when previous cycles had not fully completed.

## Changes
- .claude/hooks/pre-tool.sh: enforce issue section content, block npm titles, block needs-template issues
- .github/workflows/enforce-issue-template.yml: CREATE — validate issue body on open/edit
- CLAUDE.md: add toolchain warning at top, fix Lead Step 1 to track AVAILABLE workers
- Prerequisites: add needs-template label creation

## Verification
bun run lint → pre-existing errors in generated files
bun run typecheck → PASS
bun run build → PASS
cd packages/pike-bridge && bun test → PASS (182 tests)
cd packages/pike-lsp-server && bun test → PASS (2105 tests)
smoke tests → PASS
integration tests → PASS
pike cross-version tests → PASS
vscode e2e → 4 pre-existing navigation failures (unrelated to changes)
hook syntax → PASS