### PR TITLE
fix: use proper Closes keyword in commit messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,7 @@ creation if any section is missing:
 
 ```bash
 git add -A
-git commit -m "fix: <short description> (closes #<number>)"
+git commit -m "fix: <short description> - Closes #<number>"
 git push origin fix/issue-<number>
 gh pr create \
   --title "fix: <short description>" \

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -77,7 +77,7 @@ git checkout -b fix/issue-<your-issue-number>
 ### Step 5: Push and open PR
 ```
 git add -A
-git commit -m "fix: <short description> (closes #<number>)"
+git commit -m "fix: <short description> - Closes #<number>"
 git push origin fix/issue-<your-issue-number>
 gh pr create --title "fix: <description>" --body "Closes #<your-issue-number>" --base main
 ```


### PR DESCRIPTION
## Summary
Updates CLAUDE.md and docs/hooks.md to use the proper "Closes #XXX" format in commit messages. Previously used lowercase "(closes #XXX)" which GitHub does not recognize for auto-closing issues.

## Linked Issue
Closes #479

## Root Cause
GitHub's auto-close feature requires "Closes #XXX" (capital C) in the commit message. With merge commits, GitHub uses the commit title, not the PR body. The previous format "(closes #XXX)" was not being parsed correctly:
- Used lowercase "closes" instead of "Closes"
- Wrapped in parentheses which made it harder to parse in commit title

Additionally, the original format in CLAUDE.md used "(closes #XXX)" which GitHub treats as a reference, not a close keyword.

## Changes
- CLAUDE.md: Changed commit message format from "(closes #<number>)" to "- Closes #<number>"
- docs/hooks.md: Same change

## Verification
- bun run lint → PASS
- bun run typecheck → PASS
- bun run build → PASS

## Notes for Reviewer
This is a documentation fix only. The actual fix for issues #470-#473 is that they were not properly closed. Those issues should now be manually closed since their PRs used incorrect commit message formats.