### PR TITLE
pike: Add #pragma strict_types to Pike source files

### DIFF
--- a/pike-scripts/LSP.pmod/Analysis.pmod/Analysis.pike
+++ b/pike-scripts/LSP.pmod/Analysis.pmod/Analysis.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Analysis.pike - Delegating analysis class for Pike LSP
 //!
 //! This class forwards requests to specialized handlers in the Analysis module:

--- a/pike-scripts/LSP.pmod/Analysis.pmod/Completions.pike
+++ b/pike-scripts/LSP.pmod/Analysis.pmod/Completions.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Completions.pike - Code completion context analysis
 //!
 //! This file provides completion context analysis for Pike code.

--- a/pike-scripts/LSP.pmod/Analysis.pmod/Diagnostics.pike
+++ b/pike-scripts/LSP.pmod/Analysis.pmod/Diagnostics.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Diagnostics.pike - Uninitialized variable analysis
 //!
 //! This file provides diagnostic analysis for Pike code, specifically

--- a/pike-scripts/LSP.pmod/Analysis.pmod/Variables.pike
+++ b/pike-scripts/LSP.pmod/Analysis.pmod/Variables.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Variables.pike - Variable analysis and occurrences
 //!
 //! This file provides variable analysis for Pike code, specifically

--- a/pike-scripts/LSP.pmod/Intelligence.pmod/Intelligence.pike
+++ b/pike-scripts/LSP.pmod/Intelligence.pmod/Intelligence.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Intelligence.pike - Backward-compatible delegating class
 //!
 //! This class forwards all handler calls to the appropriate specialized class

--- a/pike-scripts/LSP.pmod/Intelligence.pmod/Introspection.pike
+++ b/pike-scripts/LSP.pmod/Intelligence.pmod/Introspection.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Introspection.pike - Symbol extraction and introspection handlers
 //!
 //! This file provides handlers for introspecting Pike code to extract

--- a/pike-scripts/LSP.pmod/Intelligence.pmod/ModuleResolution.pike
+++ b/pike-scripts/LSP.pmod/Intelligence.pmod/ModuleResolution.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! ModuleResolution.pike - Import/include/inherit/require directive handling
 //!
 //! This file provides handlers for parsing and resolving Pike module imports

--- a/pike-scripts/LSP.pmod/Intelligence.pmod/Resolution.pike
+++ b/pike-scripts/LSP.pmod/Intelligence.pmod/Resolution.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Resolution.pike - Module name resolution and stdlib introspection handlers
 //!
 //! This file provides handlers for resolving module paths to file locations,

--- a/pike-scripts/LSP.pmod/Intelligence.pmod/TypeAnalysis.pike
+++ b/pike-scripts/LSP.pmod/Intelligence.pmod/TypeAnalysis.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! TypeAnalysis.pike - Type inheritance and AutoDoc parsing handlers
 //!
 //! This file provides handlers for type inheritance traversal and AutoDoc

--- a/pike-scripts/LSP.pmod/Parser.pike
+++ b/pike-scripts/LSP.pmod/Parser.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Parser.pike - Stateless parser class for Pike LSP
 //!
 //! Design per CONTEXT.md:

--- a/pike-scripts/LSP.pmod/Rename.pike
+++ b/pike-scripts/LSP.pmod/Rename.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Rename.pike - Smart rename handler for Pike LSP
 //!
 //! Issue #194: Smart rename that handles Pike module structure.

--- a/pike-scripts/LSP.pmod/Roxen.pmod/MixedContent.pike
+++ b/pike-scripts/LSP.pmod/Roxen.pmod/MixedContent.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Mixed Content.pike - RXML string detection in Pike multiline strings
 //! Per ADR-001: Uses Parser.Pike.split() for all code parsing
 //! Per ADR-002: Uses String.trim_all_whites() for whitespace handling

--- a/pike-scripts/LSP.pmod/Roxen.pmod/Roxen.pike
+++ b/pike-scripts/LSP.pmod/Roxen.pmod/Roxen.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Roxen.pike - Roxen module analysis for LSP
 //! Per ADR-001: Uses Parser.Pike.split() for all code parsing
 //! Per ADR-002: Uses String.trim_all_whites() for whitespace handling

--- a/pike-scripts/LSP.pmod/Roxen.pmod/tests/test_defvar.pike
+++ b/pike-scripts/LSP.pmod/Roxen.pmod/tests/test_defvar.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Roxen defvar parsing tests - TDD RED phase
 //! These tests MUST fail before implementing the fixes
 

--- a/pike-scripts/LSP.pmod/Roxen.pmod/tests/test_detect.pike
+++ b/pike-scripts/LSP.pmod/Roxen.pmod/tests/test_detect.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Roxen module detection tests - TDD RED phase
 //! These tests MUST fail before implementing the fixes
 

--- a/pike-scripts/LSP.pmod/Roxen.pmod/tests/test_module_detection.pike
+++ b/pike-scripts/LSP.pmod/Roxen.pmod/tests/test_module_detection.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Test Roxen module detection
 //! TDD: These tests must fail before implementation
 

--- a/pike-scripts/LSP.pmod/Roxen.pmod/tests/test_tags.pike
+++ b/pike-scripts/LSP.pmod/Roxen.pmod/tests/test_tags.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Roxen tag parsing tests - TDD RED phase
 //! These tests MUST fail before implementing the fixes
 

--- a/pike-scripts/LSP.pmod/RoxenStubs.pmod/RXML.pike
+++ b/pike-scripts/LSP.pmod/RoxenStubs.pmod/RXML.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! RXML.pike - Stub module for RXML (Roxen XML) framework LSP support
 //!
 //! Provides minimal stub implementations of RXML classes to allow

--- a/pike-scripts/LSP.pmod/RoxenStubs.pmod/Roxen.pike
+++ b/pike-scripts/LSP.pmod/RoxenStubs.pmod/Roxen.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Roxen.pike - Stub module for Roxen framework LSP support
 //!
 //! This provides minimal stub implementations of Roxen framework classes

--- a/pike-scripts/LSP.pmod/RoxenStubs.pmod/module.pike
+++ b/pike-scripts/LSP.pmod/RoxenStubs.pmod/module.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! RoxenStubs.pmod/module.pike - Module index for Roxen framework stubs
 //!
 //! This module provides stub implementations of Roxen framework classes

--- a/pike-scripts/analyzer.pike
+++ b/pike-scripts/analyzer.pike
@@ -1,4 +1,5 @@
 #!/usr/bin/env pike
+#pragma strict_types
 #pike __REAL_VERSION__
 
 //! Pike LSP Analyzer Script

--- a/pike-scripts/test-parser-error-recovery.pike
+++ b/pike-scripts/test-parser-error-recovery.pike
@@ -1,4 +1,5 @@
 #!pike __REAL_VERSION__
+#pragma strict_types
 //! Test error recovery in Pike parser
 //!
 //! Tests that the parser can:

--- a/pike-scripts/test-parser-simple.pike
+++ b/pike-scripts/test-parser-simple.pike
@@ -1,4 +1,5 @@
 #!/usr/bin/env pike
+#pragma strict_types
 #pike __REAL_VERSION__
 
 //! Simple test for parser error recovery

--- a/pike-scripts/test-tokenizer.pike
+++ b/pike-scripts/test-tokenizer.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Test tokenizer behavior with "Module." pattern
 //! This documents the EXPECTED output format for cursor detection
 int main() {


### PR DESCRIPTION
## Summary
Added #pragma strict_types directive as the first line to all 24 Pike source files in pike-scripts/ directories. This enables strict type checking for these files.

## Linked Issue
Closes #470

## Root Cause
The Pike source files in pike-scripts/ were missing the #pragma strict_types directive, which is required for proper type checking and helps catch type-related errors at compile time.

## Changes
- pike-scripts/analyzer.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Analysis.pmod/Analysis.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Analysis.pmod/Completions.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Analysis.pmod/Diagnostics.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Analysis.pmod/Variables.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Intelligence.pmod/Intelligence.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Intelligence.pmod/Introspection.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Intelligence.pmod/ModuleResolution.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Intelligence.pmod/Resolution.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Intelligence.pmod/TypeAnalysis.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Parser.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Rename.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Roxen.pmod/MixedContent.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Roxen.pmod/Roxen.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/Roxen.pmod/tests/*.pike: Added #pragma strict_types
- pike-scripts/LSP.pmod/RoxenStubs.pmod/*.pike: Added #pragma strict_types
- pike-scripts/test-*.pike: Added #pragma strict_types

## Verification
bun run lint → PASS
bun run build → PASS
pre-commit smoke tests → PASS (3/3)

## Notes for Reviewer
24 files modified, all with the same simple change: adding #pragma strict_types as the first line after the shebang/pike version directive.