### PR TITLE
cleanup: remove stray # test from end of README.md (#480)

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,4 +377,4 @@ MIT License - see [LICENSE](LICENSE) for details.
 - [vscode-languageserver-node](https://github.com/microsoft/vscode-languageserver-node) - LSP framework
 - [Pike](https://pike.lysator.liu.se/) - The Pike programming language
 - [Tools.AutoDoc](https://pike.lysator.liu.se/generated/manual/modref/ex/predef_3A_3A/Tools/AutoDoc.html) - Pike's documentation parser
-# test
+


### PR DESCRIPTION
## Summary
Remove stray "# test" text from the end of README.md file.

## Linked Issue
Closes #480

## Root Cause
The README.md file had stray "# test" text appended at the end, likely from a test or accidental edit.

## Changes
- Removed "# test" line from end of README.md

## Verification
Visual verification: tail -5 README.md shows clean ending

## Notes for Reviewer
Simple one-line cleanup fix.