### PR TITLE
fix: add pages write permission to benchmark CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pages: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
The benchmark CI workflow fails when trying to push benchmark results to the gh-pages branch because the `github-action-benchmark@v1` action lacks the required `pages: write` permission.

## Linked Issue
N/A - CI infrastructure fix

## Root Cause
The benchmark workflow only had `contents: write` permission, but pushing to the gh-pages branch (a GitHub Pages branch) requires `pages: write` permission.

## Changes
- `.github/workflows/bench.yml`: Added `pages: write` permission to the benchmark job

## Verification
- Pre-commit checks pass (lint, typecheck, build)
- This is a workflow configuration change with no runtime code impact

## Notes for Reviewer
This fix follows the GitHub Actions best practice of explicitly specifying all required permissions rather than relying on default permissions.