### PR TITLE
feat: implement range operator (..) context detection

### DIFF
--- a/pike-scripts/LSP.pmod/Analysis.pmod/Completions.pike
+++ b/pike-scripts/LSP.pmod/Analysis.pmod/Completions.pike
@@ -176,6 +176,17 @@ mapping handle_get_completion_context(mapping params) {
                 }
             }
 
+            // Check for range operator (..)
+            // Range operator is used in:
+            // - Array/string slicing: arr[2..5], arr[2..], arr[..5]
+            // - Case ranges: case 1..10:
+            // - Creating ranges: 1..10
+            // - Type expressions: int(0..255)
+            if (text == "..") {
+                found_operator = "..";
+                operator_idx = i;
+            }
+
             // Stop at statement boundaries
             if (text == ";" || text == "{" || text == "}") {
                 break;
@@ -220,7 +231,7 @@ mapping handle_get_completion_context(mapping params) {
                     obj_text == "=" || obj_text == "==" || obj_text == "+" ||
                     obj_text == "-" || obj_text == "*" || obj_text == "/" ||
                     obj_text == "->" || obj_text == "::" ||
-                    obj_text == "?" || obj_text == ":") {
+                    obj_text == "?" || obj_text == ":" || obj_text == "..") {
                     break;
                 }
 
@@ -243,6 +254,11 @@ mapping handle_get_completion_context(mapping params) {
             // Ternary operator - provide expression context
             result->context = "expression";
             result->operator = "?:";
+        } else if (found_operator == "..") {
+            // Range operator - provide expression context
+            // Used in: arr[2..5], arr[2..], arr[..5], 1..10, case 1..10:, int(0..255)
+            result->context = "expression";
+            result->operator = "..";
         } else if (cursor_after_dot && token_idx >= 0) {
             // NEW: Cursor is after a dot but token scan didn't find the operator
             // This happens when there's no token after the dot (e.g., "Array.|")
@@ -407,6 +423,17 @@ mapping handle_get_completion_context_cached(mapping params) {
                 }
             }
 
+            // Check for range operator (..)
+            // Range operator is used in:
+            // - Array/string slicing: arr[2..5], arr[2..], arr[..5]
+            // - Case ranges: case 1..10:
+            // - Creating ranges: 1..10
+            // - Type expressions: int(0..255)
+            if (text == "..") {
+                found_operator = "..";
+                operator_idx = i;
+            }
+
             // Stop at statement boundaries
             if (text == ";" || text == "{" || text == "}") {
                 break;
@@ -451,7 +478,7 @@ mapping handle_get_completion_context_cached(mapping params) {
                     obj_text == "=" || obj_text == "==" || obj_text == "+" ||
                     obj_text == "-" || obj_text == "*" || obj_text == "/" ||
                     obj_text == "->" || obj_text == "::" ||
-                    obj_text == "?" || obj_text == ":") {
+                    obj_text == "?" || obj_text == ":" || obj_text == "..") {
                     break;
                 }
 
@@ -474,6 +501,11 @@ mapping handle_get_completion_context_cached(mapping params) {
             // Ternary operator - provide expression context
             result->context = "expression";
             result->operator = "?:";
+        } else if (found_operator == "..") {
+            // Range operator - provide expression context
+            // Used in: arr[2..5], arr[2..], arr[..5], 1..10, case 1..10:, int(0..255)
+            result->context = "expression";
+            result->operator = "..";
         } else if (cursor_after_dot && token_idx >= 0) {
             // NEW: Cursor is after a dot but token scan didn't find the operator
             // This happens when there's no token after the dot (e.g., "Array.|")


### PR DESCRIPTION
## Summary
Implements range operator (`..`) context detection for code completion in the Pike LSP. This enables proper completion context detection for array slicing, case ranges, and type expressions using the range operator.

## Linked Issue
closes #621

## Root Cause
The completion context analyzer did not recognize the `..` (range) operator, which is used in Pike for:
- Array/string slicing: `arr[2..5]`, `arr[2..]`, `arr[..5]`
- Case ranges: `case 1..10:`
- Range creation: `1..10`
- Type expressions: `int(0..255)`

## Changes
- `pike-scripts/LSP.pmod/Analysis.pmod/Completions.pike`:
  - Added detection for `..` token as range operator in both `handle_get_completion_context` and `handle_get_completion_context_cached` functions
  - Added `..` to the stop list when building object names
  - Set context to "expression" when cursor is after range operator

## Verification
- bun run lint → PASS
- bun run typecheck → PASS  
- bun run build → PASS
- Pre-commit smoke tests: Pike compile PASS, bridge PASS, server PASS