### PR TITLE
fix: display object constraint in type formatting (object(ClassName))

### DIFF
--- a/packages/pike-lsp-server/src/features/utils/pike-type-formatter.ts
+++ b/packages/pike-lsp-server/src/features/utils/pike-type-formatter.ts
@@ -51,7 +51,7 @@ export function formatPikeType(typeObj: unknown): string {
 
     // Handle object types: name="object", className="Gmp.mpz"
     if (name === 'object' && t['className']) {
-        return t['className'] as string;
+        return `object(${t['className']})`;
     }
 
     // Handle program types: name="program", className="..."


### PR DESCRIPTION
## Summary
Fixes the display of constrained object types in hover and completions. Previously, types like `object(MyClass)` were displayed as just `MyClass` instead of the proper `object(MyClass)` syntax.

## Linked Issue
closes #617

## Root Cause
The `formatPikeType` function in `pike-type-formatter.ts` was returning only the className for constrained object types, missing the `object()` wrapper that makes the constraint explicit.

## Changes
- \`packages/pike-lsp-server/src/features/utils/pike-type-formatter.ts\`: Changed object type formatting to return \`object(className)\` instead of just the className

## Verification
bun run typecheck → PASS
bun run build → PASS
cd packages/pike-lsp-server && bun test → PASS (2949 tests)
bun test ./packages/pike-lsp-server/src/tests/smoke.test.ts → PASS (7 tests)