### PR TITLE
fix: harden issue auto-close and merged-branch cleanup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,35 @@
 ## Summary
+
 <!-- Required: What does this PR do? 1-3 sentences. Not a list — write prose.
      Bad: "fixes stuff"
      Good: "Fixes hover type resolution for inherited Pike methods by correcting
             the symbol table lookup order in packages/pike-lsp-server/src/hover.ts" -->
 
 ## Linked Issue
-<!-- Required: must be Closes #N, Fixes #N, or Resolves #N -->
-Closes #
+
+<!-- Required: must include at least one closing keyword line, e.g. closes #123 -->
+
+closes #
 
 ## Root Cause
+
 <!-- Required: What was the underlying cause of the problem?
      Agents: do not skip this. It proves you understood the issue, not just patched it. -->
 
 ## Changes
+
 <!-- Required: One bullet per file changed. Explain WHY not just WHAT.
      Bad: "- hover.ts: fixed bug"
      Good: "- packages/pike-lsp-server/src/hover.ts: corrected symbol lookup to
               check inherited scope chain before returning null" -->
 
 ## Verification
+
 <!-- Required: What did you run locally and what was the result?
      List the actual commands and their outcomes.
      CI will verify independently — this is for human reviewers to understand
      what you checked and how. -->
 
 ## Notes for Reviewer
+
 <!-- Optional: Anything unusual, tradeoffs made, follow-up issues created, etc. -->

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -1,27 +1,35 @@
 name: Cleanup Merged Branches
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   cleanup:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Delete merged branch
-        run: |
-          # Get the head branch name
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          REPO_NAME="${{ github.event.pull_request.head.repo.full_name }}"
+      - name: Delete merged branch ref
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = context.payload.pull_request.head.ref;
+            const ref = `heads/${branch}`;
 
-          # Only delete if it's not a fork
-          if [ "$REPO_NAME" == "${{ github.repository }}" ]; then
-            echo "Deleting branch: $BRANCH_NAME"
-            git push origin --delete "$BRANCH_NAME"
-          else
-            echo "Skipping delete for fork branch: $BRANCH_NAME"
-          fi
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref });
+              core.info(`Deleted branch ref: ${ref}`);
+            } catch (error) {
+              const status = error?.status;
+              if (status === 422 || status === 404) {
+                core.info(`Branch already missing or cannot be deleted: ${ref}`);
+                return;
+              }
+              throw error;
+            }

--- a/.github/workflows/close-issue-on-merge.yml
+++ b/.github/workflows/close-issue-on-merge.yml
@@ -1,46 +1,59 @@
 name: Close Linked Issue on Merge
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
     branches: [main]
 
 permissions:
   issues: write
-  contents: read
+  pull-requests: read
 
 jobs:
   close-issue:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - name: Close linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const text = `${pr.title || ''}\n${pr.body || ''}`;
+            const re = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
 
-      - name: Close linked issue
-        run: |
-          ISSUE=$(gh pr view ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --json body --jq '.body' \
-            | grep -oE '(closes|fixes|resolves) #[0-9]+' \
-            | grep -oE '[0-9]+' \
-            | head -1)
+            const issueNumbers = new Set();
+            let match;
+            while ((match = re.exec(text)) !== null) {
+              issueNumbers.add(Number(match[1]));
+            }
 
-          if [ -z "$ISSUE" ]; then
-            echo "No linked issue found, skipping"
-            exit 0
-          fi
+            if (issueNumbers.size === 0) {
+              core.info(`PR #${pr.number}: no linked issues found.`);
+              return;
+            }
 
-          STATE=$(gh issue view $ISSUE \
-            --repo ${{ github.repository }} \
-            --json state --jq '.state')
+            for (const issueNumber of issueNumbers) {
+              const issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+              if (issue.data.state === 'closed') {
+                core.info(`Issue #${issueNumber} already closed.`);
+                continue;
+              }
 
-          if [ "$STATE" = "CLOSED" ]; then
-            echo "Issue #$ISSUE already closed"
-            exit 0
-          fi
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: `Closed automatically: PR #${pr.number} merged.`,
+              });
 
-          gh issue close $ISSUE \
-            --repo ${{ github.repository }} \
-            --comment "Closed automatically: PR #${{ github.event.pull_request.number }} merged."
-          echo "Closed issue #$ISSUE"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                state: 'closed',
+              });
+
+              core.info(`Closed issue #${issueNumber}.`);
+            }

--- a/.github/workflows/enforce-acceptance-criteria.yml
+++ b/.github/workflows/enforce-acceptance-criteria.yml
@@ -59,11 +59,11 @@ jobs:
             }
 
             // Must have linked issue
-            const hasLinkedIssue = /(closes|fixes|resolves)\s*#[0-9]+/.test(body);
+            const hasLinkedIssue = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*#[0-9]+\b/i.test(body);
             if (!hasLinkedIssue) {
               errors.push(
                 '- Missing linked issue.\n' +
-                '  Add one of (lowercase): closes #N, fixes #N, resolves #N'
+                '  Add one of: closes #N, fixes #N, resolves #N'
               );
             }
 


### PR DESCRIPTION
## Summary
This PR makes merge-time automation deterministic for both linked-issue closure and merged-branch cleanup. It replaces brittle shell parsing with GitHub API-based workflow steps, broadens accepted closing-keyword variants, and aligns the PR template wording to the enforced rules.

## Linked Issue
closes #677

## Root Cause
The previous merge automation relied on fragile shell/grep behavior and workflow trigger combinations that were not reliably running for merged PR events. In addition, keyword parsing/validation was narrower than actual contributor usage, which made auto-close behavior inconsistent in practice.

## Changes
- `.github/workflows/close-issue-on-merge.yml`: switched merge-close handling to robust `actions/github-script` logic that extracts keyword-linked issue IDs case-insensitively and closes all referenced open issues.
- `.github/workflows/cleanup-branches.yml`: switched branch cleanup to `pull_request_target` close event with same-repo guard and GitHub ref deletion via API, avoiding push/delete shell fragility.
- `.github/workflows/enforce-acceptance-criteria.yml`: expanded linked-issue validation regex to accept common close/fix/resolve variants, case-insensitive.
- `.github/PULL_REQUEST_TEMPLATE.md`: updated linked-issue guidance/example to the canonical lowercase `closes #` form.

## Verification
`bun run lint` -> PASS (0 errors; existing warnings in `packages/vscode-pike/__mocks__/vscode.js`)
`bun run build` -> PASS
manual workflow logic sanity-check (regex/API path review) -> PASS

## Notes for Reviewer
Repo-level setting `deleteBranchOnMerge` was also enabled (`true`) to provide a native fallback for merged branch deletion in addition to workflow-based cleanup.