### PR TITLE
fix: proper Closes format in commit messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,7 @@ creation if any section is missing:
 
 ```bash
 git add -A
-git commit -m "fix: <short description> - Closes #<number>"
+git commit -m "fix: <short description> Closes #<number>"
 git push origin fix/issue-<number>
 gh pr create \
   --title "fix: <short description>" \

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -77,7 +77,7 @@ git checkout -b fix/issue-<your-issue-number>
 ### Step 5: Push and open PR
 ```
 git add -A
-git commit -m "fix: <short description> - Closes #<number>"
+git commit -m "fix: <short description> Closes #<number>"
 git push origin fix/issue-<your-issue-number>
 gh pr create --title "fix: <description>" --body "Closes #<your-issue-number>" --base main
 ```


### PR DESCRIPTION
## Summary
Updates commit message format to use "Closes #XXX" at the end of the first line, which GitHub correctly parses for auto-closing issues when PRs are merged.

## Linked Issue
Closes #479

## Root Cause
GitHub's auto-close requires "Closes #XXX" (capital C) at the START or END of the commit title. The previous format "(closes #XXX)" was:
1. Using lowercase "closes"
2. Wrapped in parentheses in the middle of the line

PR #485 attempted to fix this with "- Closes #XXX" but that still didn't work because GitHub needs "Closes #XXX" at the very end of the first line.

## Changes
- CLAUDE.md: Changed to `"fix: <short description> Closes #<number>"`
- docs/hooks.md: Changed to `"fix: <short description> Closes #<number>"`

## Verification
- Pre-commit checks → PASS