### PR TITLE
feat: implement typedef/name type support

### DIFF
--- a/packages/pike-bridge/src/types.ts
+++ b/packages/pike-bridge/src/types.ts
@@ -50,7 +50,8 @@ export type PikeType =
     | PikeMixedType
     | PikeVoidType
     | PikeZeroType
-    | PikeOrType;
+    | PikeOrType
+    | PikeNameType;
 
 export interface PikeIntType {
     kind: 'int';
@@ -130,6 +131,19 @@ export interface PikeZeroType {
 export interface PikeOrType {
     kind: 'or';
     types: PikeType[];
+}
+
+/**
+ * Named type (typedef/name type alias)
+ * Represents Pike's named types like `typedef int myint`
+ * The type field contains the resolved/underlying type
+ */
+export interface PikeNameType {
+    kind: 'name';
+    /** Name of the typedef/type alias (e.g., "myint") */
+    name: string;
+    /** Resolved underlying type (e.g., "int" for typedef int myint) */
+    type?: PikeType;
 }
 
 /**

--- a/packages/pike-lsp-server/src/features/editing/completion-helpers.ts
+++ b/packages/pike-lsp-server/src/features/editing/completion-helpers.ts
@@ -22,6 +22,7 @@ export function convertCompletionKind(kind?: string): CompletionItemKind {
         case 'method': case 'function': return CompletionItemKind.Function;
         case 'variable': return CompletionItemKind.Variable;
         case 'constant': return CompletionItemKind.Constant;
+        case 'typedef': return CompletionItemKind.TypeParameter;
         case 'module': return CompletionItemKind.Module;
         case 'inherit': return CompletionItemKind.Reference;
         default: return CompletionItemKind.Text;
@@ -373,6 +374,12 @@ export function buildLabelDetails(symbol: PikeSymbol): LabelDetails | undefined 
     if (symbol.kind === 'variable' && symbol.type) {
         const typeName = formatTypeName(symbol.type);
         return typeName ? { detail: typeName } : undefined;
+    }
+
+    // For typedef: show the underlying type
+    if (symbol.kind === 'typedef' && symbol.type) {
+        const typeName = formatTypeName(symbol.type);
+        return typeName ? { detail: `typedef ${typeName}` } : undefined;
     }
 
     // For classes/modules: show kind

--- a/packages/pike-lsp-server/src/features/utils/hover-builder.ts
+++ b/packages/pike-lsp-server/src/features/utils/hover-builder.ts
@@ -487,6 +487,23 @@ export function buildHoverContent(symbol: PikeSymbol, parentScope?: string): str
         const modifier = symbol.kind === 'constant' ? 'constant ' : '';
         parts.push(`${modifier}${type} ${symbol.name}`);
         parts.push('```');
+    } else if (symbol.kind === 'typedef') {
+        // Handle typedef - show the typedef definition
+        const type = symbol.type
+            ? formatPikeType(symbol.type)
+            : (sym['type'] as { name?: string })?.name ?? 'mixed';
+
+        // Check for resolved type from type_to_json (contains nameAlias and resolvedType)
+        const resolvedType = sym['resolvedType'] as string | undefined;
+        const nameAlias = sym['nameAlias'] as string | undefined;
+
+        parts.push('```pike');
+        if (nameAlias && resolvedType) {
+            parts.push(`typedef ${resolvedType} ${nameAlias}`);
+        } else {
+            parts.push(`typedef ${type} ${symbol.name}`);
+        }
+        parts.push('```');
     } else if (symbol.kind === 'class') {
         parts.push('```pike');
         parts.push(`class ${symbol.name}`);

--- a/pike-scripts/LSP.pmod/Parser.pike
+++ b/pike-scripts/LSP.pmod/Parser.pike
@@ -1652,6 +1652,26 @@ protected mapping|int type_to_json(object|void type) {
         };
     }
 
+    // Handle NamedType (typedef/name type): Pike returns "{ myint = int }" for typedefs
+    // Check if this is a named type by looking for "=" in the type representation
+    if (result->name && has_value(class_path, "NamedType")) {
+        // This is a named/typedef type - extract the alias name and resolve to underlying type
+        // Pike's typeof returns "{ alias = underlying }" format
+        string type_str = sprintf("%O", type);
+        if (has_value(type_str, "=")) {
+            // Parse "{ name = underlying }" format
+            // Extract the name before "="
+            string name_part = "";
+            string underlying_part = "";
+            sscanf(type_str, "{%s=%s}", name_part, underlying_part);
+            if (sizeof(name_part) && sizeof(underlying_part)) {
+                result->name = "name";
+                result->nameAlias = String.trim_all_whites(name_part);
+                result->resolvedType = String.trim_all_whites(underlying_part);
+            }
+        }
+    }
+
     return sizeof(result) > 0 ? result : 0;
 }
 


### PR DESCRIPTION
## Summary
Implements support for Pike's named types (typedef) allowing user-defined type aliases to be resolved in the LSP. This adds the ability to parse, store, and display typedef information for hover tooltips and completions.

## Linked Issue
closes #618

## Root Cause
The Pike LSP was not handling named types (typedef) from Pike's type system. When Pike's typeof() returns a typedef type, it returns "{ alias = underlying }" format (e.g., "{ myint = int }"), but the parser was not extracting this information for display.

## Changes
- `packages/pike-bridge/src/types.ts`: Added `PikeNameType` interface to represent named types with kind 'name', name alias, and resolved type
- `pike-scripts/LSP.pmod/Parser.pike`: Added handling for NamedType in type_to_json to extract the alias name and underlying type from Pike's "{ alias = underlying }" format
- `packages/pike-lsp-server/src/features/utils/hover-builder.ts`: Added typedef handling to display typedef definitions in hover tooltips
- `packages/pike-lsp-server/src/features/editing/completion-helpers.ts`: Added typedef to completion kinds (TypeParameter) and label details

## Verification
- Build: `bun run build` → PASS
- Lint: `bun run lint` → PASS  
- Tests: `bun test packages/pike-lsp-server` → 2949 pass, 0 fail
- Pike compile: `pike-compile` → PASS
- Bridge: `bridge` → PASS
- Server: `server` → PASS