### PR TITLE
fix: add handler for textDocument/semanticTokens/full/delta

### DIFF
--- a/packages/pike-lsp-server/src/features/advanced/semantic-tokens.ts
+++ b/packages/pike-lsp-server/src/features/advanced/semantic-tokens.ts
@@ -9,6 +9,7 @@ import {
     Connection,
     SemanticTokensBuilder,
     SemanticTokens,
+    SemanticTokensDelta,
 } from 'vscode-languageserver/node.js';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { TextDocuments } from 'vscode-languageserver/node.js';
@@ -207,6 +208,35 @@ export function registerSemanticTokensHandler(
         } catch (err) {
             log.error('Semantic tokens request failed', { error: err instanceof Error ? err.message : String(err) });
             return { data: [] };
+        }
+    });
+
+    /**
+     * Semantic Tokens - Delta request handler
+     *
+     * Handles incremental semantic token updates. Since we don't maintain token state
+     * for delta computation, we return all tokens as a delta edit that replaces
+     * everything from position 0. This triggers a full refresh on the client side.
+     */
+    connection.languages.semanticTokens.onDelta((params): SemanticTokensDelta => {
+        log.debug('Semantic tokens delta request', { uri: params.textDocument.uri });
+        try {
+            const uri = params.textDocument.uri;
+            const document = documents.get(uri);
+
+            if (!document) {
+                return { resultId: '0', edits: [] };
+            }
+
+            // Build full tokens and return as delta replacing all
+            const tokens = buildTokens(uri, document);
+            return {
+                resultId: '0',
+                edits: [{ start: 0, deleteCount: tokens.data.length, data: tokens.data }],
+            };
+        } catch (err) {
+            log.error('Semantic tokens delta request failed', { error: err instanceof Error ? err.message : String(err) });
+            return { resultId: '0', edits: [] };
         }
     });
 }


### PR DESCRIPTION
## Summary
Added a handler for the `textDocument/semanticTokens/full/delta` LSP method that was causing 'Unhandled method' errors during e2e tests. The handler returns a full token refresh when delta computation is not available.

## Linked Issue
Closes #426

## Root Cause
The server advertised delta support in capabilities (`semanticTokensProvider: { full: { delta: true } }`) but lacked a handler for the corresponding method. VSCode was requesting delta updates but the server had no handler registered.

## Changes
- packages/pike-lsp-server/src/features/advanced/semantic-tokens.ts: Added `onDelta` handler that returns a full token refresh when delta computation is not available

## Verification
e2e tests run: grep for "Unhandled method" returns no results
- The "Unhandled method textDocument/semanticTokens/full/delta" errors no longer appear in e2e test output
- Build: PASS
- Pre-commit tests: PASS (3/3)

## Notes for Reviewer
The remaining 4 test failures in the Include/Import/Inherit Navigation tests are pre-existing issues unrelated to this fix.