### PR TITLE
fix: add error handling to empty .catch() blocks (#471)

### DIFF
--- a/packages/pike-lsp-server/src/server.ts
+++ b/packages/pike-lsp-server/src/server.ts
@@ -446,8 +446,8 @@ connection.onShutdown(async () => {
 });
 
 connection.onExit(() => {
-    bridgeManager?.stop().catch(() => {
-        // Ignore errors during exit
+    bridgeManager?.stop().catch(err => {
+        connection.console.error(`Error during shutdown: ${err}`);
     });
 });
 

--- a/packages/pike-lsp-server/src/tests/editing/completion-integration.test.ts
+++ b/packages/pike-lsp-server/src/tests/editing/completion-integration.test.ts
@@ -27,14 +27,14 @@ beforeAll(async () => {
         // Suppress stderr noise during tests
         bridge.on('stderr', () => {});
     } catch (err) {
-        await bridge.stop().catch(() => {});
+        await bridge.stop().catch(e => console.error(`Failed to stop bridge: ${e}`));
         throw err;
     }
 });
 
 afterAll(async () => {
     if (bridge) {
-        await bridge.stop().catch(() => {});
+        await bridge.stop().catch(e => console.error(`Failed to stop bridge: ${e}`));
     }
 });
 


### PR DESCRIPTION
## Summary
Replace empty `.catch(() => {})` blocks with proper error logging in the server shutdown handler and test cleanup code.

## Linked Issue
Closes #471

## Root Cause
The existing code silently swallowed errors in catch handlers, which makes debugging difficult when errors actually occur during cleanup operations.

## Changes
- `packages/pike-lsp-server/src/server.ts`: Added error logging to bridge shutdown catch block using `connection.console.error`
- `packages/pike-lsp-server/src/tests/editing/completion-integration.test.ts`: Added error logging to bridge stop catch blocks in beforeAll and afterAll hooks

## Verification
bun run lint → PASS
bun run typecheck → PASS
bun run build → PASS
Pre-commit smoke tests → PASS (3/3)

## Notes for Reviewer
The changes are minimal and focused on the specific issue of empty catch blocks. The server.ts uses `connection.console.error` to properly output to LSP clients, while the test file uses `console.error` for test output.