### PR TITLE
cleanup: Remove stale branches and worktrees (closes #489)

### DIFF
--- a/CLEANUP_489.md
+++ b/CLEANUP_489.md
@@ -1,0 +1,5 @@
+# Cleanup Issue 489
+
+## Audit Results
+- No stale remote branches found (all previous fix/issue-* branches already cleaned)
+- Existing worktrees are for open issues (491, 492, 493)


### PR DESCRIPTION
## Summary
Ran cleanup audit on the repository. Found no stale remote branches to delete (all fix/issue-* branches have already been cleaned up). Existing worktrees (issues 491, 492, 493) are for open issues and were left intact.

## Linked Issue
Closes #489

## Verification
- Checked remote branches: only origin/main exists
- Checked worktrees: 5 total (main + 4 issue worktrees for 489, 491, 492, 493)
- Issues 491, 492, 493 are OPEN - worktrees correctly preserved
- No stale remote branches found