### PR TITLE
fix: Replace @ts-ignore with @ts-expect-error in test files

### DIFF
--- a/packages/pike-bridge/src/bridge.test.ts
+++ b/packages/pike-bridge/src/bridge.test.ts
@@ -4,7 +4,7 @@
  * Tests the core IPC communication with Pike subprocess
  */
 
-// @ts-ignore - Bun test types
+// @ts-expect-error - Bun test types not included in base tsconfig, used for runtime test execution
 import { describe, it, beforeAll, afterAll } from 'bun:test';
 import assert from 'node:assert/strict';
 import { PikeBridge } from './bridge.js';

--- a/packages/pike-bridge/src/corpus.test.ts
+++ b/packages/pike-bridge/src/corpus.test.ts
@@ -11,7 +11,7 @@
  * Run with: cd packages/pike-bridge && bun run test:corpus
  */
 
-// @ts-ignore - Bun test types
+// @ts-expect-error - Bun test types not included in base tsconfig, used for runtime test execution
 import { describe, it, beforeAll, afterAll } from 'bun:test';
 import assert from 'node:assert/strict';
 import { PikeBridge } from './bridge.js';

--- a/packages/pike-bridge/src/get-pike-paths.test.ts
+++ b/packages/pike-bridge/src/get-pike-paths.test.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - Bun test types
+// @ts-expect-error - Bun test types not included in base tsconfig, used for runtime test execution
 import { describe, it, beforeAll, afterAll } from 'bun:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';

--- a/packages/pike-bridge/src/process.test.ts
+++ b/packages/pike-bridge/src/process.test.ts
@@ -5,7 +5,7 @@
  * Uses a mock process pattern to test without requiring actual Pike installation.
  */
 
-// @ts-ignore - Bun test types
+// @ts-expect-error - Bun test types not included in base tsconfig, used for runtime test execution
 import { describe, it } from 'bun:test';
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'events';

--- a/packages/pike-bridge/src/response-validator.test.ts
+++ b/packages/pike-bridge/src/response-validator.test.ts
@@ -1,4 +1,4 @@
-// @ts-ignore - Bun test types
+// @ts-expect-error - Bun test types not included in base tsconfig, used for runtime test execution
 import { describe, it } from 'bun:test';
 import assert from 'node:assert/strict';
 import {

--- a/packages/pike-bridge/src/roxen.test.ts
+++ b/packages/pike-bridge/src/roxen.test.ts
@@ -2,7 +2,7 @@
  * Roxen Module Analysis Tests
  */
 
-// @ts-ignore - Bun test types
+// @ts-expect-error - Bun test types not included in base tsconfig, used for runtime test execution
 import { describe, it, beforeAll, afterAll } from 'bun:test';
 import assert from 'node:assert/strict';
 import { PikeBridge } from './bridge.js';

--- a/packages/pike-lsp-server/src/tests/features/file-watcher.test.ts
+++ b/packages/pike-lsp-server/src/tests/features/file-watcher.test.ts
@@ -5,7 +5,7 @@
  * Verifies that file changes trigger proper index updates.
  */
 
-// @ts-ignore - Bun test types
+// @ts-expect-error - Bun test types not included in base tsconfig, used for runtime test execution
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { WorkspaceIndex } from '../../workspace-index.js';
 import { PikeBridge } from '@pike-lsp/pike-bridge';

--- a/packages/pike-lsp-server/src/tests/hover-links.test.ts
+++ b/packages/pike-lsp-server/src/tests/hover-links.test.ts
@@ -49,10 +49,7 @@ describe('Hover Links', () => {
             modifiers: [],
             argNames: [],
             argTypes: [],
-            // @ts-ignore - 'documentation' property is not defined in the PikeMethod interface,
-            // but it's used here to test that buildHoverContent handles it dynamically at runtime
-            // (checked at hover-builder.ts:518). This allows extending symbol types without
-            // modifying the core interface.
+            // Note: documentation is inherited from PikeSymbol base interface
             documentation: {
                 text: 'Write data.',
                 seealso: ['Stdio.File', 'read']


### PR DESCRIPTION
## Summary
Replace `@ts-ignore` directives in test files with proper `@ts-expect-error` comments with documentation, and fix one case where `@ts-ignore` was incorrectly used (the `documentation` property already exists in the `PikeSymbol` interface).

## Linked Issue
Closes #473

## Root Cause
Test files were using `@ts-ignore` to suppress TypeScript errors from importing `bun:test` types which are not included in the base tsconfig. Additionally, one test file had an incorrect `@ts-ignore` for a property (`documentation`) that already exists in the base `PikeSymbol` interface.

## Changes
- `packages/pike-bridge/src/bridge.test.ts`: Replace `@ts-ignore` with `@ts-expect-error` for Bun test types
- `packages/pike-bridge/src/corpus.test.ts`: Replace `@ts-ignore` with `@ts-expect-error` for Bun test types
- `packages/pike-bridge/src/get-pike-paths.test.ts`: Replace `@ts-ignore` with `@ts-expect-error` for Bun test types
- `packages/pike-bridge/src/process.test.ts`: Replace `@ts-ignore` with `@ts-expect-error` for Bun test types
- `packages/pike-bridge/src/response-validator.test.ts`: Replace `@ts-ignore` with `@ts-expect-error` for Bun test types
- `packages/pike-bridge/src/roxen.test.ts`: Replace `@ts-ignore` with `@ts-expect-error` for Bun test types
- `packages/pike-lsp-server/src/tests/features/file-watcher.test.ts`: Replace `@ts-ignore` with `@ts-expect-error` for Bun test types
- `packages/pike-lsp-server/src/tests/hover-links.test.ts`: Remove `@ts-ignore` (property exists in PikeSymbol interface)

## Verification
bun run lint → PASS
bun run typecheck → PASS
bun run build → PASS
cd packages/pike-bridge && bun test → PASS (182 tests)
cd packages/pike-lsp-server && bun test → PASS (2193 tests)