### PR TITLE
refactor: improve logging in LSP server

### DIFF
--- a/packages/pike-lsp-server/src/features/rxml/diagnostics.ts
+++ b/packages/pike-lsp-server/src/features/rxml/diagnostics.ts
@@ -119,7 +119,7 @@ export async function validateRXMLDocument(
                 resolve(diagnostics);
             } catch (error) {
                 // Log error and resolve with empty diagnostics to prevent Promise hang
-                console.error('[RXML Validation] Error during validation:', error);
+                console.warn(`[RXML Validation] Warning during validation for ${uri}:`, error);
                 resolve([]);
             }
         }, debounceMs);

--- a/packages/pike-lsp-server/src/features/rxml/parser.ts
+++ b/packages/pike-lsp-server/src/features/rxml/parser.ts
@@ -113,7 +113,7 @@ export function parseRXMLTemplate(code: string, uri: string): RXMLTag[] {
         return walkDOM(document.children, contentToParse);
     } catch (error) {
         // Log parsing errors but don't fail - return empty array
-        console.error(`Failed to parse RXML template in ${uri}:`, error);
+        console.warn(`[RXML Parser] Warning: failed to parse template in ${uri}:`, error);
         return [];
     }
 }

--- a/packages/pike-lsp-server/src/services/workspace-scanner.ts
+++ b/packages/pike-lsp-server/src/services/workspace-scanner.ts
@@ -181,8 +181,12 @@ export class WorkspaceScanner {
                                 path: uri,
                                 lastModified: stat.mtimeMs,
                             });
-                        } catch {
-                            // File might have been deleted, skip
+                        } catch (err) {
+                            // File might have been deleted, skip - log at debug level
+                            this.logger.debug('WorkspaceScanner: failed to stat file', {
+                                path: fullPath,
+                                error: err instanceof Error ? err.message : String(err),
+                            });
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
Improved logging throughout the LSP server for better debugging. Replaced direct console.error calls with more descriptive console.warn messages, and added debug logging for file stat failures in WorkspaceScanner.

## Linked Issue
Closes #456

## Root Cause
The LSP server had some direct console.error calls in RXML parsing/diagnostics that could be improved with more descriptive messages. Also, empty catch blocks in WorkspaceScanner lacked logging for troubleshooting.

## Changes
- packages/pike-lsp-server/src/features/rxml/diagnostics.ts: Changed console.error to console.warn with more descriptive message including URI
- packages/pike-lsp-server/src/features/rxml/parser.ts: Changed console.error to console.warn with more descriptive message including URI  
- packages/pike-lsp-server/src/services/workspace-scanner.ts: Added debug logging for file stat failures

## Verification
bun run lint → PASS
bun run build → PASS
bun test → 2436 pass, 16 skip, 17 todo, 23 fail (failures pre-existing, not related to logging changes)

## Notes for Reviewer
The test failures shown are pre-existing and not related to these logging improvements.