### PR TITLE
fix: use correct LSP method for on-type formatting

### DIFF
--- a/packages/pike-lsp-server/src/features/advanced/on-type-formatting.ts
+++ b/packages/pike-lsp-server/src/features/advanced/on-type-formatting.ts
@@ -27,7 +27,7 @@ export function registerOnTypeFormattingHandler(
     const log = new Logger('OnTypeFormatting');
 
     // Check if the connection supports on-type formatting
-    if (typeof connection.onTypeFormat !== 'function') {
+    if (typeof connection.languages.onTypeFormatting !== 'function') {
         log.debug('On-type formatting support not available in this LSP connection version');
         return;
     }
@@ -36,7 +36,7 @@ export function registerOnTypeFormattingHandler(
     const triggerCharacters = ['\n', ';', '}'];
 
     // Register the handler
-    connection.onTypeFormat(async (params): Promise<TextEdit[]> => {
+    connection.languages.onTypeFormatting(async (params): Promise<TextEdit[]> => {
         log.debug('On-type format request', {
             uri: params.textDocument.uri,
             trigger: params.ch[0],


### PR DESCRIPTION
## Summary
Changed `connection.onTypeFormat` to `connection.languages.onTypeFormatting` to use the correct LSP method name.

## Linked Issue
Closes #513

## Root Cause
The code was using a deprecated/non-existent method `connection.onTypeFormat` instead of the proper `connection.languages.onTypeFormatting` API.

## Changes
- `packages/pike-lsp-server/src/features/advanced/on-type-formatting.ts`: Changed both occurrences of `connection.onTypeFormat` to `connection.languages.onTypeFormatting`

## Verification
bun run typecheck → PASS

## Notes for Reviewer
Simple fix - just updating the method name to match the correct LSP API.