### PR TITLE
feat: implement range operator support (..) (#621)

### DIFF
--- a/pike-scripts/LSP.pmod/Analysis.pmod/Completions.pike
+++ b/pike-scripts/LSP.pmod/Analysis.pmod/Completions.pike
@@ -156,6 +156,15 @@ mapping handle_get_completion_context(mapping params) {
                 }
             }
 
+            // Check for range operator (..) - tokenized as .. (single token in Pike)
+            // Used in array slicing: arr[lo..hi], arr[lo..], arr[..hi]
+            // Also used in case statements: case 1..10:
+            if (text == "..") {
+                found_operator = "..";
+                operator_idx = i;
+                break;
+            }
+
             // Check for ternary operator (? :)
             // Look for ? but not ?-> or ?[ (safe navigation)
             if (text == "?") {
@@ -243,6 +252,13 @@ mapping handle_get_completion_context(mapping params) {
             // Ternary operator - provide expression context
             result->context = "expression";
             result->operator = "?:";
+        } else if (found_operator == "..") {
+            // Range operator - provide expression context
+            // Used in array slicing: arr[lo..hi], arr[lo..], arr[..hi]
+            // Also used in case statements: case 1..10:
+            // And as range expressions: 1..10
+            result->context = "expression";
+            result->operator = "..";
         } else if (cursor_after_dot && token_idx >= 0) {
             // NEW: Cursor is after a dot but token scan didn't find the operator
             // This happens when there's no token after the dot (e.g., "Array.|")
@@ -387,6 +403,15 @@ mapping handle_get_completion_context_cached(mapping params) {
                 }
             }
 
+            // Check for range operator (..) - tokenized as .. (single token in Pike)
+            // Used in array slicing: arr[lo..hi], arr[lo..], arr[..hi]
+            // Also used in case statements: case 1..10:
+            if (text == "..") {
+                found_operator = "..";
+                operator_idx = i;
+                break;
+            }
+
             // Check for ternary operator (? :)
             // Look for ? but not ?-> or ?[ (safe navigation)
             if (text == "?") {
@@ -474,6 +499,13 @@ mapping handle_get_completion_context_cached(mapping params) {
             // Ternary operator - provide expression context
             result->context = "expression";
             result->operator = "?:";
+        } else if (found_operator == "..") {
+            // Range operator - provide expression context
+            // Used in array slicing: arr[lo..hi], arr[lo..], arr[..hi]
+            // Also used in case statements: case 1..10:
+            // And as range expressions: 1..10
+            result->context = "expression";
+            result->operator = "..";
         } else if (cursor_after_dot && token_idx >= 0) {
             // NEW: Cursor is after a dot but token scan didn't find the operator
             // This happens when there's no token after the dot (e.g., "Array.|")


### PR DESCRIPTION
## Summary
Implements range operator (..) support for Pike LSP completion context analysis. The range operator is used in Pike for array/string slicing (arr[lo..hi]), case ranges in switch statements (case 1..10:), and creating range expressions (1..10).

## Linked Issue
closes #621

## Root Cause
The completion context analysis did not recognize the range operator (..), treating it as a generic token instead of detecting it as an expression context operator.

## Changes
- `pike-scripts/LSP.pmod/Analysis.pmod/Completions.pike`: Added detection of `..` token in the operator scan loop, and added context handling for range operator (returns "expression" context with operator "..")

## Verification
- bun run lint → PASS
- bun run typecheck → PASS  
- bun run build → PASS
- Pike compile check → PASS
- Pre-commit smoke tests → PASS (3/3)

## Notes for Reviewer
The range operator handling follows the same pattern as ternary operator detection - when `..` is detected, it returns an "expression" context so completion providers can offer appropriate suggestions. This enables proper completion support inside range expressions.