### PR TITLE
feat: support unlimited nested class depth (closes #533)

### DIFF
--- a/pike-scripts/LSP.pmod/Parser.pike
+++ b/pike-scripts/LSP.pmod/Parser.pike
@@ -1120,25 +1120,12 @@ protected mapping simple_parse_autodoc(string doc) {
 //! @param parser The PikeParser positioned after the opening {
 //! @param autodoc_by_line Mapping of line->autodoc documentation
 //! @param filename Source filename for position tracking
-//! @param max_depth Maximum recursion depth (default 5)
-//! @param current_depth Current depth (default 0)
 //! @returns Array of child symbol mappings
 protected array(mapping) parse_class_body(
     object parser,
     mapping autodoc_by_line,
-    string filename,
-    int|void max_depth,
-    int|void current_depth
+    string filename
 ) {
-    // Set defaults
-    if (!max_depth) max_depth = 5;
-    if (!current_depth) current_depth = 0;
-
-    // Guard against excessive recursion
-    if (current_depth >= max_depth) {
-        return ({});
-    }
-
     array(mapping) class_children = ({});
     array(string) member_autodoc_buffer = ({});
     int block_iter = 0;
@@ -1227,9 +1214,7 @@ protected array(mapping) parse_class_body(
                 array(mapping) nested_children = parse_class_body(
                     parser,
                     autodoc_by_line,
-                    filename,
-                    max_depth,
-                    current_depth + 1
+                    filename
                 );
 
                 // Attach nested children to the last class member


### PR DESCRIPTION
## Summary
Removed the hardcoded 5-level depth cap in Parser.pike's parse_class_body() function, allowing the LSP server to parse deeply nested classes and enums without limitation.

## Linked Issue
Closes #533

## Root Cause
The parse_class_body() function had a hardcoded max_depth=5 parameter that would return an empty array when the recursion depth exceeded this limit, causing nested classes beyond 5 levels to not have their symbols extracted.

## Changes
- pike-scripts/LSP.pmod/Parser.pike: Removed max_depth and current_depth parameters from parse_class_body(), removed the depth check guard, simplified the function to recursively parse all nested classes

## Verification
bun run typecheck → PASS
bun run build → PASS
cd packages/pike-bridge && bun test → PASS (182 tests)
cd packages/pike-lsp-server && bun test → PASS (2193 tests)
pre-commit smoke tests → PASS (3/3)

## Notes for Reviewer
This is a minimal change that removes the artificial limit. The existing MAX_BLOCK_ITERATIONS constant still provides protection against infinite loops.