### PR TITLE
fix: use lowercase closes in PR template for auto-close

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -746,7 +746,7 @@ gh pr create \
 <What this PR does — 1-3 sentences of prose. Not a list.>
 
 ## Linked Issue
-Closes #<number>
+closes #<number>
 
 ## Root Cause
 <What caused the problem — be specific. Proves understanding, not just patching.>


### PR DESCRIPTION
## Summary
Fixed the PR template in CLAUDE.md to use lowercase "closes" instead of "Closes" so GitHub auto-closes issues when PRs are merged.

## Linked Issue
closes #577

## Root Cause
GitHub requires lowercase keywords (closes, fixes, resolves) to auto-close issues. The template had "Closes" with capital C.

## Changes
- CLAUDE.md line 749: Changed "Closes" to "closes"

## Verification
- Local tests pass