### PR TITLE
feat: support Pike union/intersection/range/attribute types

### DIFF
--- a/packages/pike-bridge/src/types.ts
+++ b/packages/pike-bridge/src/types.ts
@@ -50,7 +50,11 @@ export type PikeType =
     | PikeMixedType
     | PikeVoidType
     | PikeZeroType
+    | PikeTypeType
+    | PikeUnknownType
     | PikeOrType
+    | PikeAndType
+    | PikeAttributeType
     | PikeNameType;
 
 export interface PikeIntType {
@@ -128,9 +132,29 @@ export interface PikeZeroType {
     kind: 'zero';
 }
 
+export interface PikeTypeType {
+    kind: 'type';
+    subtype?: PikeType;
+}
+
+export interface PikeUnknownType {
+    kind: 'unknown';
+}
+
 export interface PikeOrType {
     kind: 'or';
     types: PikeType[];
+}
+
+export interface PikeAndType {
+    kind: 'and';
+    types: PikeType[];
+}
+
+export interface PikeAttributeType {
+    kind: '__attribute__';
+    attribute?: string;
+    type?: PikeType;
 }
 
 /**

--- a/packages/pike-lsp-server/src/tests/pike-type-formatter.test.ts
+++ b/packages/pike-lsp-server/src/tests/pike-type-formatter.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'bun:test';
+import { formatPikeType } from '../features/utils/pike-type-formatter.js';
+
+describe('Pike Type Formatter', () => {
+    it('formats union types', () => {
+        const formatted = formatPikeType({
+            name: 'or',
+            types: [{ name: 'int' }, { name: 'string' }],
+        });
+
+        expect(formatted).toBe('int | string');
+    });
+
+    it('formats intersection types', () => {
+        const formatted = formatPikeType({
+            name: 'and',
+            types: [{ name: 'A' }, { name: 'B' }],
+        });
+
+        expect(formatted).toBe('A & B');
+    });
+
+    it('formats ranged int types', () => {
+        const formatted = formatPikeType({
+            name: 'int',
+            min: '0',
+            max: '255',
+        });
+
+        expect(formatted).toBe('int(0..255)');
+    });
+
+    it('formats attributed types', () => {
+        const formatted = formatPikeType({
+            name: '__attribute__',
+            attribute: 'deprecated',
+            type: { name: 'int' },
+        });
+
+        expect(formatted).toBe('__attribute__(deprecated) int');
+    });
+
+    it('maps object(unknown) to unknown', () => {
+        const formatted = formatPikeType({
+            name: 'object',
+            className: 'unknown',
+        });
+
+        expect(formatted).toBe('unknown');
+    });
+});


### PR DESCRIPTION
## Summary
This PR adds end-to-end Pike type-system support for union, intersection, range, and attributed type declarations, and extends built-in type handling for `zero`, `type`, and `unknown`. It updates parser fallback recovery, type serialization/formatting, and editor completions so these types are recognized and displayed consistently.

## Linked Issue
closes #612
closes #613
closes #614
closes #615
closes #616

## Root Cause
The parser fallback path only recognized a narrow set of simple type declarations, so valid Pike constructs like `A&B`, `__attribute__(...) T`, and ranged ints were parsed as partial symbols without usable type metadata. In addition, serialized/formatter/completion layers did not cover all Pike built-ins and composite type shapes, causing missing or incorrect hover/completion output.

## Changes
- `pike-scripts/LSP.pmod/Parser.pike`: added robust token-recovery parsing for union/intersection/attribute/range declarations and expanded type JSON serialization (`and`, `type`, range bounds, `unknown`, preserved `__attribute__` wrapper).
- `packages/pike-bridge/src/types.ts`: expanded `PikeType` union with `type`, `unknown`, `and`, and `__attribute__` type representations to match parser output.
- `packages/pike-lsp-server/src/features/utils/pike-type-formatter.ts`: added formatting for intersections, ranges, attributes, and `unknown` mapping.
- `packages/pike-lsp-server/src/features/editing/completion.ts`: added built-in completions for `zero`, `type`, `unknown`, `__attribute__`, and `int(0..255)` plus attribute-name suggestions inside `__attribute__(...)`.
- `test/tests/parser-tests.pike`: added parser regression tests for union, intersection, range, attribute, and built-in type variants.
- `packages/pike-lsp-server/src/tests/editing/completion-provider.test.ts`: added completion coverage for new built-ins, attribute contexts, and `|`/`&` type contexts.
- `packages/pike-lsp-server/src/tests/pike-type-formatter.test.ts`: added focused formatter tests for new type shapes.

## Verification
pike test/tests/parser-tests.pike -> PASS (30/30)
bun test packages/pike-lsp-server/src/tests/editing/completion-provider.test.ts packages/pike-lsp-server/src/tests/pike-type-formatter.test.ts -> PASS (74/74)
bun run typecheck -> PASS
Pre-push hook TypeScript build check -> PASS
Pre-push hook Pike compile check -> PASS

## Notes for Reviewer
The initial pre-commit fast regression check failed in the repository's existing `server` fast test target, but the targeted parser/completion/type test suites for this change set pass cleanly and the pre-push required checks pass.
