### PR TITLE
fix: Add server.js to .eslintignore (closes #491)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,5 +6,8 @@ dist/
 build/
 out/
 
+# VSCode extension server (generated)
+packages/vscode-pike/server/
+
 # Node modules
 node_modules/


### PR DESCRIPTION
## Summary
Add packages/vscode-pike/server/ to .eslintignore to ignore generated files.

## Changes
- .eslintignore: Added packages/vscode-pike/server/

## Verification
bun run lint → PASS