### PR TITLE
fix: prevent stale validations from causing false syntax errors after undo (closes #563)

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics.ts
@@ -183,6 +183,9 @@ export function registerDiagnosticsHandlers(
 
     // Validation timers for debouncing
     const validationTimers = new Map<string, ReturnType<typeof setTimeout>>();
+    // INC-563: Track expected document version for each debounced validation
+    // This prevents stale validations from overwriting fresher results after undo
+    const validationVersions = new Map<string, number>();
 
     // Configuration settings
     const defaultSettings: PikeSettings = {
@@ -580,9 +583,27 @@ export function registerDiagnosticsHandlers(
             clearTimeout(existingTimer);
         }
 
+        // INC-563: Store expected version for this scheduled validation
+        // This prevents stale validations from overwriting fresher results after undo
+        const expectedVersion = version;
+        validationVersions.set(uri, expectedVersion);
+
         // Set new timer
         const timer = setTimeout(() => {
             validationTimers.delete(uri);
+            validationVersions.delete(uri);
+
+            // INC-563: Check if this validation is stale (a newer version was scheduled)
+            const currentVersion = document.version;
+            if (currentVersion !== expectedVersion) {
+                connection.console.log(
+                    `[DEBOUNCE] uri=${uri}, expected=${expectedVersion}, current=${currentVersion} - SKIPPING stale validation`
+                );
+                // Clear pending change range since we're skipping
+                pendingChangeRanges.delete(uri);
+                return;
+            }
+
             // LOG-14-01: Track debounce timer execution
             connection.console.log(`[DEBOUNCE] uri=${uri}, version=${version}, executing validateDocument`);
 


### PR DESCRIPTION
## Summary
Added version tracking to debounced document validation to prevent race conditions during rapid text changes (like CTRL+Z undo). When a user rapidly edits and undoes code, the debounced validation timer from an older document version could fire after a newer version was already validated, causing false "Unexpected token" syntax errors.

## Linked Issue
Closes #563

## Root Cause
The `validateDocumentDebounced` function scheduled validation with a debounce timer, but when rapid changes occurred (edit → undo → edit), the timer from an older version could execute after a newer version was already validated. This caused the parser to analyze stale document state against cached results from the newer version, leading to false syntax errors.

## Changes
- `packages/pike-lsp-server/src/features/diagnostics.ts`: Added `validationVersions` Map to track the expected document version for each scheduled debounced validation. When the timer fires, we verify the current document version matches the expected version before proceeding. If they don't match, the stale validation is skipped.

## Verification
bun run lint → PASS
bun run typecheck → PASS
bun run build → PASS
cd packages/pike-lsp-server && bun test → PASS (2193 tests)
cd packages/pike-lsp-server && bun test ./src/tests/smoke.test.ts → PASS (7 tests)