### PR TITLE
fix: exclude generated server.js from ESLint (closes #508)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ export default [
             '**/.planning/**',
             '**/*.test.ts',
             'packages/vscode-pike/**/*.ts',
+            'packages/vscode-pike/server/**/*.js',
             'docs/**',
         ],
     },


### PR DESCRIPTION
## Summary
Add `packages/vscode-pike/server/**/*.js` to the ESLint ignores array to exclude generated server files from linting.

## Linked Issue
Closes #508

## Root Cause
Generated JavaScript files in packages/vscode-pike/server/ should not be linted as they are built artifacts.

## Changes
- `eslint.config.mjs`: Added `packages/vscode-pike/server/**/*.js` to ignores array

## Verification
bun run lint → PASS

## Notes for Reviewer
Simple config change to exclude generated files.