### PR TITLE
docs: Fix npm/pnpm references in README to use bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,16 +185,15 @@ code --install-extension vscode-pike-1.0.0.vsix
 git clone https://github.com/TheSmuks/pike-lsp.git
 cd pike-lsp
 
-# Install dependencies (requires pnpm)
-npm install -g pnpm
-pnpm install
+# Install dependencies
+bun install
 
 # Build all packages
-pnpm build
+bun run build
 
 # Package the VS Code extension
 cd packages/vscode-pike
-pnpm package
+bun run package
 ```
 
 ## Keyboard Shortcuts
@@ -248,14 +247,14 @@ pike-lsp/
 ./scripts/run-tests.sh
 
 # Run specific test suites
-pnpm --filter @pike-lsp/pike-bridge test
-pnpm --filter @pike-lsp/pike-lsp-server test
+bun --filter @pike-lsp/pike-bridge test
+bun --filter @pike-lsp/pike-lsp-server test
 
 # Run smoke tests
-pnpm --filter @pike-lsp/pike-lsp-server test:smoke
+bun --filter @pike-lsp/pike-lsp-server test:smoke
 
 # Run VSCode E2E tests (requires display or xvfb)
-cd packages/vscode-pike && pnpm run test:e2e
+cd packages/vscode-pike && bun run test:e2e
 ```
 
 ### Pike Stdlib Source Paths
@@ -279,9 +278,6 @@ PIKE_STDLIB=/path/to/Pike/lib/modules PIKE_TOOLS=/path/to/Pike/lib/include ./scr
 ### Prerequisites
 
 ```bash
-# Install pnpm globally
-npm install -g pnpm
-
 # Install Pike 8
 # Ubuntu/Debian:
 sudo apt-get install pike8.0
@@ -296,8 +292,8 @@ go install github.com/nektos/act@latest
 ### Building
 
 ```bash
-pnpm install
-pnpm build
+bun install
+bun run build
 ```
 
 ### Testing the Extension
@@ -313,9 +309,9 @@ pnpm build
 # 1. Update version in packages/vscode-pike/package.json
 # 2. Update CHANGELOG.md
 # 3. Build and package
-pnpm build
+bun run build
 cd packages/vscode-pike
-pnpm package
+bun run package
 
 # 4. The .vsix file is created in packages/vscode-pike/
 ```


### PR DESCRIPTION
## Summary
Replaced all npm/pnpm references in README.md with bun commands to reflect the project's exclusive use of bun as the package manager.

## Linked Issue
Closes #478

## Root Cause
The README.md contained outdated instructions referencing pnpm and npm, but this project uses bun exclusively.

## Changes
- README.md: Replaced  and Progress: resolved 1, reused 0, downloaded 0, added 0

   ╭───────────────────────────────────────────────╮
   │                                               │
   │     Update available! 10.28.2 → 10.30.0.      │
   │     Changelog: https://pnpm.io/v/10.30.0      │
   │   To update, run: corepack use pnpm@10.30.0   │
   │                                               │
   ╰───────────────────────────────────────────────╯

Progress: resolved 33, reused 0, downloaded 20, added 0
Progress: resolved 116, reused 0, downloaded 102, added 0
Progress: resolved 283, reused 0, downloaded 262, added 0
Progress: resolved 417, reused 0, downloaded 392, added 0
Progress: resolved 587, reused 0, downloaded 557, added 0
Progress: resolved 734, reused 0, downloaded 707, added 0
Progress: resolved 857, reused 0, downloaded 815, added 0
Progress: resolved 992, reused 0, downloaded 961, added 0
Progress: resolved 1090, reused 0, downloaded 1050, added 0
Progress: resolved 1239, reused 0, downloaded 1228, added 0
Packages: +1249
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 1250, reused 0, downloaded 1249, added 7
Progress: resolved 1250, reused 0, downloaded 1249, added 1249, done

> pike-lsp@0.1.0-alpha.20 postinstall /home/smuks/OpenCode/pike-lsp-issue-478
> bash scripts/setup-workspace-links.sh

Linked @pike-lsp/pike-bridge
Linked @pike-lsp/core
Linked @pike-lsp/pike-lsp-server
Linked @pike-lsp/vscode-pike
Workspace links created successfully

> pike-lsp@0.1.0-alpha.20 prepare /home/smuks/OpenCode/pike-lsp-issue-478
> husky


dependencies:
+ @docusaurus/module-type-aliases 3.9.2
+ @docusaurus/tsconfig 3.9.2
+ @docusaurus/types 3.9.2
+ @mdx-js/react 3.1.1
+ clsx 2.1.1
+ prism-react-renderer 2.4.1
+ react 19.2.4
+ react-dom 19.2.4
+ react-router 7.13.0
+ react-router-dom 7.13.0

devDependencies:
+ @docusaurus/core 3.9.2
+ @docusaurus/preset-classic 3.9.2
+ @eslint/js 10.0.1
+ @types/node 25.3.0
+ @types/react 19.2.14
+ @types/react-dom 19.2.3
+ eslint 10.0.0
+ globals 17.3.0
+ husky 9.1.7
+ prettier 3.8.1
+ typedoc 0.28.17
+ typescript 5.9.3
+ typescript-eslint 8.56.0
+ xml2js 0.6.2

╭ Warning ─────────────────────────────────────────────────────────────────────╮
│                                                                              │
│   Ignored build scripts: core-js-pure@3.48.0, core-js@3.48.0.                │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
│   to run scripts.                                                            │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
Done in 12s using pnpm v10.28.2 with bun install v1.3.8 (b64edcb4)
Linked @pike-lsp/pike-bridge
Linked @pike-lsp/core
Linked @pike-lsp/pike-lsp-server
Linked @pike-lsp/vscode-pike
Workspace links created successfully

Checked 1441 installs across 1465 packages (no changes) [491.00ms]
- README.md: Replaced 
> pike-lsp@0.1.0-alpha.20 build /home/smuks/OpenCode/pike-lsp-issue-478
> bun run build:tsc with 
- README.md: Replaced undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "package" not found

Did you mean "pnpm test:packages"? with 
- README.md: Replaced  ERROR  Unsupported package selector: {"exclude":false,"excludeSelf":false,"includeDependencies":true,"includeDependents":false,"followProdDepsOnly":false}

pnpm: Unsupported package selector: {"exclude":false,"excludeSelf":false,"includeDependencies":true,"includeDependents":false,"followProdDepsOnly":false}
    at _filterGraph (/home/smuks/.cache/node/corepack/v1/pnpm/10.28.2/dist/pnpm.cjs:112839:17)
    at filterWorkspacePackages (/home/smuks/.cache/node/corepack/v1/pnpm/10.28.2/dist/pnpm.cjs:112799:121)
    at filterPkgsBySelectorObjects (/home/smuks/.cache/node/corepack/v1/pnpm/10.28.2/dist/pnpm.cjs:112763:33)
    at filterPackages (/home/smuks/.cache/node/corepack/v1/pnpm/10.28.2/dist/pnpm.cjs:112755:14)
    at filterPackagesFromDir (/home/smuks/.cache/node/corepack/v1/pnpm/10.28.2/dist/pnpm.cjs:112750:18)
    at async main (/home/smuks/.cache/node/corepack/v1/pnpm/10.28.2/dist/pnpm.cjs:194123:31)
    at async runPnpm (/home/smuks/.cache/node/corepack/v1/pnpm/10.28.2/dist/pnpm.cjs:194430:5)
    at async /home/smuks/.cache/node/corepack/v1/pnpm/10.28.2/dist/pnpm.cjs:194422:7 with 
- README.md: Replaced  ERR_PNPM_NO_SCRIPT  Missing script: test:e2e

Command "test:e2e" not found. Did you mean "pnpm run test:all"? with 
- README.md: Removed redundant pnpm installation instructions

## Verification
bun run lint → PASS
bun run build → PASS

## Notes for Reviewer
This is a documentation-only change to align README with the actual toolchain.