### PR TITLE
perf: reduce LSP startup blocking and edit-path logging overhead

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics/index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/index.ts
@@ -11,11 +11,11 @@
  */
 
 import type {
-    Connection,
-    TextDocuments,
-    Diagnostic,
-    DidChangeConfigurationParams,
-    Range,
+  Connection,
+  TextDocuments,
+  Diagnostic,
+  DidChangeConfigurationParams,
+  Range,
 } from 'vscode-languageserver/node.js';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Services } from '../../services/index.js';
@@ -27,10 +27,22 @@ import { computeContentHash, computeLineHashes } from '../../services/document-c
 import { detectRoxenModule, provideRoxenDiagnostics } from '../roxen/index.js';
 
 // Import from split modules
-export { convertDiagnostic, isDeprecatedSymbolDiagnostic, extractDeprecatedFromSymbols } from './utils.js';
+export {
+  convertDiagnostic,
+  isDeprecatedSymbolDiagnostic,
+  extractDeprecatedFromSymbols,
+} from './utils.js';
 export { buildSymbolNameIndex } from './symbol-index.js';
-export { buildSymbolPositionIndex, buildSymbolPositionIndexRegex, flattenSymbols } from './symbol-index.js';
-export { classifyChange, stripLineComments, type ChangeClassification } from './change-detection.js';
+export {
+  buildSymbolPositionIndex,
+  buildSymbolPositionIndexRegex,
+  flattenSymbols,
+} from './symbol-index.js';
+export {
+  classifyChange,
+  stripLineComments,
+  type ChangeClassification,
+} from './change-detection.js';
 
 /**
  * Register diagnostics handlers with the LSP connection.
@@ -40,566 +52,600 @@ export { classifyChange, stripLineComments, type ChangeClassification } from './
  * @param documents - Text document manager
  */
 export function registerDiagnosticsHandlers(
-    connection: Connection,
-    services: Services,
-    documents: TextDocuments<TextDocument>
+  connection: Connection,
+  services: Services,
+  documents: TextDocuments<TextDocument>
 ): void {
-    // Import functions from split modules
-    const { convertDiagnostic, isDeprecatedSymbolDiagnostic, extractDeprecatedFromSymbols } = require('./utils.js');
-    const { buildSymbolPositionIndex, buildSymbolNameIndex, flattenSymbols } = require('./symbol-index.js');
-    const { classifyChange } = require('./change-detection.js');
+  // Import functions from split modules
+  const {
+    convertDiagnostic,
+    isDeprecatedSymbolDiagnostic,
+    extractDeprecatedFromSymbols,
+  } = require('./utils.js');
+  const {
+    buildSymbolPositionIndex,
+    buildSymbolNameIndex,
+    flattenSymbols,
+  } = require('./symbol-index.js');
+  const { classifyChange } = require('./change-detection.js');
 
-    // NOTE: We access services.bridge dynamically instead of destructuring,
-    // because bridge is null when handlers are registered and only initialized later in onInitialize.
-    const { documentCache, typeDatabase, workspaceIndex } = services;
-    const log = new Logger('diagnostics');
+  // NOTE: We access services.bridge dynamically instead of destructuring,
+  // because bridge is null when handlers are registered and only initialized later in onInitialize.
+  const { documentCache, typeDatabase, workspaceIndex } = services;
+  const log = new Logger('diagnostics');
 
-    // Validation timers for debouncing
-    const validationTimers = new Map<string, ReturnType<typeof setTimeout>>();
-    // INC-563: Track expected document version for each debounced validation
+  // Validation timers for debouncing
+  const validationTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  // INC-563: Track expected document version for each debounced validation
+  // This prevents stale validations from overwriting fresher results after undo
+  const validationVersions = new Map<string, number>();
+
+  // INC-002: Track change ranges for incremental parsing.
+  // Stores the range of the most recent change for each document URI.
+  const pendingChangeRanges = new Map<string, Range | undefined>();
+
+  // Configuration settings
+  const defaultSettings: PikeSettings = {
+    pikePath: 'pike',
+    maxNumberOfProblems: DEFAULT_MAX_PROBLEMS,
+    diagnosticDelay: DIAGNOSTIC_DELAY_DEFAULT,
+  };
+  let globalSettings: PikeSettings = defaultSettings;
+
+  function validateDocumentDebounced(document: TextDocument): void {
+    const uri = document.uri;
+    const version = document.version;
+
+    // Clear existing timer
+    const existingTimer = validationTimers.get(uri);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+
+    // INC-563: Store expected version for this scheduled validation
     // This prevents stale validations from overwriting fresher results after undo
-    const validationVersions = new Map<string, number>();
+    const expectedVersion = version;
+    validationVersions.set(uri, expectedVersion);
 
-    // INC-002: Track change ranges for incremental parsing.
-    // Stores the range of the most recent change for each document URI.
-    const pendingChangeRanges = new Map<string, Range | undefined>();
+    // Set new timer
+    const timer = setTimeout(() => {
+      validationTimers.delete(uri);
+      validationVersions.delete(uri);
 
-    // Configuration settings
-    const defaultSettings: PikeSettings = {
-        pikePath: 'pike',
-        maxNumberOfProblems: DEFAULT_MAX_PROBLEMS,
-        diagnosticDelay: DIAGNOSTIC_DELAY_DEFAULT,
-    };
-    let globalSettings: PikeSettings = defaultSettings;
+      // INC-563: Check if this validation is stale (a newer version was scheduled)
+      const currentVersion = document.version;
+      if (currentVersion !== expectedVersion) {
+        // Clear pending change range since we're skipping
+        pendingChangeRanges.delete(uri);
+        return;
+      }
 
-    /**
-     * Validate document with debouncing
-     * INC-002: Now includes incremental change classification
-     * LOG-14-01: Logs didChange events and debounce execution
-     */
-    function validateDocumentDebounced(document: TextDocument): void {
-        const uri = document.uri;
-        const version = document.version;
+      // INC-002: Classify change to determine if parsing is needed
+      const changeRange = pendingChangeRanges.get(uri);
+      const cachedEntry = documentCache.get(uri);
+      const classification = classifyChange(document, changeRange, cachedEntry);
 
-        // LOG-14-01: Track didChange event triggering debounce
-        connection.console.log(`[DID_CHANGE] uri=${uri}, version=${version}, delay=${globalSettings.diagnosticDelay}ms`);
-
-        // Clear existing timer
-        const existingTimer = validationTimers.get(uri);
-        if (existingTimer) {
-            clearTimeout(existingTimer);
+      if (classification.canSkip) {
+        // Skip parsing entirely - just update cache metadata
+        if (cachedEntry && classification.newHash) {
+          // Update hash metadata without full reparse
+          cachedEntry.contentHash = classification.newHash;
+          if (classification.newLineHashes) {
+            cachedEntry.lineHashes = classification.newLineHashes;
+          }
+          cachedEntry.version = version;
         }
 
-        // INC-563: Store expected version for this scheduled validation
-        // This prevents stale validations from overwriting fresher results after undo
-        const expectedVersion = version;
-        validationVersions.set(uri, expectedVersion);
+        // Clear the pending change range
+        pendingChangeRanges.delete(uri);
+        return;
+      }
 
-        // Set new timer
-        const timer = setTimeout(() => {
-            validationTimers.delete(uri);
-            validationVersions.delete(uri);
+      // Proceed with full validation
+      const promise = validateDocument(document, classification);
+      documentCache.setPending(uri, promise);
+      promise.catch(err => {
+        log.error('Debounced validation failed', {
+          uri,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }, globalSettings.diagnosticDelay);
 
-            // INC-563: Check if this validation is stale (a newer version was scheduled)
-            const currentVersion = document.version;
-            if (currentVersion !== expectedVersion) {
-                connection.console.log(
-                    `[DEBOUNCE] uri=${uri}, expected=${expectedVersion}, current=${currentVersion} - SKIPPING stale validation`
-                );
-                // Clear pending change range since we're skipping
-                pendingChangeRanges.delete(uri);
-                return;
-            }
+    validationTimers.set(uri, timer);
+  }
 
-            // LOG-14-01: Track debounce timer execution
-            connection.console.log(`[DEBOUNCE] uri=${uri}, version=${version}, executing validateDocument`);
+  /**
+   * Validate document and send diagnostics
+   * INC-002: Accepts classification to reuse computed hashes
+   * LOG-14-01: Logs validation start with version tracking
+   */
+  async function validateDocument(
+    document: TextDocument,
+    classification?: import('./change-detection.js').ChangeClassification
+  ): Promise<void> {
+    const uri = document.uri;
+    const version = document.version;
 
-            // INC-002: Classify change to determine if parsing is needed
-            const changeRange = pendingChangeRanges.get(uri);
-            const cachedEntry = documentCache.get(uri);
-            const classification = classifyChange(document, changeRange, cachedEntry);
+    log.debug('VALIDATE_START', { uri, version });
 
-            connection.console.log(
-                `[INC-002] Change classification: canSkip=${classification.canSkip}, reason=${classification.reason}`
-            );
-
-            if (classification.canSkip) {
-                // Skip parsing entirely - just update cache metadata
-                connection.console.log(`[INC-002] Skipping parse for ${uri} (${classification.reason})`);
-
-                if (cachedEntry && classification.newHash) {
-                    // Update hash metadata without full reparse
-                    cachedEntry.contentHash = classification.newHash;
-                    if (classification.newLineHashes) {
-                        cachedEntry.lineHashes = classification.newLineHashes;
-                    }
-                    cachedEntry.version = version;
-                }
-
-                // Clear the pending change range
-                pendingChangeRanges.delete(uri);
-                return;
-            }
-
-            // Proceed with full validation
-            const promise = validateDocument(document, classification);
-            documentCache.setPending(uri, promise);
-            promise.catch(err => {
-                log.error('Debounced validation failed', {
-                    uri,
-                    error: err instanceof Error ? err.message : String(err)
-                });
-            });
-        }, globalSettings.diagnosticDelay);
-
-        validationTimers.set(uri, timer);
+    const bridge = services.bridge;
+    if (!bridge) {
+      log.warn('Bridge not available');
+      return;
     }
 
-    /**
-     * Validate document and send diagnostics
-     * INC-002: Accepts classification to reuse computed hashes
-     * LOG-14-01: Logs validation start with version tracking
-     */
-    async function validateDocument(document: TextDocument, classification?: import('./change-detection.js').ChangeClassification): Promise<void> {
-        const uri = document.uri;
-        const version = document.version;
-
-        // LOG-14-01: Track validation start before bridge operations
-        connection.console.log(`[VALIDATE_START] uri=${uri}, version=${version}`);
-
-        const bridge = services.bridge;
-        if (!bridge) {
-            log.warn('Bridge not available');
-            return;
-        }
-
-        if (!bridge.isRunning()) {
-            connection.console.warn('[VALIDATE] Bridge not running, attempting to start...');
-            try {
-                await bridge.start();
-                connection.console.log('[VALIDATE] Bridge started successfully');
-            } catch (err) {
-                connection.console.error(`[VALIDATE] Failed to start bridge: ${err}`);
-                return;
-            }
-        }
-
-        const text = document.getText();
-
-        connection.console.log(`[VALIDATE] Document version: ${version}, length: ${text.length} chars`);
-
-        // INC-002: Compute hashes for incremental change detection
-        // Use pre-computed hashes from classification if available
-        const contentHash = classification?.newHash ?? computeContentHash(text);
-        const lineHashes = classification?.newLineHashes ?? computeLineHashes(text);
-
-        // Extract filename from URI and decode URL encoding
-        const filename = decodeURIComponent(uri.replace(/^file:\/\//, ''));
-
-        try {
-            connection.console.log(`[VALIDATE] Calling unified analyze for: ${filename}`);
-            // PERF-004: Include 'tokenize' to avoid separate findOccurrences call for symbolPositions
-            // Tokens are used to build symbolPositions index without additional IPC round-trip
-            // Single unified analyze call - replaces 3 separate calls (introspect, parse, analyzeUninitialized)
-            // Pass document version for cache key (open docs use LSP version, no stat overhead)
-            const analyzeResult = await bridge.analyze(text, ['parse', 'introspect', 'diagnostics', 'tokenize'], filename, version);
-
-            // Log completion status
-            const hasParse = !!analyzeResult.result?.parse;
-            const hasIntrospect = !!analyzeResult.result?.introspect;
-            const hasDiagnostics = !!analyzeResult.result?.diagnostics;
-            connection.console.log(`[VALIDATE] Analyze completed - parse: ${hasParse}, introspect: ${hasIntrospect}, diagnostics: ${hasDiagnostics}`);
-
-
-            // Log cache hit/miss for debugging
-            if (analyzeResult._perf) {
-                const cacheHit = analyzeResult._perf.cache_hit;
-                connection.console.log(`[VALIDATE] Cache ${cacheHit ? 'HIT' : 'MISS'} for ${uri}`);
-            }
-
-            // Log any partial failures
-            if (analyzeResult.failures && Object.keys(analyzeResult.failures).length > 0) {
-                connection.console.log(`[VALIDATE] Partial failures: ${Object.keys(analyzeResult.failures).join(', ')}`);
-            }
-
-            // Extract results with fallback values for partial failures
-            const parseData = analyzeResult.failures?.parse
-                ? { symbols: [], diagnostics: [] }
-                : analyzeResult.result?.parse ?? { symbols: [], diagnostics: [] };
-            const introspectData = analyzeResult.failures?.introspect
-                ? { success: 0, symbols: [], functions: [], variables: [], classes: [], inherits: [], diagnostics: [] }
-                : analyzeResult.result?.introspect ?? { success: 0, symbols: [], functions: [], variables: [], classes: [], inherits: [], diagnostics: [] };
-            const diagnosticsData = analyzeResult.failures?.diagnostics
-                ? { diagnostics: [] }
-                : analyzeResult.result?.diagnostics ?? { diagnostics: [] };
-            // PERF-004: Extract tokens for symbolPositions building
-            const tokenizeData = analyzeResult.result?.tokenize?.tokens;
-
-            // Convert Pike diagnostics to LSP diagnostics
-            const diagnostics: Diagnostic[] = [];
-
-            // Patterns for module resolution errors we should skip
-            const skipPatterns = [
-                /Index .* not present in module/i,
-                /Indexed module was:/i,
-                /Illegal program identifier/i,
-                /Not a valid program specifier/i,
-                /Failed to evaluate constant expression/i,
-            ];
-
-            const shouldSkipDiagnostic = (msg: string): boolean => {
-                return skipPatterns.some(pattern => pattern.test(msg));
-            };
-
-            // Process diagnostics from introspection
-            for (const pikeDiag of introspectData.diagnostics) {
-                if (diagnostics.length >= globalSettings.maxNumberOfProblems) {
-                    break;
-                }
-                // Skip module resolution errors
-                if (shouldSkipDiagnostic(pikeDiag.message)) {
-                    continue;
-                }
-
-                // Check if this diagnostic is about a deprecated symbol
-                const isDeprecated = isDeprecatedSymbolDiagnostic(
-                    pikeDiag.message,
-                    introspectData.symbols
-                );
-
-                diagnostics.push(convertDiagnostic(pikeDiag, document, { deprecated: isDeprecated }));
-            }
-
-            // Update type database with introspected symbols if compilation succeeded
-            if (introspectData.success && introspectData.symbols.length > 0) {
-                // Convert introspected symbols to Maps
-                const symbolMap = new Map(introspectData.symbols.map(s => [s.name, s]));
-                const functionMap = new Map(introspectData.functions.map(s => [s.name, s]));
-                const variableMap = new Map(introspectData.variables.map(s => [s.name, s]));
-                const classMap = new Map(introspectData.classes.map(s => [s.name, s]));
-
-                // Estimate size
-                const sizeBytes = TypeDatabase.estimateProgramSize(symbolMap, introspectData.inherits);
-
-                const programInfo: CompiledProgramInfo = {
-                    uri,
-                    version,
-                    symbols: symbolMap,
-                    functions: functionMap,
-                    variables: variableMap,
-                    classes: classMap,
-                    inherits: introspectData.inherits,
-                    imports: new Set(),
-                    compiledAt: Date.now(),
-                    sizeBytes,
-                };
-
-                typeDatabase.setProgram(programInfo);
-
-                // Also update legacy cache for backward compatibility
-                // Merge introspected symbols with parse symbols to get position info
-                const legacySymbols: import('@pike-lsp/pike-bridge').PikeSymbol[] = [];
-
-                // Log introspection results for debugging
-                connection.console.log(`[VALIDATE] Introspection: success=${introspectData.success}, symbols=${introspectData.symbols.length}, functions=${introspectData.functions?.length || 0}, classes=${introspectData.classes?.length || 0}`);
-                // Log first few introspected symbol names/kinds
-                for (let i = 0; i < Math.min(5, introspectData.symbols.length); i++) {
-                    const sym = introspectData.symbols[i];
-                    if (sym) {
-                        connection.console.log(`[VALIDATE]   Introspect ${i}: name="${sym.name}", kind=${sym.kind}`);
-                    }
-                }
-
-                if (parseData && parseData.symbols.length > 0) {
-                    // Flatten nested symbols to include class members
-                    // This ensures get_n, get_e, set_random etc. are indexed
-                    const flatParseSymbols = flattenSymbols(parseData.symbols);
-
-                    connection.console.log(`[VALIDATE] Flattened ${parseData.symbols.length} symbols to ${flatParseSymbols.length} total (including class members)`);
-                    // Log first few parsed symbol names/kinds
-                    for (let i = 0; i < Math.min(5, flatParseSymbols.length); i++) {
-                        const sym = flatParseSymbols[i];
-                        if (sym) {
-                            connection.console.log(`[VALIDATE]   Parsed ${i}: name="${sym.name}", kind=${sym.kind}`);
-                        }
-                    }
-
-                    // Build a set of all parsed symbol names (including flattened) for faster lookup
-                    const parsedSymbolNames = new Set(flatParseSymbols.map(s => s.name));
-
-                    // For each parsed symbol (including nested), enrich with type info from introspection
-                    for (const parsedSym of flatParseSymbols) {
-                        // Skip symbols with null names
-                        if (!parsedSym.name) continue;
-
-                        const introspectedSym = introspectData.symbols.find(s => s.name === parsedSym.name);
-                        if (introspectedSym) {
-                            // Merge: position from parse, type from introspection
-                            legacySymbols.push({
-                                ...parsedSym,
-                                type: introspectedSym.type,
-                                modifiers: introspectedSym.modifiers,
-                            });
-                        } else {
-                            // Only in parse results
-                            legacySymbols.push(parsedSym);
-                        }
-                    }
-
-                    // Add any introspected symbols not in parse results
-                    // Check against flattened symbols to avoid missing class methods
-                    for (const introspectedSym of introspectData.symbols) {
-                        // Skip symbols with null names
-                        if (!introspectedSym.name) continue;
-
-                        const inParse = parsedSymbolNames.has(introspectedSym.name);
-                        if (!inParse) {
-                            connection.console.log(`[VALIDATE]   Adding introspected-only symbol: name="${introspectedSym.name}", kind=${introspectedSym.kind}`);
-                            legacySymbols.push({
-                                name: introspectedSym.name,
-                                kind: introspectedSym.kind as any,
-                                modifiers: introspectedSym.modifiers,
-                                type: introspectedSym.type,
-                            });
-                        }
-                    }
-                } else {
-                    // No parse results, use introspection only (no positions)
-                    for (const s of introspectData.symbols) {
-                        // Skip symbols with null names
-                        if (!s.name) continue;
-
-                        legacySymbols.push({
-                            name: s.name,
-                            kind: s.kind as import('@pike-lsp/pike-bridge').PikeSymbolKind,
-                            modifiers: s.modifiers,
-                            type: s.type,
-                        });
-                    }
-                }
-
-                // Resolve include/import dependencies for IntelliSense
-                let dependencies: import('../../core/types.js').DocumentDependencies | undefined;
-                if (services.includeResolver) {
-                    dependencies = await services.includeResolver.resolveDependencies(uri, legacySymbols);
-                }
-
-                // P.2 FIX: Store hierarchical symbols (not flattened) so classSymbol.children works
-                // Apply extractDeprecatedFromSymbols to preserve class hierarchy with deprecated flags
-                const hierarchicalSymbols = parseData && parseData.symbols.length > 0
-                    ? extractDeprecatedFromSymbols(parseData.symbols)
-                    : legacySymbols;
-
-                const cacheEntry: DocumentCacheEntry = {
-                    version,
-                    symbols: hierarchicalSymbols,  // Use hierarchical symbols with children preserved
-                    diagnostics,
-                    symbolPositions: await buildSymbolPositionIndex(text, legacySymbols, tokenizeData, bridge),
-                    // PERF-005: Build symbol name index for O(1) hover lookups
-                    symbolNames: buildSymbolNameIndex(hierarchicalSymbols),
-                    // INC-002: Store hashes for incremental change detection
-                    contentHash,
-                    lineHashes,
-                    // Store introspection for AutoDoc data including @deprecated tags
-                    introspection: introspectData.success ? introspectData : undefined,
-                };
-                if (dependencies) {
-                    cacheEntry.dependencies = dependencies;
-                if (introspectData.inherits) {
-                    cacheEntry.inherits = introspectData.inherits;
-                }
-                }
-
-                documentCache.set(uri, cacheEntry);
-                connection.console.log(`[VALIDATE] Cached document - total symbols: ${legacySymbols.length}, introspection success: ${introspectData.success}`);
-            } else if (parseData && parseData.symbols.length > 0) {
-                // Introspection failed, use parse results
-                // P.2 FIX: Extract @deprecated tags from source even when introspection fails
-                const symbolsWithDeprecated = extractDeprecatedFromSymbols(parseData.symbols);
-                connection.console.log(`[VALIDATE] Using parse result with ${symbolsWithDeprecated.length} symbols (with deprecated extraction)`);
-                // Log first few symbol names for debugging
-                for (let i = 0; i < Math.min(5, parseData.symbols.length); i++) {
-                    const sym = parseData.symbols[i];
-                    if (sym) {
-                        connection.console.log(`[VALIDATE]   Symbol ${i}: name="${sym.name}", kind=${sym.kind}`);
-                    }
-                }
-                // Resolve include/import dependencies for IntelliSense
-                let dependencies: import('../../core/types.js').DocumentDependencies | undefined;
-                if (services.includeResolver) {
-                    dependencies = await services.includeResolver.resolveDependencies(uri, symbolsWithDeprecated);
-                }
-
-                const cacheEntry: DocumentCacheEntry = {
-                    version,
-                    symbols: symbolsWithDeprecated,  // Use symbols with deprecated extracted from source
-                    diagnostics,
-                    symbolPositions: await buildSymbolPositionIndex(text, symbolsWithDeprecated, tokenizeData, bridge),
-                    // PERF-005: Build symbol name index for O(1) hover lookups
-                    symbolNames: buildSymbolNameIndex(symbolsWithDeprecated),
-                    // INC-002: Store hashes for incremental change detection
-                    contentHash,
-                    lineHashes,
-                };
-                if (dependencies) {
-                    cacheEntry.dependencies = dependencies;
-                if (introspectData.inherits) {
-                    cacheEntry.inherits = introspectData.inherits;
-                }
-                }
-
-                documentCache.set(uri, cacheEntry);
-                connection.console.log(`[VALIDATE] Cached document - symbols count: ${symbolsWithDeprecated.length}`);
-            } else {
-                connection.console.log(`[VALIDATE] No parse result available - features will not work`);
-            }
-
-            // Process diagnostics from unified analyze (includes syntax errors + uninitialized warnings)
-            if (diagnosticsData.diagnostics && diagnosticsData.diagnostics.length > 0) {
-                connection.console.log(`[VALIDATE] Found ${diagnosticsData.diagnostics.length} diagnostics from analyze`);
-                for (const diag of diagnosticsData.diagnostics) {
-                    if (diagnostics.length >= globalSettings.maxNumberOfProblems) {
-                        break;
-                    }
-                    // Determine severity: 'error' = 1 (Error), 'warning' = 2 (Warning), default = Error
-                    const severity = diag.severity === 'warning' ? 2 : 1;
-                    // Determine source based on diagnostic type
-                    const source = diag.variable ? 'pike-uninitialized' : 'pike';
-
-                    diagnostics.push({
-                        severity,
-                        range: {
-                            start: {
-                                line: Math.max(0, (diag.position?.line ?? 1) - 1),
-                                character: Math.max(0, diag.position?.character ?? 0),
-                            },
-                            end: {
-                                line: Math.max(0, (diag.position?.line ?? 1) - 1),
-                                character: Math.max(0, diag.position?.character ?? 0) + (diag.variable?.length ?? 10),
-                            },
-                        },
-                        message: diag.message,
-                        source,
-                    });
-                }
-            }
-
-            // --- Roxen diagnostics integration ---
-            try {
-                if (services.bridge?.bridge) {
-                    const roxenInfo = await detectRoxenModule(text, uri, services.bridge.bridge);
-                    if (roxenInfo && roxenInfo.is_roxen_module === 1) {
-                        const roxenDiags = await provideRoxenDiagnostics(uri, text, services.bridge.bridge, 0);
-                        diagnostics.push(...roxenDiags);
-                        connection.console.log(`[VALIDATE] Added ${roxenDiags.length} Roxen diagnostics`);
-                    }
-                }
-            } catch (err) {
-                connection.console.log(`[VALIDATE] Roxen diagnostics failed: ${err}`);
-            }
-            // --- End Roxen integration ---
-
-            // Send diagnostics
-            connection.sendDiagnostics({ uri, diagnostics });
-            connection.console.log(`[VALIDATE] Sent ${diagnostics.length} diagnostics`);
-
-            // Log memory stats periodically
-            const stats = typeDatabase.getMemoryStats();
-            if (stats.programCount % 10 === 0 && stats.programCount > 0) {
-                connection.console.log(
-                    `Type DB: ${stats.programCount} programs, ${stats.symbolCount} symbols, ` +
-                    `${(stats.totalBytes / 1024 / 1024).toFixed(1)}MB (${stats.utilizationPercent.toFixed(1)}%)`
-                );
-            }
-
-            connection.console.log(`[VALIDATE] ✓ Validation complete for ${uri}`);
-
-        } catch (err) {
-            connection.console.error(`[VALIDATE] ✗ Validation failed for ${uri}: ${err}`);
-        }
+    if (!bridge.isRunning()) {
+      connection.console.warn('[VALIDATE] Bridge not running, attempting to start...');
+      try {
+        await bridge.start();
+        log.debug('Bridge started successfully for validation', { uri });
+      } catch (err) {
+        connection.console.error(`[VALIDATE] Failed to start bridge: ${err}`);
+        return;
+      }
     }
 
-    // Configuration change handler
-    connection.onDidChangeConfiguration((change: DidChangeConfigurationParams) => {
-        const settings = change.settings as { pike?: Partial<PikeSettings> } | undefined;
-        globalSettings = {
-            ...defaultSettings,
-            ...(settings?.pike ?? {}),
+    const text = document.getText();
+
+    log.debug('Validating document', { uri, version, length: text.length });
+
+    // INC-002: Compute hashes for incremental change detection
+    // Use pre-computed hashes from classification if available
+    const contentHash = classification?.newHash ?? computeContentHash(text);
+    const lineHashes = classification?.newLineHashes ?? computeLineHashes(text);
+
+    // Extract filename from URI and decode URL encoding
+    const filename = decodeURIComponent(uri.replace(/^file:\/\//, ''));
+
+    try {
+      log.debug('Calling unified analyze', { filename, version });
+      // PERF-004: Include 'tokenize' to avoid separate findOccurrences call for symbolPositions
+      // Tokens are used to build symbolPositions index without additional IPC round-trip
+      // Single unified analyze call - replaces 3 separate calls (introspect, parse, analyzeUninitialized)
+      // Pass document version for cache key (open docs use LSP version, no stat overhead)
+      const analyzeResult = await bridge.analyze(
+        text,
+        ['parse', 'introspect', 'diagnostics', 'tokenize'],
+        filename,
+        version
+      );
+
+      // Log completion status
+      const hasParse = !!analyzeResult.result?.parse;
+      const hasIntrospect = !!analyzeResult.result?.introspect;
+      const hasDiagnostics = !!analyzeResult.result?.diagnostics;
+      log.debug('Analyze completed', { uri, hasParse, hasIntrospect, hasDiagnostics });
+
+      // Log cache hit/miss for debugging
+      if (analyzeResult._perf) {
+        const cacheHit = analyzeResult._perf.cache_hit;
+        log.debug('Analyze cache status', { uri, cacheHit });
+      }
+
+      // Log any partial failures
+      if (analyzeResult.failures && Object.keys(analyzeResult.failures).length > 0) {
+        log.debug('Analyze partial failures', {
+          uri,
+          failures: Object.keys(analyzeResult.failures),
+        });
+      }
+
+      // Extract results with fallback values for partial failures
+      const parseData = analyzeResult.failures?.parse
+        ? { symbols: [], diagnostics: [] }
+        : (analyzeResult.result?.parse ?? { symbols: [], diagnostics: [] });
+      const introspectData = analyzeResult.failures?.introspect
+        ? {
+            success: 0,
+            symbols: [],
+            functions: [],
+            variables: [],
+            classes: [],
+            inherits: [],
+            diagnostics: [],
+          }
+        : (analyzeResult.result?.introspect ?? {
+            success: 0,
+            symbols: [],
+            functions: [],
+            variables: [],
+            classes: [],
+            inherits: [],
+            diagnostics: [],
+          });
+      const diagnosticsData = analyzeResult.failures?.diagnostics
+        ? { diagnostics: [] }
+        : (analyzeResult.result?.diagnostics ?? { diagnostics: [] });
+      // PERF-004: Extract tokens for symbolPositions building
+      const tokenizeData = analyzeResult.result?.tokenize?.tokens;
+
+      // Convert Pike diagnostics to LSP diagnostics
+      const diagnostics: Diagnostic[] = [];
+
+      // Patterns for module resolution errors we should skip
+      const skipPatterns = [
+        /Index .* not present in module/i,
+        /Indexed module was:/i,
+        /Illegal program identifier/i,
+        /Not a valid program specifier/i,
+        /Failed to evaluate constant expression/i,
+      ];
+
+      const shouldSkipDiagnostic = (msg: string): boolean => {
+        return skipPatterns.some(pattern => pattern.test(msg));
+      };
+
+      // Process diagnostics from introspection
+      for (const pikeDiag of introspectData.diagnostics) {
+        if (diagnostics.length >= globalSettings.maxNumberOfProblems) {
+          break;
+        }
+        // Skip module resolution errors
+        if (shouldSkipDiagnostic(pikeDiag.message)) {
+          continue;
+        }
+
+        // Check if this diagnostic is about a deprecated symbol
+        const isDeprecated = isDeprecatedSymbolDiagnostic(pikeDiag.message, introspectData.symbols);
+
+        diagnostics.push(convertDiagnostic(pikeDiag, document, { deprecated: isDeprecated }));
+      }
+
+      // Update type database with introspected symbols if compilation succeeded
+      if (introspectData.success && introspectData.symbols.length > 0) {
+        // Convert introspected symbols to Maps
+        const symbolMap = new Map(introspectData.symbols.map(s => [s.name, s]));
+        const functionMap = new Map(introspectData.functions.map(s => [s.name, s]));
+        const variableMap = new Map(introspectData.variables.map(s => [s.name, s]));
+        const classMap = new Map(introspectData.classes.map(s => [s.name, s]));
+
+        // Estimate size
+        const sizeBytes = TypeDatabase.estimateProgramSize(symbolMap, introspectData.inherits);
+
+        const programInfo: CompiledProgramInfo = {
+          uri,
+          version,
+          symbols: symbolMap,
+          functions: functionMap,
+          variables: variableMap,
+          classes: classMap,
+          inherits: introspectData.inherits,
+          imports: new Set(),
+          compiledAt: Date.now(),
+          sizeBytes,
         };
 
-        // Revalidate all open documents
-        documents.all().forEach(validateDocumentDebounced);
-    });
+        typeDatabase.setProgram(programInfo);
 
-    // Handle document open - validate immediately without debouncing
-    documents.onDidOpen((event) => {
-        connection.console.log(`Document opened: ${event.document.uri}`);
-        const promise = validateDocument(event.document);
-        documentCache.setPending(event.document.uri, promise);
-        promise.catch(err => {
-            log.error('Document open validation failed', {
-                uri: event.document.uri,
-                error: err instanceof Error ? err.message : String(err)
-            });
+        // Also update legacy cache for backward compatibility
+        // Merge introspected symbols with parse symbols to get position info
+        const legacySymbols: import('@pike-lsp/pike-bridge').PikeSymbol[] = [];
+
+        log.debug('Introspection summary', {
+          uri,
+          success: introspectData.success,
+          symbols: introspectData.symbols.length,
+          functions: introspectData.functions?.length ?? 0,
+          classes: introspectData.classes?.length ?? 0,
         });
-    });
 
-    // Handle document changes - debounced validation (errors caught in setTimeout handler)
-    // INC-002: Capture change range for incremental parsing
-    documents.onDidChangeContent((change) => {
-        validateDocumentDebounced(change.document);
-    });
+        if (parseData && parseData.symbols.length > 0) {
+          // Flatten nested symbols to include class members
+          // This ensures get_n, get_e, set_random etc. are indexed
+          const flatParseSymbols = flattenSymbols(parseData.symbols);
 
-    // INC-002: Listen to raw LSP change notifications to capture change ranges
-    // This runs before TextDocuments processes the change, allowing us to capture the range
-    connection.onDidChangeTextDocument((params) => {
-        const contentChanges = params.contentChanges;
-        let changeRange: Range | undefined;
+          log.debug('Flattened parse symbols', {
+            uri,
+            originalSymbolCount: parseData.symbols.length,
+            flattenedSymbolCount: flatParseSymbols.length,
+          });
 
-        if (contentChanges.length > 0) {
-            const firstChange = contentChanges[0];
-            // If range is present, it's an incremental change
-            // If range is absent, it's a full document replacement
-            if (firstChange && 'range' in firstChange && firstChange.range) {
-                changeRange = firstChange.range;
+          // Build a set of all parsed symbol names (including flattened) for faster lookup
+          const parsedSymbolNames = new Set<string>();
+          for (const symbol of flatParseSymbols) {
+            if (symbol.name) {
+              parsedSymbolNames.add(symbol.name);
             }
-        }
+          }
 
-        // Store the change range for use in debounced validation
-        pendingChangeRanges.set(params.textDocument.uri, changeRange);
-    });
+          // For each parsed symbol (including nested), enrich with type info from introspection
+          for (const parsedSym of flatParseSymbols) {
+            // Skip symbols with null names
+            if (!parsedSym.name) continue;
 
-    // Handle document save - validate immediately without debouncing
-    documents.onDidSave((event) => {
-        const promise = validateDocument(event.document);
-        documentCache.setPending(event.document.uri, promise);
-        promise.catch(err => {
-            log.error('Document save validation failed', {
-                uri: event.document.uri,
-                error: err instanceof Error ? err.message : String(err)
+            const introspectedSym = introspectData.symbols.find(s => s.name === parsedSym.name);
+            if (introspectedSym) {
+              // Merge: position from parse, type from introspection
+              legacySymbols.push({
+                ...parsedSym,
+                type: introspectedSym.type,
+                modifiers: introspectedSym.modifiers,
+              });
+            } else {
+              // Only in parse results
+              legacySymbols.push(parsedSym);
+            }
+          }
+
+          // Add any introspected symbols not in parse results
+          // Check against flattened symbols to avoid missing class methods
+          for (const introspectedSym of introspectData.symbols) {
+            // Skip symbols with null names
+            if (!introspectedSym.name) continue;
+
+            const inParse = parsedSymbolNames.has(introspectedSym.name);
+            if (!inParse) {
+              legacySymbols.push({
+                name: introspectedSym.name,
+                kind: introspectedSym.kind as any,
+                modifiers: introspectedSym.modifiers,
+                type: introspectedSym.type,
+              });
+            }
+          }
+        } else {
+          // No parse results, use introspection only (no positions)
+          for (const s of introspectData.symbols) {
+            // Skip symbols with null names
+            if (!s.name) continue;
+
+            legacySymbols.push({
+              name: s.name,
+              kind: s.kind as import('@pike-lsp/pike-bridge').PikeSymbolKind,
+              modifiers: s.modifiers,
+              type: s.type,
             });
-        });
-    });
-
-    // Handle document close
-    documents.onDidClose((event) => {
-        // Clear cache for closed document
-        documentCache.delete(event.document.uri);
-
-        // Clear from type database
-        typeDatabase.removeProgram(event.document.uri);
-
-        // Clear from workspace index
-        workspaceIndex.removeDocument(event.document.uri);
-
-        // Clear any pending validation timer
-        const timer = validationTimers.get(event.document.uri);
-        if (timer) {
-            clearTimeout(timer);
-            validationTimers.delete(event.document.uri);
+          }
         }
 
-        // Clear diagnostics for closed document
-        connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
+        // Resolve include/import dependencies for IntelliSense
+        let dependencies: import('../../core/types.js').DocumentDependencies | undefined;
+        if (services.includeResolver) {
+          dependencies = await services.includeResolver.resolveDependencies(uri, legacySymbols);
+        }
+
+        // P.2 FIX: Store hierarchical symbols (not flattened) so classSymbol.children works
+        // Apply extractDeprecatedFromSymbols to preserve class hierarchy with deprecated flags
+        const hierarchicalSymbols =
+          parseData && parseData.symbols.length > 0
+            ? extractDeprecatedFromSymbols(parseData.symbols)
+            : legacySymbols;
+
+        const cacheEntry: DocumentCacheEntry = {
+          version,
+          symbols: hierarchicalSymbols, // Use hierarchical symbols with children preserved
+          diagnostics,
+          symbolPositions: await buildSymbolPositionIndex(
+            text,
+            legacySymbols,
+            tokenizeData,
+            bridge
+          ),
+          // PERF-005: Build symbol name index for O(1) hover lookups
+          symbolNames: buildSymbolNameIndex(hierarchicalSymbols),
+          // INC-002: Store hashes for incremental change detection
+          contentHash,
+          lineHashes,
+          // Store introspection for AutoDoc data including @deprecated tags
+          introspection: introspectData.success ? introspectData : undefined,
+        };
+        if (dependencies) {
+          cacheEntry.dependencies = dependencies;
+          if (introspectData.inherits) {
+            cacheEntry.inherits = introspectData.inherits;
+          }
+        }
+
+        documentCache.set(uri, cacheEntry);
+        log.debug('Cached document after introspection merge', {
+          uri,
+          symbolCount: legacySymbols.length,
+          introspectionSuccess: introspectData.success,
+        });
+      } else if (parseData && parseData.symbols.length > 0) {
+        // Introspection failed, use parse results
+        // P.2 FIX: Extract @deprecated tags from source even when introspection fails
+        const symbolsWithDeprecated = extractDeprecatedFromSymbols(parseData.symbols);
+        log.debug('Using parse result fallback', {
+          uri,
+          symbolCount: symbolsWithDeprecated.length,
+        });
+        // Resolve include/import dependencies for IntelliSense
+        let dependencies: import('../../core/types.js').DocumentDependencies | undefined;
+        if (services.includeResolver) {
+          dependencies = await services.includeResolver.resolveDependencies(
+            uri,
+            symbolsWithDeprecated
+          );
+        }
+
+        const cacheEntry: DocumentCacheEntry = {
+          version,
+          symbols: symbolsWithDeprecated, // Use symbols with deprecated extracted from source
+          diagnostics,
+          symbolPositions: await buildSymbolPositionIndex(
+            text,
+            symbolsWithDeprecated,
+            tokenizeData,
+            bridge
+          ),
+          // PERF-005: Build symbol name index for O(1) hover lookups
+          symbolNames: buildSymbolNameIndex(symbolsWithDeprecated),
+          // INC-002: Store hashes for incremental change detection
+          contentHash,
+          lineHashes,
+        };
+        if (dependencies) {
+          cacheEntry.dependencies = dependencies;
+          if (introspectData.inherits) {
+            cacheEntry.inherits = introspectData.inherits;
+          }
+        }
+
+        documentCache.set(uri, cacheEntry);
+        log.debug('Cached document from parse result', {
+          uri,
+          symbolCount: symbolsWithDeprecated.length,
+        });
+      } else {
+        log.debug('No parse result available for document', { uri });
+      }
+
+      // Process diagnostics from unified analyze (includes syntax errors + uninitialized warnings)
+      if (diagnosticsData.diagnostics && diagnosticsData.diagnostics.length > 0) {
+        log.debug('Analyze diagnostics extracted', {
+          uri,
+          count: diagnosticsData.diagnostics.length,
+        });
+        for (const diag of diagnosticsData.diagnostics) {
+          if (diagnostics.length >= globalSettings.maxNumberOfProblems) {
+            break;
+          }
+          // Determine severity: 'error' = 1 (Error), 'warning' = 2 (Warning), default = Error
+          const severity = diag.severity === 'warning' ? 2 : 1;
+          // Determine source based on diagnostic type
+          const source = diag.variable ? 'pike-uninitialized' : 'pike';
+
+          diagnostics.push({
+            severity,
+            range: {
+              start: {
+                line: Math.max(0, (diag.position?.line ?? 1) - 1),
+                character: Math.max(0, diag.position?.character ?? 0),
+              },
+              end: {
+                line: Math.max(0, (diag.position?.line ?? 1) - 1),
+                character:
+                  Math.max(0, diag.position?.character ?? 0) + (diag.variable?.length ?? 10),
+              },
+            },
+            message: diag.message,
+            source,
+          });
+        }
+      }
+
+      // --- Roxen diagnostics integration ---
+      try {
+        if (services.bridge?.bridge) {
+          const roxenInfo = await detectRoxenModule(text, uri, services.bridge.bridge);
+          if (roxenInfo && roxenInfo.is_roxen_module === 1) {
+            const roxenDiags = await provideRoxenDiagnostics(uri, text, services.bridge.bridge, 0);
+            diagnostics.push(...roxenDiags);
+            log.debug('Added Roxen diagnostics', { uri, count: roxenDiags.length });
+          }
+        }
+      } catch (err) {
+        log.debug('Roxen diagnostics failed', {
+          uri,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      // --- End Roxen integration ---
+
+      // Send diagnostics
+      connection.sendDiagnostics({ uri, diagnostics });
+      log.debug('Sent diagnostics', { uri, count: diagnostics.length });
+
+      // Log memory stats periodically
+      const stats = typeDatabase.getMemoryStats();
+      if (stats.programCount % 10 === 0 && stats.programCount > 0) {
+        log.debug('Type DB stats', {
+          programs: stats.programCount,
+          symbols: stats.symbolCount,
+          mb: Number((stats.totalBytes / 1024 / 1024).toFixed(1)),
+          utilizationPercent: Number(stats.utilizationPercent.toFixed(1)),
+        });
+      }
+
+      log.debug('Validation complete', { uri, version, diagnostics: diagnostics.length });
+    } catch (err) {
+      connection.console.error(`[VALIDATE] ✗ Validation failed for ${uri}: ${err}`);
+    }
+  }
+
+  // Configuration change handler
+  connection.onDidChangeConfiguration((change: DidChangeConfigurationParams) => {
+    const settings = change.settings as { pike?: Partial<PikeSettings> } | undefined;
+    globalSettings = {
+      ...defaultSettings,
+      ...(settings?.pike ?? {}),
+    };
+
+    // Revalidate all open documents
+    documents.all().forEach(validateDocumentDebounced);
+  });
+
+  // Handle document open - validate immediately without debouncing
+  documents.onDidOpen(event => {
+    log.debug('Document opened', { uri: event.document.uri });
+    const promise = validateDocument(event.document);
+    documentCache.setPending(event.document.uri, promise);
+    promise.catch(err => {
+      log.error('Document open validation failed', {
+        uri: event.document.uri,
+        error: err instanceof Error ? err.message : String(err),
+      });
     });
+  });
+
+  // Handle document changes - debounced validation (errors caught in setTimeout handler)
+  // INC-002: Capture change range for incremental parsing
+  documents.onDidChangeContent(change => {
+    validateDocumentDebounced(change.document);
+  });
+
+  // INC-002: Listen to raw LSP change notifications to capture change ranges
+  // This runs before TextDocuments processes the change, allowing us to capture the range
+  connection.onDidChangeTextDocument(params => {
+    const contentChanges = params.contentChanges;
+    let changeRange: Range | undefined;
+
+    if (contentChanges.length > 0) {
+      const firstChange = contentChanges[0];
+      // If range is present, it's an incremental change
+      // If range is absent, it's a full document replacement
+      if (firstChange && 'range' in firstChange && firstChange.range) {
+        changeRange = firstChange.range;
+      }
+    }
+
+    // Store the change range for use in debounced validation
+    pendingChangeRanges.set(params.textDocument.uri, changeRange);
+  });
+
+  // Handle document save - validate immediately without debouncing
+  documents.onDidSave(event => {
+    const promise = validateDocument(event.document);
+    documentCache.setPending(event.document.uri, promise);
+    promise.catch(err => {
+      log.error('Document save validation failed', {
+        uri: event.document.uri,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  });
+
+  // Handle document close
+  documents.onDidClose(event => {
+    // Clear cache for closed document
+    documentCache.delete(event.document.uri);
+
+    // Clear from type database
+    typeDatabase.removeProgram(event.document.uri);
+
+    // Clear from workspace index
+    workspaceIndex.removeDocument(event.document.uri);
+
+    // Clear any pending validation timer
+    const timer = validationTimers.get(event.document.uri);
+    if (timer) {
+      clearTimeout(timer);
+      validationTimers.delete(event.document.uri);
+    }
+
+    // Clear diagnostics for closed document
+    connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
+  });
 }

--- a/packages/pike-lsp-server/src/server.ts
+++ b/packages/pike-lsp-server/src/server.ts
@@ -8,13 +8,13 @@
  */
 
 import {
-    createConnection,
-    ProposedFeatures,
-    InitializeParams,
-    InitializeResult,
-    TextDocumentSyncKind,
-    TextDocuments,
-    DidChangeConfigurationNotification,
+  createConnection,
+  ProposedFeatures,
+  InitializeParams,
+  InitializeResult,
+  TextDocumentSyncKind,
+  TextDocuments,
+  DidChangeConfigurationNotification,
 } from 'vscode-languageserver/node.js';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import * as fsSync from 'fs';
@@ -35,16 +35,41 @@ import * as features from './features/index.js';
 
 // Semantic tokens legend (defined here for capabilities)
 const tokenTypes = [
-    'namespace', 'type', 'class', 'enum', 'interface',
-    'struct', 'typeParameter', 'parameter', 'variable', 'property',
-    'enumMember', 'event', 'function', 'method', 'macro',
-    'keyword', 'modifier', 'comment', 'string', 'number',
-    'regexp', 'operator', 'decorator'
+  'namespace',
+  'type',
+  'class',
+  'enum',
+  'interface',
+  'struct',
+  'typeParameter',
+  'parameter',
+  'variable',
+  'property',
+  'enumMember',
+  'event',
+  'function',
+  'method',
+  'macro',
+  'keyword',
+  'modifier',
+  'comment',
+  'string',
+  'number',
+  'regexp',
+  'operator',
+  'decorator',
 ];
 const tokenModifiers = [
-    'declaration', 'definition', 'readonly', 'static',
-    'deprecated', 'abstract', 'async', 'modification',
-    'documentation', 'defaultLibrary'
+  'declaration',
+  'definition',
+  'readonly',
+  'static',
+  'deprecated',
+  'abstract',
+  'async',
+  'modification',
+  'documentation',
+  'defaultLibrary',
 ];
 
 // ============================================================================
@@ -76,34 +101,34 @@ let includePaths: string[] = [];
 // ============================================================================
 
 function findAnalyzerPath(): string | undefined {
-    // Determine the current module's directory
-    // Handle both ESM (import.meta.url) and CJS (__filename) cases
-    let resolvedDirname: string;
+  // Determine the current module's directory
+  // Handle both ESM (import.meta.url) and CJS (__filename) cases
+  let resolvedDirname: string;
 
-    // Check if running in CJS mode (bundled with esbuild)
-    // __filename and __dirname are available in CJS but not in strict ESM
-     
-    if (typeof __filename !== 'undefined') {
-        resolvedDirname = path.dirname(__filename as string);
-    } else {
-        // ESM mode
-        const modulePath = fileURLToPath(import.meta.url);
-        resolvedDirname = path.dirname(modulePath);
+  // Check if running in CJS mode (bundled with esbuild)
+  // __filename and __dirname are available in CJS but not in strict ESM
+
+  if (typeof __filename !== 'undefined') {
+    resolvedDirname = path.dirname(__filename as string);
+  } else {
+    // ESM mode
+    const modulePath = fileURLToPath(import.meta.url);
+    resolvedDirname = path.dirname(modulePath);
+  }
+
+  const possiblePaths = [
+    path.resolve(resolvedDirname, 'pike-scripts', 'analyzer.pike'),
+    path.resolve(resolvedDirname, '..', '..', '..', 'pike-scripts', 'analyzer.pike'),
+    path.resolve(resolvedDirname, '..', 'pike-scripts', 'analyzer.pike'),
+  ];
+
+  for (const p of possiblePaths) {
+    if (fsSync.existsSync(p)) {
+      return p;
     }
+  }
 
-    const possiblePaths = [
-        path.resolve(resolvedDirname, 'pike-scripts', 'analyzer.pike'),
-        path.resolve(resolvedDirname, '..', '..', '..', 'pike-scripts', 'analyzer.pike'),
-        path.resolve(resolvedDirname, '..', 'pike-scripts', 'analyzer.pike'),
-    ];
-
-    for (const p of possiblePaths) {
-        if (fsSync.existsSync(p)) {
-            return p;
-        }
-    }
-
-    return undefined;
+  return undefined;
 }
 
 // NOTE: Document validation is handled by features/diagnostics.ts
@@ -114,19 +139,19 @@ function findAnalyzerPath(): string | undefined {
 // ============================================================================
 
 function createServices(): features.Services {
-    return {
-        bridge: bridgeManager, // Will be null initially, updated after onInitialize
-        logger,
-        documentCache,
-        moduleContext,
-        typeDatabase,
-        workspaceIndex,
-        stdlibIndex,
-        includeResolver, // Will be null initially, updated after onInitialize
-        workspaceScanner,
-        globalSettings,
-        includePaths,
-    };
+  return {
+    bridge: bridgeManager, // Will be null initially, updated after onInitialize
+    logger,
+    documentCache,
+    moduleContext,
+    typeDatabase,
+    workspaceIndex,
+    stdlibIndex,
+    includeResolver, // Will be null initially, updated after onInitialize
+    workspaceScanner,
+    globalSettings,
+    includePaths,
+  };
 }
 
 // ============================================================================
@@ -135,11 +160,11 @@ function createServices(): features.Services {
 
 const logFile = '/tmp/pike-lsp-debug.log';
 const log = (msg: string) => {
-    try {
-        fsSync.appendFileSync(logFile, `[${new Date().toISOString()}] ${msg}\n`);
-    } catch {
-        // Silently ignore logging failures to prevent cascading errors
-    }
+  try {
+    fsSync.appendFileSync(logFile, `[${new Date().toISOString()}] ${msg}\n`);
+  } catch {
+    // Silently ignore logging failures to prevent cascading errors
+  }
 };
 
 // ============================================================================
@@ -147,9 +172,8 @@ const log = (msg: string) => {
 // ============================================================================
 
 connection.onInitialize(async (params: InitializeParams): Promise<InitializeResult> => {
-
-    try {
-        log('onInitialize started');
+  try {
+    log('onInitialize started');
 
     // Do NOT override connection.console methods as it causes issues with 'this' context
     connection.console.log('Pike LSP Server initializing...');
@@ -157,49 +181,51 @@ connection.onInitialize(async (params: InitializeParams): Promise<InitializeResu
 
     const analyzerPath = findAnalyzerPath();
     if (analyzerPath) {
-        connection.console.log(`Found analyzer.pike at: ${analyzerPath}`);
-        log(`Found analyzer.pike at: ${analyzerPath}`);
+      connection.console.log(`Found analyzer.pike at: ${analyzerPath}`);
+      log(`Found analyzer.pike at: ${analyzerPath}`);
     } else {
-        connection.console.warn('Could not find analyzer.pike script');
-        log('Could not find analyzer.pike script');
+      connection.console.warn('Could not find analyzer.pike script');
+      log('Could not find analyzer.pike script');
     }
 
-    const initOptions = params.initializationOptions as {
-        pikePath?: string;
-        diagnosticDelay?: number;
-        analyzerPath?: string;
-        env?: NodeJS.ProcessEnv
-    } | undefined;
+    const initOptions = params.initializationOptions as
+      | {
+          pikePath?: string;
+          diagnosticDelay?: number;
+          analyzerPath?: string;
+          env?: NodeJS.ProcessEnv;
+        }
+      | undefined;
 
     log(`Init options: ${JSON.stringify(initOptions)}`);
 
     const bridgeOptions: { pikePath: string; analyzerPath?: string; env: NodeJS.ProcessEnv } = {
-        pikePath: initOptions?.pikePath ?? 'pike',
-        env: initOptions?.env ?? {},
+      pikePath: initOptions?.pikePath ?? 'pike',
+      env: initOptions?.env ?? {},
     };
 
     // Update global settings with initialization options
     if (initOptions?.diagnosticDelay !== undefined) {
-        globalSettings = {
-            ...globalSettings,
-            diagnosticDelay: initOptions.diagnosticDelay,
-        };
+      globalSettings = {
+        ...globalSettings,
+        diagnosticDelay: initOptions.diagnosticDelay,
+      };
     }
 
     includePaths = (initOptions?.env?.['PIKE_INCLUDE_PATH'] ?? '')
-        .split(':')
-        .map(entry => entry.trim())
-        .filter(entry => entry.length > 0);
+      .split(':')
+      .map(entry => entry.trim())
+      .filter(entry => entry.length > 0);
 
     // Use analyzer path from init options if provided, otherwise use findAnalyzerPath()
     if (initOptions?.analyzerPath) {
-        bridgeOptions.analyzerPath = initOptions.analyzerPath;
-        log(`Using analyzer path from init options: ${initOptions.analyzerPath}`);
+      bridgeOptions.analyzerPath = initOptions.analyzerPath;
+      log(`Using analyzer path from init options: ${initOptions.analyzerPath}`);
     } else if (analyzerPath) {
-        bridgeOptions.analyzerPath = analyzerPath;
-        log(`Using analyzer path from findAnalyzerPath: ${analyzerPath}`);
+      bridgeOptions.analyzerPath = analyzerPath;
+      log(`Using analyzer path from findAnalyzerPath: ${analyzerPath}`);
     } else {
-        log('WARNING: No analyzer path found, Pike bridge will try to auto-detect');
+      log('WARNING: No analyzer path found, Pike bridge will try to auto-detect');
     }
 
     log(`Initializing PikeBridge with options: ${JSON.stringify(bridgeOptions)}`);
@@ -211,265 +237,264 @@ connection.onInitialize(async (params: InitializeParams): Promise<InitializeResu
     (services as features.Services).bridge = bridgeManager;
     (services as features.Services).includeResolver = includeResolver;
 
-    try {
-        log('Checking Pike availability...');
-        const available = await bridge.checkPike();
-        log(`Pike available: ${available}`);
-
-        if (!available) {
-            connection.console.warn('Pike executable not found. Some features may not work.');
-            log('Pike executable not found');
-        } else {
-            stdlibIndex = new StdlibIndexManager(bridge);
-
-            // Update services.stdlibIndex now that stdlibIndex is initialized
-            (services as features.Services).stdlibIndex = stdlibIndex;
-
-            bridge.on('stderr', (msg: string) => {
-                connection.console.log(`[Pike] ${msg}`);
-                log(`[Pike STDERR] ${msg}`);
-            });
-
-            log('Starting bridge...');
-            await bridgeManager.start();
-            log('Bridge started successfully');
-            connection.console.log(`Pike bridge started (diagnosticDelay: ${globalSettings.diagnosticDelay}ms)`);
-        }
-    } catch (err) {
-        const errorMsg = `Failed to start Pike bridge: ${err}`;
-        connection.console.error(errorMsg);
-        log(errorMsg);
-    }
-
     workspaceIndex.setBridge(bridge);
     workspaceIndex.setErrorCallback((message, uri) => {
-        connection.console.warn(message + (uri ? ` (${uri})` : ''));
-        log(`[WorkspaceIndex Error] ${message} (${uri})`);
+      connection.console.warn(message + (uri ? ` (${uri})` : ''));
+      log(`[WorkspaceIndex Error] ${message} (${uri})`);
     });
 
     log('onInitialize completing');
 
     return {
-        capabilities: {
-                textDocumentSync: TextDocumentSyncKind.Incremental,
-                documentSymbolProvider: true,
-                workspaceSymbolProvider: true,
-                hoverProvider: true,
-                definitionProvider: true,
-                declarationProvider: true,
-                typeDefinitionProvider: true,
-                referencesProvider: true,
-                implementationProvider: true,
-                completionProvider: {
-                    resolveProvider: true,
-                    triggerCharacters: ['.', ':', '>', '-', '!'],
-                },
-                executeCommandProvider: {
-                    commands: ['pike.lsp.showDiagnostics'],
-                },
-                signatureHelpProvider: {
-                    triggerCharacters: ['(', ','],
-                },
-                renameProvider: {
-                    prepareProvider: true,
-                    // renameProvider is missing in capabilities interface for some reason, check version?
-                    // Wait, renameProvider can be boolean or RenameOptions.
-                },
-                callHierarchyProvider: true,
-                typeHierarchyProvider: true,
-                documentHighlightProvider: true,
-                foldingRangeProvider: true,
-                selectionRangeProvider: true,
-                inlayHintProvider: true,
-                semanticTokensProvider: {
-                    legend: { tokenTypes, tokenModifiers },
-                    full: { delta: true },
-                },
-                codeActionProvider: {
-                    codeActionKinds: [
-                        'quickfix',
-                        'source.organizeImports',
-                        'refactor',
-                        'refactor.extract',
-                        'refactor.rewrite',
-                    ],
-                },
-                documentFormattingProvider: true,
-                documentRangeFormattingProvider: true,
-                documentOnTypeFormattingProvider: {
-                    firstTriggerCharacter: ';',
-                    moreTriggerCharacter: ['}', '\n'],
-                },
-                documentLinkProvider: { resolveProvider: true },
-                codeLensProvider: { resolveProvider: true },
-                linkedEditingRangeProvider: true,
-                inlineValueProvider: true,
-                monikerProvider: true,
-                workspace: {
-                    workspaceFolders: {
-                        supported: true,
-                        changeNotifications: true,
-                    },
-                },
-            },
-        };
-    } catch (err) {
-        const errMsg = err instanceof Error ? err.stack : String(err);
-        connection.console.error(`CRITICAL ERROR in onInitialize: ${errMsg}. This error occurred during LSP server initialization. Check that Pike is installed correctly and the analyzer.pike script exists.`);
-        log(`CRITICAL ERROR in onInitialize: ${errMsg}`);
-        throw err;
-    }
+      capabilities: {
+        textDocumentSync: TextDocumentSyncKind.Incremental,
+        documentSymbolProvider: true,
+        workspaceSymbolProvider: true,
+        hoverProvider: true,
+        definitionProvider: true,
+        declarationProvider: true,
+        typeDefinitionProvider: true,
+        referencesProvider: true,
+        implementationProvider: true,
+        completionProvider: {
+          resolveProvider: true,
+          triggerCharacters: ['.', ':', '>', '-', '!'],
+        },
+        executeCommandProvider: {
+          commands: ['pike.lsp.showDiagnostics'],
+        },
+        signatureHelpProvider: {
+          triggerCharacters: ['(', ','],
+        },
+        renameProvider: {
+          prepareProvider: true,
+          // renameProvider is missing in capabilities interface for some reason, check version?
+          // Wait, renameProvider can be boolean or RenameOptions.
+        },
+        callHierarchyProvider: true,
+        typeHierarchyProvider: true,
+        documentHighlightProvider: true,
+        foldingRangeProvider: true,
+        selectionRangeProvider: true,
+        inlayHintProvider: true,
+        semanticTokensProvider: {
+          legend: { tokenTypes, tokenModifiers },
+          full: { delta: true },
+        },
+        codeActionProvider: {
+          codeActionKinds: [
+            'quickfix',
+            'source.organizeImports',
+            'refactor',
+            'refactor.extract',
+            'refactor.rewrite',
+          ],
+        },
+        documentFormattingProvider: true,
+        documentRangeFormattingProvider: true,
+        documentOnTypeFormattingProvider: {
+          firstTriggerCharacter: ';',
+          moreTriggerCharacter: ['}', '\n'],
+        },
+        documentLinkProvider: { resolveProvider: true },
+        codeLensProvider: { resolveProvider: true },
+        linkedEditingRangeProvider: true,
+        inlineValueProvider: true,
+        monikerProvider: true,
+        workspace: {
+          workspaceFolders: {
+            supported: true,
+            changeNotifications: true,
+          },
+        },
+      },
+    };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.stack : String(err);
+    connection.console.error(
+      `CRITICAL ERROR in onInitialize: ${errMsg}. This error occurred during LSP server initialization. Check that Pike is installed correctly and the analyzer.pike script exists.`
+    );
+    log(`CRITICAL ERROR in onInitialize: ${errMsg}`);
+    throw err;
+  }
 });
 
 connection.onInitialized(async () => {
-    connection.console.log('Pike LSP Server initialized');
-    connection.client.register(DidChangeConfigurationNotification.type, undefined);
+  connection.console.log('Pike LSP Server initialized');
+  connection.client.register(DidChangeConfigurationNotification.type, undefined);
 
-    // Register health check command handler
-    connection.onExecuteCommand(async (params) => {
-        if (params.command === 'pike.lsp.showDiagnostics') {
-            const health = await bridgeManager?.getHealth();
+  // Register health check command handler
+  connection.onExecuteCommand(async params => {
+    if (params.command === 'pike.lsp.showDiagnostics') {
+      const health = await bridgeManager?.getHealth();
 
-            // Format health status as readable output
-            const lines: string[] = [];
-            lines.push('=== Pike LSP Server Health ===');
-            lines.push('');
+      // Format health status as readable output
+      const lines: string[] = [];
+      lines.push('=== Pike LSP Server Health ===');
+      lines.push('');
 
-            if (health) {
-                const uptime = Math.floor(health.serverUptime / 1000);
-                const uptimeStr = uptime > 60
-                    ? `${Math.floor(uptime / 60)}m ${uptime % 60}s`
-                    : `${uptime}s`;
+      if (health) {
+        const uptime = Math.floor(health.serverUptime / 1000);
+        const uptimeStr =
+          uptime > 60 ? `${Math.floor(uptime / 60)}m ${uptime % 60}s` : `${uptime}s`;
 
-                lines.push(`Server Uptime: ${uptimeStr}`);
-                lines.push(`Bridge Connected: ${health.bridgeConnected ? 'YES' : 'NO'}`);
-                lines.push(`Pike PID: ${health.pikePid ?? 'N/A'}`);
-                lines.push(`Pike Version: ${health.pikeVersion?.version ?? 'Unknown'} (${health.pikeVersion?.display ?? 'N/A'})`);
-                lines.push(`Pike Path: ${health.pikeVersion?.pikePath ?? 'Unknown'}`);
+        lines.push(`Server Uptime: ${uptimeStr}`);
+        lines.push(`Bridge Connected: ${health.bridgeConnected ? 'YES' : 'NO'}`);
+        lines.push(`Pike PID: ${health.pikePid ?? 'N/A'}`);
+        lines.push(
+          `Pike Version: ${health.pikeVersion?.version ?? 'Unknown'} (${health.pikeVersion?.display ?? 'N/A'})`
+        );
+        lines.push(`Pike Path: ${health.pikeVersion?.pikePath ?? 'Unknown'}`);
 
-                if (health.recentErrors.length > 0) {
-                    lines.push('');
-                    lines.push('Recent Errors:');
-                    for (const err of health.recentErrors) {
-                        lines.push(`  - ${err}`);
-                    }
-                } else {
-                    lines.push('');
-                    lines.push('No recent errors');
-                }
-            } else {
-                lines.push('Health status unavailable');
-            }
-
-            lines.push('');
-            lines.push('============================');
-
-            return lines.join('\n');
+        if (health.recentErrors.length > 0) {
+          lines.push('');
+          lines.push('Recent Errors:');
+          for (const err of health.recentErrors) {
+            lines.push(`  - ${err}`);
+          }
+        } else {
+          lines.push('');
+          lines.push('No recent errors');
         }
+      } else {
+        lines.push('Health status unavailable');
+      }
 
-        return null;
-    });
+      lines.push('');
+      lines.push('============================');
 
-    // Keep workspace indices/scanner in sync when folders are added/removed.
-    if (typeof connection.workspace.onDidChangeWorkspaceFolders === 'function') {
-        connection.workspace.onDidChangeWorkspaceFolders(async (event) => {
-            const added = event.added ?? [];
-            const removed = event.removed ?? [];
-
-            if (added.length === 0 && removed.length === 0) {
-                return;
-            }
-
-            connection.console.log(`Workspace folders changed (+${added.length}, -${removed.length})`);
-
-            for (const folder of removed) {
-                const folderPath = decodeURIComponent(folder.uri.replace(/^file:\/\//, ''));
-                workspaceScanner.removeFolder(folderPath);
-            }
-
-            for (const folder of added) {
-                const folderPath = decodeURIComponent(folder.uri.replace(/^file:\/\//, ''));
-                try {
-                    await workspaceScanner.addFolder(folderPath);
-                } catch (err) {
-                    connection.console.warn(`Failed to scan added folder ${folder.name}: ${err}`);
-                }
-            }
-
-            // Rebuild workspace index from currently active folders.
-            workspaceIndex.clear();
-            const currentFolders = await connection.workspace.getWorkspaceFolders();
-            if (currentFolders && currentFolders.length > 0) {
-                for (const folder of currentFolders) {
-                    try {
-                        const folderPath = decodeURIComponent(folder.uri.replace(/^file:\/\//, ''));
-                        await workspaceIndex.indexDirectory(folderPath, true);
-                    } catch (err) {
-                        connection.console.warn(`Failed to re-index folder ${folder.name}: ${err}`);
-                    }
-                }
-            }
-        });
+      return lines.join('\n');
     }
 
-    if (bridgeManager?.bridge && !bridgeManager.bridge.isRunning()) {
+    return null;
+  });
+
+  // Keep workspace indices/scanner in sync when folders are added/removed.
+  if (typeof connection.workspace.onDidChangeWorkspaceFolders === 'function') {
+    connection.workspace.onDidChangeWorkspaceFolders(async event => {
+      const added = event.added ?? [];
+      const removed = event.removed ?? [];
+
+      if (added.length === 0 && removed.length === 0) {
+        return;
+      }
+
+      connection.console.log(`Workspace folders changed (+${added.length}, -${removed.length})`);
+
+      for (const folder of removed) {
+        const folderPath = decodeURIComponent(folder.uri.replace(/^file:\/\//, ''));
+        workspaceScanner.removeFolder(folderPath);
+      }
+
+      for (const folder of added) {
+        const folderPath = decodeURIComponent(folder.uri.replace(/^file:\/\//, ''));
         try {
-            await bridgeManager.bridge.start();
+          await workspaceScanner.addFolder(folderPath);
         } catch (err) {
-            connection.console.warn(`Failed to start bridge: ${err}`);
-            log(`Bridge start error: ${err}`);
+          connection.console.warn(`Failed to scan added folder ${folder.name}: ${err}`);
         }
-    }
+      }
 
-    // NOTE: Stdlib preloading disabled due to Pike subprocess crash when introspecting bootstrap modules (Stdio, String, Array, Mapping).
-    // These modules are used internally by the resolver and cannot be safely introspected.
-    // Modules will be loaded lazily on-demand instead.
-    connection.console.log('Stdlib preloading skipped - modules will load on-demand');
+      // Rebuild workspace index from currently active folders.
+      workspaceIndex.clear();
+      const currentFolders = await connection.workspace.getWorkspaceFolders();
+      if (currentFolders && currentFolders.length > 0) {
+        for (const folder of currentFolders) {
+          try {
+            const folderPath = decodeURIComponent(folder.uri.replace(/^file:\/\//, ''));
+            await workspaceIndex.indexDirectory(folderPath, true);
+          } catch (err) {
+            connection.console.warn(`Failed to re-index folder ${folder.name}: ${err}`);
+          }
+        }
+      }
+    });
+  }
 
-    // Index workspace
-    const workspaceFolders = await connection.workspace.getWorkspaceFolders();
-    if (workspaceFolders && workspaceFolders.length > 0 && bridgeManager?.bridge) {
-        connection.console.log(`Indexing ${workspaceFolders.length} workspace folder(s)...`);
-        setImmediate(async () => {
-            let _totalIndexed = 0;
-            const folderPaths: string[] = [];
-            for (const folder of workspaceFolders) {
-                try {
-                    const folderPath = decodeURIComponent(folder.uri.replace(/^file:\/\//, ''));
-                    folderPaths.push(folderPath);
-                    const indexed = await workspaceIndex.indexDirectory(folderPath, true);
-                    _totalIndexed += indexed;
-                    connection.console.log(`Indexed ${indexed} files from ${folder.name}`);
-                } catch (err) {
-                    connection.console.warn(`Failed to index folder ${folder.name}: ${err}`);
-                    log(`Indexing error for folder ${folder.name}: ${err}`);
-                }
-            }
-            const stats = workspaceIndex.getStats();
-            connection.console.log(`Workspace indexing complete: ${stats.documents} files, ${stats.symbols} symbols`);
+  if (bridgeManager?.bridge) {
+    try {
+      log('Checking Pike availability after initialize handshake');
+      const available = await bridgeManager.checkPike();
 
-            // Initialize workspace scanner for workspace-wide references
-            try {
-                await workspaceScanner.initialize(folderPaths);
-                const scannerStats = workspaceScanner.getStats();
-                connection.console.log(`Workspace scanner initialized: ${scannerStats.fileCount} Pike files found`);
-            } catch (err) {
-                connection.console.warn(`Failed to initialize workspace scanner: ${err}`);
-            }
+      if (!available) {
+        connection.console.warn('Pike executable not found. Some features may not work.');
+        log('Pike executable not found');
+      } else {
+        stdlibIndex = new StdlibIndexManager(bridgeManager.bridge);
+        (services as features.Services).stdlibIndex = stdlibIndex;
+
+        bridgeManager.on('stderr', (msg: unknown) => {
+          log(`[Pike STDERR] ${String(msg)}`);
         });
-    }
 
-    // NOTE: Open documents will be validated by diagnostics.ts onDidOpen handlers
-    // which are triggered when documents.listen(connection) starts
+        if (!bridgeManager.bridge.isRunning()) {
+          log('Starting bridge after initialize handshake...');
+          await bridgeManager.bridge.start();
+        }
+
+        connection.console.log(
+          `Pike bridge started (diagnosticDelay: ${globalSettings.diagnosticDelay}ms)`
+        );
+      }
+    } catch (err) {
+      connection.console.warn(`Failed to start bridge: ${err}`);
+      log(`Bridge start error: ${err}`);
+    }
+  }
+
+  // NOTE: Stdlib preloading disabled due to Pike subprocess crash when introspecting bootstrap modules (Stdio, String, Array, Mapping).
+  // These modules are used internally by the resolver and cannot be safely introspected.
+  // Modules will be loaded lazily on-demand instead.
+  connection.console.log('Stdlib preloading skipped - modules will load on-demand');
+
+  // Index workspace
+  const workspaceFolders = await connection.workspace.getWorkspaceFolders();
+  if (workspaceFolders && workspaceFolders.length > 0 && bridgeManager?.bridge) {
+    connection.console.log(`Indexing ${workspaceFolders.length} workspace folder(s)...`);
+    setImmediate(async () => {
+      let _totalIndexed = 0;
+      const folderPaths: string[] = [];
+      for (const folder of workspaceFolders) {
+        try {
+          const folderPath = decodeURIComponent(folder.uri.replace(/^file:\/\//, ''));
+          folderPaths.push(folderPath);
+          const indexed = await workspaceIndex.indexDirectory(folderPath, true);
+          _totalIndexed += indexed;
+          connection.console.log(`Indexed ${indexed} files from ${folder.name}`);
+        } catch (err) {
+          connection.console.warn(`Failed to index folder ${folder.name}: ${err}`);
+          log(`Indexing error for folder ${folder.name}: ${err}`);
+        }
+      }
+      const stats = workspaceIndex.getStats();
+      connection.console.log(
+        `Workspace indexing complete: ${stats.documents} files, ${stats.symbols} symbols`
+      );
+
+      // Initialize workspace scanner for workspace-wide references
+      try {
+        await workspaceScanner.initialize(folderPaths);
+        const scannerStats = workspaceScanner.getStats();
+        connection.console.log(
+          `Workspace scanner initialized: ${scannerStats.fileCount} Pike files found`
+        );
+      } catch (err) {
+        connection.console.warn(`Failed to initialize workspace scanner: ${err}`);
+      }
+    });
+  }
+
+  // NOTE: Open documents will be validated by diagnostics.ts onDidOpen handlers
+  // which are triggered when documents.listen(connection) starts
 });
 
-connection.onDidChangeConfiguration((change) => {
-    const settings = change.settings as { pike?: Partial<PikeSettings> } | undefined;
-    globalSettings = {
-        ...defaultSettings,
-        ...(settings?.pike ?? {}),
-    };
-    // NOTE: Document revalidation is handled by diagnostics.ts onDidChangeConfiguration
+connection.onDidChangeConfiguration(change => {
+  const settings = change.settings as { pike?: Partial<PikeSettings> } | undefined;
+  globalSettings = {
+    ...defaultSettings,
+    ...(settings?.pike ?? {}),
+  };
+  // NOTE: Document revalidation is handled by diagnostics.ts onDidChangeConfiguration
 });
 
 // ============================================================================
@@ -496,14 +521,14 @@ features.registerFileWatcher(connection, services, documents);
 // ============================================================================
 
 connection.onShutdown(async () => {
-    connection.console.log('Pike LSP Server shutting down...');
-    await bridgeManager?.stop();
+  connection.console.log('Pike LSP Server shutting down...');
+  await bridgeManager?.stop();
 });
 
 connection.onExit(() => {
-    bridgeManager?.stop().catch(() => {
-        // Ignore errors during exit
-    });
+  bridgeManager?.stop().catch(() => {
+    // Ignore errors during exit
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
This PR improves perceived LSP responsiveness by removing bridge startup work from the `initialize` handshake and reducing hot-path diagnostics logging while typing. The server now returns capabilities faster and performs bridge warmup after initialization, while validation details are routed through debug logger paths instead of client output spam.

## Linked Issue
closes #675

## Root Cause
Startup latency came from awaiting bridge availability/startup directly in `onInitialize`, which delays LSP handshake completion. Edit clunkiness came from frequent `connection.console.log(...)` calls in diagnostics debounce/validate paths, causing high output churn during normal typing.

## Changes
- `packages/pike-lsp-server/src/server.ts`: moved bridge availability check/start sequence out of `onInitialize` into `onInitialized`, so capability negotiation is no longer blocked by Pike bridge warmup.
- `packages/pike-lsp-server/src/features/diagnostics/index.ts`: replaced high-frequency connection console logging in edit/validate paths with `Logger.debug(...)` events; preserved warning/error console output for actionable failures.
- `packages/pike-lsp-server/src/features/diagnostics/index.ts`: tightened parsed-symbol-name set construction to avoid diagnostics hinting and keep the hot path straightforward.

## Verification
lsp diagnostics (`server.ts`) -> PASS (no diagnostics)
lsp diagnostics (`features/diagnostics/index.ts`) -> PASS (no diagnostics)
`bun run typecheck` -> PASS
`bun run --filter @pike-lsp/pike-lsp-server test` -> PASS (2916 pass, 4 skip, 0 fail)
`bun run build` -> PASS

## Notes for Reviewer
A measurable code-level reduction is included: hot-path `connection.console.log(...)` usage in diagnostics dropped from 29 call sites to 0, and `onInitialize` no longer awaits bridge startup work.