### PR TITLE
test: add stress tests for goto definition (closes #548)

### DIFF
--- a/packages/pike-lsp-server/src/tests/navigation/definition-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/navigation/definition-provider.test.ts
@@ -616,4 +616,619 @@ int x = myVar;`;
 
         test.todo('requires bridge mock: cross-file definition performance');
     });
+
+    describe('Stress Tests: Goto Definition', () => {
+        describe('Functions', () => {
+            it('should handle many function definitions', async () => {
+                const lines: string[] = [];
+                const symbols: PikeSymbol[] = [];
+
+                // Create 100 functions
+                for (let i = 0; i < 100; i++) {
+                    lines.push(`int func_${i}(int x) { return x + ${i}; }`);
+                    symbols.push({
+                        name: `func_${i}`,
+                        kind: 'method',
+                        modifiers: [],
+                        position: { file: 'test.pike', line: i + 1 },
+                    });
+                }
+                // Call function 50
+                lines.push('int result = func_50(10);');
+
+                const code = lines.join('\n');
+                const { definition } = setup({ code, symbols });
+
+                const result = await definition(100, 14);
+                expect(result).not.toBeNull();
+                const loc = result as Location;
+                expect(loc.range.start.line).toBe(50);
+            });
+
+            it('should handle recursive function calls', async () => {
+                const code = `int factorial(int n) {
+    if (n <= 1) return 1;
+    return n * factorial(n - 1);
+}
+int x = factorial(5);`;
+
+                const { definition } = setup({
+                    code,
+                    symbols: [{
+                        name: 'factorial',
+                        kind: 'method',
+                        modifiers: [],
+                        position: { file: 'test.pike', line: 1 },
+                    }],
+                });
+
+                // Navigate from recursive call to definition
+                const result = await definition(2, 19);
+                expect(result).not.toBeNull();
+                const loc = result as Location;
+                expect(loc.range.start.line).toBe(0);
+            });
+
+            it('should handle lambda functions', async () => {
+                const code = `function<int(int)> myLambda = lambda(int x) { return x * 2; };
+int result = myLambda(5);`;
+
+                const { definition } = setup({
+                    code,
+                    symbols: [
+                        {
+                            name: 'myLambda',
+                            kind: 'variable',
+                            modifiers: [],
+                            position: { file: 'test.pike', line: 1 },
+                        },
+                    ],
+                });
+
+                const result = await definition(1, 14);
+                expect(result).not.toBeNull();
+                const loc = result as Location;
+                expect(loc.range.start.line).toBe(0);
+            });
+        });
+
+        describe('Classes', () => {
+            it('should handle many class definitions', async () => {
+                const lines: string[] = [];
+                const symbols: PikeSymbol[] = [];
+
+                for (let i = 0; i < 50; i++) {
+                    lines.push(`class Class_${i} { int val_${i}() { return ${i}; } }`);
+                    symbols.push({
+                        name: `Class_${i}`,
+                        kind: 'class',
+                        modifiers: [],
+                        position: { file: 'test.pike', line: i + 1 },
+                    });
+                }
+                lines.push(`Class_25 obj = Class_25();`);
+
+                const code = lines.join('\n');
+                const { definition } = setup({ code, symbols });
+
+                const result = await definition(50, 2);
+                expect(result).not.toBeNull();
+                const loc = result as Location;
+                expect(loc.range.start.line).toBe(25);
+            });
+
+            it('should handle class with many methods', async () => {
+                const lines = ['class MyClass {'];
+                const symbols: PikeSymbol[] = [{
+                    name: 'MyClass',
+                    kind: 'class',
+                    modifiers: [],
+                    position: { file: 'test.pike', line: 1 },
+                }];
+
+                for (let i = 0; i < 50; i++) {
+                    lines.push(`    int method_${i}() { return ${i}; }`);
+                    symbols.push({
+                        name: `method_${i}`,
+                        kind: 'method',
+                        modifiers: [],
+                        position: { file: 'test.pike', line: i + 2 },
+                    });
+                }
+                lines.push('}');
+                lines.push('MyClass obj = MyClass();');
+                lines.push('int x = obj->method_25();');
+
+                const code = lines.join('\n');
+                const { definition } = setup({ code, symbols });
+
+                // method_25 is at line 26 (index 25 + 1 for 0-indexed + 1 for class declaration line)
+                // But due to mock limitations, just verify it finds something
+                const result = await definition(52, 14);
+                expect(result === null || !!(result as Location).uri).toBe(true);
+            });
+
+            it('should handle nested class definitions', async () => {
+                const code = `class Outer {
+    class Inner {
+        int innerMethod() { return 42; }
+    }
+}
+Outer.Inner obj = Outer.Inner();`;
+
+                const { definition } = setup({
+                    code,
+                    symbols: [
+                        { name: 'Outer', kind: 'class', modifiers: [], position: { file: 'test.pike', line: 1 } },
+                        { name: 'Inner', kind: 'class', modifiers: [], position: { file: 'test.pike', line: 2 } },
+                        { name: 'innerMethod', kind: 'method', modifiers: [], position: { file: 'test.pike', line: 3 } },
+                    ],
+                });
+
+                // Nested class resolution depends on bridge mock support
+                const result = await definition(4, 18);
+                expect(result === null || !!(result as Location).uri).toBe(true);
+            });
+        });
+
+        describe('Variables', () => {
+            it('should handle many global variables', async () => {
+                const lines: string[] = [];
+                const symbols: PikeSymbol[] = [];
+
+                for (let i = 0; i < 200; i++) {
+                    lines.push(`int global_${i} = ${i};`);
+                    symbols.push({
+                        name: `global_${i}`,
+                        kind: 'variable',
+                        modifiers: [],
+                        position: { file: 'test.pike', line: i + 1 },
+                    });
+                }
+                lines.push('int result = global_150 + global_199;');
+
+                const code = lines.join('\n');
+                const { definition } = setup({ code, symbols });
+
+                const result1 = await definition(200, 14);
+                const result2 = await definition(200, 27);
+
+                expect(result1).not.toBeNull();
+                expect(result2).not.toBeNull();
+            });
+
+            it('should handle variable shadowing', async () => {
+                const code = `int x = 1;
+{
+    int x = 2;
+    int y = x;
+}`;
+
+                const { definition } = setup({
+                    code,
+                    symbols: [
+                        { name: 'x', kind: 'variable', modifiers: [], position: { file: 'test.pike', line: 1 } },
+                        { name: 'x', kind: 'variable', modifiers: [], position: { file: 'test.pike', line: 3 } },
+                    ],
+                });
+
+                // Scope resolution depends on mock infrastructure
+                const result = await definition(3, 10);
+                expect(result === null || !!(result as Location).uri).toBe(true);
+            });
+        });
+
+        describe('Constants', () => {
+            it('should handle constant definitions', async () => {
+                const code = `constant MAX_SIZE = 1000;
+constant PI = 3.14159;
+int size = MAX_SIZE;`;
+
+                const { definition } = setup({
+                    code,
+                    symbols: [
+                        { name: 'MAX_SIZE', kind: 'constant', modifiers: [], position: { file: 'test.pike', line: 1 } },
+                        { name: 'PI', kind: 'constant', modifiers: [], position: { file: 'test.pike', line: 2 } },
+                    ],
+                });
+
+                const result = await definition(2, 12);
+                expect(result).not.toBeNull();
+                const loc = result as Location;
+                expect(loc.range.start.line).toBe(0);
+            });
+
+            it('should handle many constants', async () => {
+                const lines: string[] = [];
+                const symbols: PikeSymbol[] = [];
+
+                for (let i = 0; i < 100; i++) {
+                    lines.push(`constant CONST_${i} = ${i};`);
+                    symbols.push({
+                        name: `CONST_${i}`,
+                        kind: 'constant',
+                        modifiers: [],
+                        position: { file: 'test.pike', line: i + 1 },
+                    });
+                }
+                lines.push('int x = CONST_50;');
+
+                const code = lines.join('\n');
+                const { definition } = setup({ code, symbols });
+
+                const result = await definition(100, 10);
+                expect(result).not.toBeNull();
+                const loc = result as Location;
+                expect(loc.range.start.line).toBe(50);
+            });
+        });
+
+        describe('Built-in Types', () => {
+            it('should return null for built-in types', async () => {
+                const code = `int x = 42;
+string y = "hello";
+array z = ({ 1, 2, 3 });`;
+
+                const { definition } = setup({ code, symbols: [] });
+
+                // Built-in types should not resolve
+                const resultInt = await definition(0, 2);
+                const resultString = await definition(1, 2);
+                const resultArray = await definition(2, 2);
+
+                expect(resultInt).toBeNull();
+                expect(resultString).toBeNull();
+                expect(resultArray).toBeNull();
+            });
+
+            it('should handle user types that shadow built-ins', async () => {
+                const code = `class array { }
+array x = array();`;
+
+                const { definition } = setup({
+                    code,
+                    symbols: [
+                        { name: 'array', kind: 'class', modifiers: [], position: { file: 'test.pike', line: 1 } },
+                    ],
+                });
+
+                const result = await definition(1, 2);
+                expect(result).not.toBeNull();
+            });
+        });
+
+        describe('Overloaded Functions', () => {
+            it('should handle overloaded functions', async () => {
+                const code = `int overloaded(int x) { return x; }
+string overloaded(string s) { return s; }
+int a = overloaded(1);
+string b = overloaded("test");`;
+
+                const { definition } = setup({
+                    code,
+                    symbols: [
+                        { name: 'overloaded', kind: 'method', modifiers: [], position: { file: 'test.pike', line: 1 } },
+                        { name: 'overloaded', kind: 'method', modifiers: [], position: { file: 'test.pike', line: 2 } },
+                    ],
+                });
+
+                // Overloaded function resolution depends on type inference in mock
+                const result1 = await definition(3, 10);
+                const result2 = await definition(4, 14);
+
+                // Either result or null is acceptable for overloaded
+                expect(result1 === null || !!(result1 as Location).uri).toBe(true);
+                expect(result2 === null || !!(result2 as Location).uri).toBe(true);
+            });
+        });
+
+        describe('Inherited Members', () => {
+            it('should handle class inheritance', async () => {
+                const code = `class Parent {
+    int parentMethod() { return 1; }
+}
+class Child {
+    inherit Parent;
+    int childMethod() { return 2; }
+}
+Child obj = Child();
+int x = obj->parentMethod();`;
+
+                const { definition } = setup({
+                    code,
+                    symbols: [
+                        { name: 'Parent', kind: 'class', modifiers: [], position: { file: 'test.pike', line: 1 } },
+                        { name: 'parentMethod', kind: 'method', modifiers: [], position: { file: 'test.pike', line: 2 } },
+                        { name: 'Child', kind: 'class', modifiers: [], position: { file: 'test.pike', line: 5 } },
+                        { name: 'childMethod', kind: 'method', modifiers: [], position: { file: 'test.pike', line: 7 } },
+                    ],
+                    inherits: [
+                        { from: 'Parent', file: 'test.pike', line: 6 },
+                    ],
+                });
+
+                const result = await definition(8, 16);
+                // May or may not resolve inherited - just shouldn't crash
+                expect(result === null || !!(result as Location).uri).toBe(true);
+            });
+
+            it('should handle multi-level inheritance', async () => {
+                const code = `class GrandParent {
+    int grandMethod() { return 0; }
+}
+class Parent {
+    inherit GrandParent;
+    int parentMethod() { return 1; }
+}
+class Child {
+    inherit Parent;
+}
+Child obj = Child();
+int x = obj->grandMethod();`;
+
+                const { definition } = setup({
+                    code,
+                    symbols: [
+                        { name: 'GrandParent', kind: 'class', modifiers: [], position: { file: 'test.pike', line: 1 } },
+                        { name: 'grandMethod', kind: 'method', modifiers: [], position: { file: 'test.pike', line: 2 } },
+                        { name: 'Parent', kind: 'class', modifiers: [], position: { file: 'test.pike', line: 5 } },
+                        { name: 'parentMethod', kind: 'method', modifiers: [], position: { file: 'test.pike', line: 7 } },
+                        { name: 'Child', kind: 'class', modifiers: [], position: { file: 'test.pike', line: 11 } },
+                    ],
+                    inherits: [
+                        { from: 'Parent', file: 'test.pike', line: 12 },
+                        { from: 'GrandParent', file: 'test.pike', line: 6 },
+                    ],
+                });
+
+                const result = await definition(13, 16);
+                expect(result === null || !!(result as Location).uri).toBe(true);
+            });
+        });
+
+        describe('Cross-file Definition', () => {
+            it('should handle cross-file definition with extra docs', async () => {
+                const code1 = `int sharedVar = 42;`;
+                const code2 = `int x = sharedVar;`;
+
+                const doc1 = TextDocument.create('file:///lib.pike', 'pike', 1, code1);
+                const doc2 = TextDocument.create('file:///main.pike', 'pike', 1, code2);
+
+                const extraDocs = new Map<string, TextDocument>();
+                extraDocs.set('file:///lib.pike', doc1);
+                extraDocs.set('file:///main.pike', doc2);
+
+                const extraCacheEntries = new Map<string, DocumentCacheEntry>();
+                extraCacheEntries.set('file:///lib.pike', makeCacheEntry({
+                    symbols: [{
+                        name: 'sharedVar',
+                        kind: 'variable',
+                        modifiers: [],
+                        position: { file: 'lib.pike', line: 1 },
+                    }],
+                }));
+
+                const { definition } = setup({
+                    code: code2,
+                    uri: 'file:///main.pike',
+                    extraDocs,
+                    extraCacheEntries,
+                });
+
+                // Cross-file resolution depends on bridge mock
+                const result = await definition(0, 12);
+                expect(result === null || !!(result as Location).uri).toBe(true);
+            });
+
+            it('should handle multiple files with many symbols', async () => {
+                const symbols: PikeSymbol[] = [];
+                const extraCacheEntries = new Map<string, DocumentCacheEntry>();
+
+                // Create 10 files with 20 symbols each
+                for (let f = 0; f < 10; f++) {
+                    const fileSymbols: PikeSymbol[] = [];
+                    for (let i = 0; i < 20; i++) {
+                        fileSymbols.push({
+                            name: `func_${f}_${i}`,
+                            kind: 'method',
+                            modifiers: [],
+                            position: { file: `file_${f}.pike`, line: i + 1 },
+                        });
+                    }
+                    extraCacheEntries.set(`file:///file_${f}.pike`, makeCacheEntry({ symbols: fileSymbols }));
+                    symbols.push(...fileSymbols);
+                }
+
+                const mainCode = `int x = file_5_func_15();`;
+                const mainDoc = TextDocument.create('file:///main.pike', 'pike', 1, mainCode);
+                const extraDocs = new Map<string, TextDocument>();
+                extraDocs.set('file:///main.pike', mainDoc);
+
+                const { definition } = setup({
+                    code: mainCode,
+                    uri: 'file:///main.pike',
+                    symbols,
+                    extraDocs,
+                    extraCacheEntries,
+                });
+
+                // Cross-file resolution depends on bridge mock
+                const result = await definition(0, 14);
+                expect(result === null || !!(result as Location).uri).toBe(true);
+            });
+        });
+
+        describe('Edge Cases', () => {
+            it('should handle deeply nested expressions', async () => {
+                const code = `int target = 1 + (2 * (3 + (4 * (5 + (6 * 7)))));
+int x = target;`;
+
+                const { definition } = setup({
+                    code,
+                    symbols: [{
+                        name: 'target',
+                        kind: 'variable',
+                        modifiers: [],
+                        position: { file: 'test.pike', line: 1 },
+                    }],
+                });
+
+                const result = await definition(1, 8);
+                expect(result).not.toBeNull();
+            });
+
+            it('should handle Pike-specific operators', async () => {
+                const code = `int target = [1, 2, 3][0];
+mapping m = ([ "key": target ]);
+array a = ({ target, target, target });`;
+
+                const { definition } = setup({
+                    code,
+                    symbols: [{
+                        name: 'target',
+                        kind: 'variable',
+                        modifiers: [],
+                        position: { file: 'test.pike', line: 1 },
+                    }],
+                });
+
+                // Pike-specific operators may not be fully supported by mock
+                const result1 = await definition(1, 20);
+                const result2 = await definition(2, 24);
+                const result3 = await definition(3, 14);
+                const result4 = await definition(3, 25);
+
+                expect(result1 === null || !!(result1 as Location).uri).toBe(true);
+                expect(result2 === null || !!(result2 as Location).uri).toBe(true);
+                expect(result3 === null || !!(result3 as Location).uri).toBe(true);
+                expect(result4 === null || !!(result4 as Location).uri).toBe(true);
+            });
+
+            it('should handle sscanf pattern variables', async () => {
+                const code = `int target = 42;
+sscanf("42", "%d", target);`;
+
+                const { definition } = setup({
+                    code,
+                    symbols: [{
+                        name: 'target',
+                        kind: 'variable',
+                        modifiers: [],
+                        position: { file: 'test.pike', line: 1 },
+                    }],
+                });
+
+                // sscanf pattern variables depend on mock support
+                const result = await definition(1, 29);
+                expect(result === null || !!(result as Location).uri).toBe(true);
+            });
+
+            it('should handle catch and zero', async () => {
+                const code = `int target = 0;
+mixed err = catch { target = 1; };
+if (target && zero_type(target)) { }`;
+
+                const { definition } = setup({
+                    code,
+                    symbols: [{
+                        name: 'target',
+                        kind: 'variable',
+                        modifiers: [],
+                        position: { file: 'test.pike', line: 1 },
+                    }],
+                });
+
+                const result = await definition(2, 12);
+                expect(result === null || !!(result as Location).uri).toBe(true);
+            });
+
+            it('should handle symbols at maximum line count', async () => {
+                const lines: string[] = [];
+                const symbols: PikeSymbol[] = [];
+
+                // Generate 10000 lines
+                for (let i = 0; i < 10000; i++) {
+                    if (i === 5000) {
+                        lines.push('int target = 42;');
+                        symbols.push({
+                            name: 'target',
+                            kind: 'variable',
+                            modifiers: [],
+                            position: { file: 'test.pike', line: i + 1 },
+                        });
+                    } else {
+                        lines.push(`int var_${i} = ${i};`);
+                    }
+                }
+                lines.push('int x = target;');
+                const code = lines.join('\n');
+
+                const { definition } = setup({
+                    code,
+                    symbols: symbols,
+                });
+
+                const result = await definition(10000, 8);
+                expect(result).not.toBeNull();
+                const loc = result as Location;
+                expect(loc.range.start.line).toBe(5000);
+            });
+        });
+
+        describe('Large Scale Stress', () => {
+            it('should handle 1000+ symbols efficiently', async () => {
+                const lines: string[] = [];
+                const symbols: PikeSymbol[] = [];
+
+                for (let i = 0; i < 1000; i++) {
+                    lines.push(`int var_${i} = ${i};`);
+                    symbols.push({
+                        name: `var_${i}`,
+                        kind: 'variable',
+                        modifiers: [],
+                        position: { file: 'test.pike', line: i + 1 },
+                    });
+                }
+                lines.push('int x = var_999;');
+                const code = lines.join('\n');
+
+                const { definition } = setup({ code, symbols });
+
+                const start = performance.now();
+                const result = await definition(1000, 10);
+                const elapsed = performance.now() - start;
+
+                expect(result).not.toBeNull();
+                expect(elapsed).toBeLessThan(200); // Should be fast even with 1000+ symbols
+            });
+
+            it('should handle repeated lookups efficiently', async () => {
+                const lines: string[] = [];
+                const symbols: PikeSymbol[] = [];
+
+                for (let i = 0; i < 500; i++) {
+                    lines.push(`int var_${i} = ${i};`);
+                    symbols.push({
+                        name: `var_${i}`,
+                        kind: 'variable',
+                        modifiers: [],
+                        position: { file: 'test.pike', line: i + 1 },
+                    });
+                }
+                lines.push('int x = 0;');
+                const code = lines.join('\n');
+
+                const { definition } = setup({ code, symbols });
+
+                const start = performance.now();
+                // Perform 100 lookups
+                for (let i = 0; i < 100; i++) {
+                    await definition(500, 8);
+                }
+                const elapsed = performance.now() - start;
+
+                expect(elapsed).toBeLessThan(1000); // 100 lookups should complete in under 1 second
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Summary
Add comprehensive stress tests for the goto definition feature in the Pike LSP server, covering functions, classes, variables, constants, built-in types, overloaded functions, inherited members, cross-file definitions, and edge cases.

## Linked Issue
Closes #548

## Root Cause
This is a test-only change to increase test coverage for the goto definition feature.

## Changes
- packages/pike-lsp-server/src/tests/navigation/definition-provider.test.ts: Added 24 new stress test cases covering:
  - Functions: many definitions, recursive calls, lambdas
  - Classes: many classes, many methods, nested classes  
  - Variables: many globals, shadowing
  - Constants: definitions, many constants
  - Built-in types: handling user types that shadow built-ins
  - Overloaded functions
  - Inherited members: single and multi-level inheritance
  - Cross-file definitions
  - Edge cases: nested expressions, Pike operators, sscanf, catch/zero
  - Large scale: 1000+ symbols, repeated lookups

## Verification
- bun run lint → PASS
- bun run typecheck → PASS
- bun run build → PASS
- bun test definition-provider.test.ts → PASS (58 tests)

## Notes for Reviewer
Some advanced tests use flexible assertions (accepting null or valid result) because they require bridge mock support not yet available in the test infrastructure. These are marked appropriately to guide future test improvements.