### PR TITLE
test: Add comprehensive test coverage for RXML tag-catalog module

### DIFF
--- a/packages/pike-lsp-server/src/tests/features/rxml/tag-catalog.test.ts
+++ b/packages/pike-lsp-server/src/tests/features/rxml/tag-catalog.test.ts
@@ -3,7 +3,15 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { RXML_TAG_CATALOG, getTagInfo } from '../../../features/rxml/tag-catalog';
+import {
+  RXML_TAG_CATALOG,
+  getTagInfo,
+  getAllTagNames,
+  getTagsByType,
+  searchTags,
+  getDeprecatedTags,
+  hasTag,
+} from '../../../features/rxml/tag-catalog';
 
 describe('RXML Tag Catalog', () => {
   describe('catalog structure', () => {
@@ -96,9 +104,32 @@ describe('RXML Tag Catalog', () => {
       expect(lower).toEqual(mixed);
     });
 
+    it('should handle mixed-case variations consistently', () => {
+      // Test all possible case variations
+      expect(getTagInfo('IF')?.name).toBe('if');
+      expect(getTagInfo('If')?.name).toBe('if');
+      expect(getTagInfo('iF')?.name).toBe('if');
+      expect(getTagInfo('FOR')?.name).toBe('for');
+      expect(getTagInfo('FoR')?.name).toBe('for');
+      expect(getTagInfo('ECHO')?.name).toBe('echo');
+      expect(getTagInfo('EcHo')?.name).toBe('echo');
+    });
+
     it('should return undefined for unknown tags', () => {
       const unknown = getTagInfo('nonexistent_tag');
       expect(unknown).toBeUndefined();
+    });
+
+    it('should handle empty string gracefully', () => {
+      const empty = getTagInfo('');
+      expect(empty).toBeUndefined();
+    });
+
+    it('should handle special characters in tag names', () => {
+      // Tags with hyphens DO exist in the catalog (e.g., page-url, page-size)
+      const hyphen = getTagInfo('page-url');
+      expect(hyphen).toBeDefined();
+      expect(hyphen?.name).toBe('page-url');
     });
 
     it('should find all tags by various name formats', () => {
@@ -174,6 +205,232 @@ describe('RXML Tag Catalog', () => {
 
       expect(tagNames.has('formoutput')).toBe(true);
       expect(tagNames.has('input')).toBe(true);
+    });
+  });
+
+  describe('duplicate tag handling', () => {
+    it('should not have duplicate tag names in catalog', () => {
+      const tagNames = RXML_TAG_CATALOG.map(t => t.name.toLowerCase());
+      const uniqueNames = new Set(tagNames);
+
+      // If there are duplicates, the unique set will be smaller
+      expect(tagNames.length).toBe(uniqueNames.size);
+    });
+
+    it('should have unique case-insensitive tag names', () => {
+      const tagNames = RXML_TAG_CATALOG.map(t => t.name.toLowerCase());
+      const seen = new Set<string>();
+      const duplicates: string[] = [];
+
+      for (const name of tagNames) {
+        if (seen.has(name)) {
+          duplicates.push(name);
+        }
+        seen.add(name);
+      }
+
+      expect(duplicates).toHaveLength(0);
+    });
+  });
+
+  describe('attribute edge cases', () => {
+    it('should handle tags with no optional attributes', () => {
+      const elseTag = getTagInfo('else');
+      expect(elseTag).toBeDefined();
+      expect(elseTag?.attributes).toHaveLength(0);
+    });
+
+    it('should handle tags with required attributes', () => {
+      const setTag = getTagInfo('set');
+      expect(setTag).toBeDefined();
+
+      const requiredAttrs = setTag?.attributes.filter(a => a.required) ?? [];
+      expect(requiredAttrs.length).toBeGreaterThan(0);
+    });
+
+    it('should handle tags with optional attributes', () => {
+      const echoTag = getTagInfo('echo');
+      expect(echoTag).toBeDefined();
+
+      const optionalAttrs = echoTag?.attributes.filter(a => !a.required) ?? [];
+      expect(optionalAttrs.length).toBeGreaterThan(0);
+    });
+
+    it('should handle attributes with enum values', () => {
+      const setTag = getTagInfo('set');
+      expect(setTag).toBeDefined();
+
+      const scopeAttr = setTag?.attributes.find(a => a.name === 'scope');
+      expect(scopeAttr).toBeDefined();
+      expect(scopeAttr?.values).toBeDefined();
+      expect(scopeAttr?.values).toContain('form');
+      expect(scopeAttr?.values).toContain('page');
+    });
+
+    it('should handle attributes without enum values', () => {
+      const echoTag = getTagInfo('echo');
+      expect(echoTag).toBeDefined();
+
+      const varAttr = echoTag?.attributes.find(a => a.name === 'var');
+      expect(varAttr).toBeDefined();
+      expect(varAttr?.values).toBeUndefined();
+    });
+  });
+
+  describe('malformed XML edge cases', () => {
+    it('should handle tags with names that look like XML entities', () => {
+      // These should return undefined as they don't exist
+      expect(getTagInfo('&lt;')).toBeUndefined();
+      expect(getTagInfo('&gt;')).toBeUndefined();
+      expect(getTagInfo('&amp;')).toBeUndefined();
+    });
+
+    it('should handle tags with numeric prefixes', () => {
+      expect(getTagInfo('123tag')).toBeUndefined();
+    });
+
+    it('should handle tags with special characters', () => {
+      // Tags with hyphens exist (e.g., page-url, config-name)
+      expect(getTagInfo('page-url')).toBeDefined();
+      expect(getTagInfo('config-name')).toBeDefined();
+      // Tags with underscores in name do NOT exist
+      expect(getTagInfo('tag_with_underscore')).toBeUndefined();
+      // Tags with dots do NOT exist
+      expect(getTagInfo('tag.with.dots')).toBeUndefined();
+    });
+
+    it('should handle very long tag names gracefully', () => {
+      const longName = 'a'.repeat(1000);
+      const result = getTagInfo(longName);
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle tags with leading/trailing whitespace', () => {
+      expect(getTagInfo('  if')).toBeUndefined();
+      expect(getTagInfo('if  ')).toBeUndefined();
+      expect(getTagInfo(' if ')).toBeUndefined();
+    });
+
+    it('should handle null/undefined input gracefully', () => {
+      // Note: The current implementation does not handle null/undefined gracefully
+      // and will throw. These tests document expected behavior if the function
+      // is updated to handle these edge cases.
+      // Currently getTagInfo(undefined) throws TypeError
+      // @ts-expect-error - testing runtime behavior that throws
+      expect(() => getTagInfo(undefined)).toThrow();
+    });
+  });
+
+  describe('getAllTagNames()', () => {
+    it('should return all tag names', () => {
+      const names = getAllTagNames();
+      expect(names.length).toBe(RXML_TAG_CATALOG.length);
+    });
+
+    it('should return unique tag names', () => {
+      const names = getAllTagNames();
+      const uniqueNames = new Set(names);
+      expect(names.length).toBe(uniqueNames.size);
+    });
+
+    it('should include all known tag names', () => {
+      const names = getAllTagNames();
+      expect(names).toContain('if');
+      expect(names).toContain('for');
+      expect(names).toContain('echo');
+      expect(names).toContain('roxen');
+    });
+  });
+
+  describe('getTagsByType()', () => {
+    it('should return only container tags', () => {
+      const containers = getTagsByType('container');
+      expect(containers.length).toBeGreaterThan(0);
+      containers.forEach(tag => {
+        expect(tag.type).toBe('container');
+      });
+    });
+
+    it('should return only simple tags', () => {
+      const simples = getTagsByType('simple');
+      expect(simples.length).toBeGreaterThan(0);
+      simples.forEach(tag => {
+        expect(tag.type).toBe('simple');
+      });
+    });
+
+    it('should cover all tags when combining types', () => {
+      const containers = getTagsByType('container');
+      const simples = getTagsByType('simple');
+      expect(containers.length + simples.length).toBe(RXML_TAG_CATALOG.length);
+    });
+  });
+
+  describe('searchTags()', () => {
+    it('should find tags by name', () => {
+      const results = searchTags('echo');
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.some(t => t.name === 'echo')).toBe(true);
+    });
+
+    it('should find tags by description', () => {
+      const results = searchTags('variable');
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('should be case-insensitive', () => {
+      const upper = searchTags('ECHO');
+      const lower = searchTags('echo');
+      expect(upper.length).toBe(lower.length);
+    });
+
+    it('should return empty array for no matches', () => {
+      const results = searchTags('xyznonexistent123');
+      expect(results).toHaveLength(0);
+    });
+
+    it('should handle partial matches', () => {
+      const results = searchTags('form');
+      expect(results.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getDeprecatedTags()', () => {
+    it('should return deprecated tags', () => {
+      const deprecated = getDeprecatedTags();
+      expect(deprecated.length).toBeGreaterThan(0);
+    });
+
+    it('should mark all returned tags as deprecated', () => {
+      const deprecated = getDeprecatedTags();
+      deprecated.forEach(tag => {
+        expect(tag.deprecated).toBe(true);
+      });
+    });
+
+    it('should include known deprecated tags', () => {
+      const deprecated = getDeprecatedTags();
+      const names = deprecated.map(t => t.name);
+      expect(names).toContain('sqloutput');
+      expect(names).toContain('sqltable');
+    });
+  });
+
+  describe('hasTag()', () => {
+    it('should return true for existing tags', () => {
+      expect(hasTag('if')).toBe(true);
+      expect(hasTag('echo')).toBe(true);
+      expect(hasTag('roxen')).toBe(true);
+    });
+
+    it('should return false for non-existing tags', () => {
+      expect(hasTag('nonexistent')).toBe(false);
+    });
+
+    it('should be case-insensitive', () => {
+      expect(hasTag('IF')).toBe(true);
+      expect(hasTag('Echo')).toBe(true);
+      expect(hasTag('ROXEN')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
Adds comprehensive test coverage for the RXML tag-catalog module, including tests for duplicate tag handling, case sensitivity, malformed XML edge cases, and additional helper functions.

## Linked Issue
Closes #472

## Root Cause
The RXML tag-catalog module lacked comprehensive tests covering edge cases and additional functionality beyond basic getTagInfo() tests.

## Changes
- `packages/pike-lsp-server/src/tests/features/rxml/tag-catalog.test.ts`: Added 17 new tests covering:
  - Duplicate tag handling (ensuring case-insensitive uniqueness)
  - Extended case sensitivity tests
  - Malformed XML edge cases (XML entities, numeric prefixes, special characters)
  - Additional helper functions (getAllTagNames, getTagsByType, searchTags, getDeprecatedTags, hasTag)
  - Attribute edge cases (enum values, required/optional attributes)

## Verification
- bun test (tag-catalog.test.ts): 51 pass, 0 fail
- bun test (both tag-catalog files): 67 pass, 0 fail
- bun test (pike-lsp-server): 2226 pass, 17 todo, 0 fail
- bun run build: PASS
- Pre-commit smoke tests: PASS (pike-compile, bridge, server)

## Notes for Reviewer
Tests follow existing patterns in the test file. The test for null/undefined input documents the current behavior (throws TypeError) rather than expecting undefined return.