### PR TITLE
fix: remove stray # test from end of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,4 +377,4 @@ MIT License - see [LICENSE](LICENSE) for details.
 - [vscode-languageserver-node](https://github.com/microsoft/vscode-languageserver-node) - LSP framework
 - [Pike](https://pike.lysator.liu.se/) - The Pike programming language
 - [Tools.AutoDoc](https://pike.lysator.liu.se/generated/manual/modref/ex/predef_3A_3A/Tools/AutoDoc.html) - Pike's documentation parser
-# test
+


### PR DESCRIPTION
## Summary
Removes stray "# test" text that was incorrectly appended at the end of the README.md file.

## Linked Issue
Closes #480

## Root Cause
The README.md file had a stray "# test" line at the end (line 380), which appears to have been accidentally left in during a previous edit.

## Changes
- README.md: Removed stray "# test" line at the end of the file

## Verification
bun run lint → PASS (no errors)

## Notes for Reviewer
This is a simple cleanup fix - removing stray text from the end of the README.