### PR TITLE
perf(ci): cache Pike 8.1116 install path in test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
 
     strategy:
       matrix:
-        pike-version: ["8.1116", "latest"]
+        pike-version: ['8.1116', 'latest']
       fail-fast: false
 
     continue-on-error: ${{ matrix.pike-version == 'latest' }}
@@ -114,44 +114,54 @@ jobs:
           restore-keys: |
             apt-${{ runner.os }}-pike-
 
+      - name: Cache Pike 8.1116 toolchain
+        if: matrix.pike-version == '8.1116'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pike/8.1116
+            ~/.cache/pike/distfiles
+          key: pike-toolchain-${{ runner.os }}-8.1116-v1
+
       - name: Install Pike ${{ matrix.pike-version }}
         run: |
-          set -x
+          set -euxo pipefail
           if [ "${{ matrix.pike-version }}" = "8.1116" ]; then
-            # Install Pike 8.1116 from official repository
-            # Try downloading from Pike's build server if available
             PIKE_VERSION="8.1116"
+            PIKE_PREFIX="$HOME/.cache/pike/${PIKE_VERSION}"
+            PIKE_DISTDIR="$HOME/.cache/pike/distfiles"
+            PIKE_ARCHIVE="$PIKE_DISTDIR/pike-${PIKE_VERSION}.tar.gz"
             PIKE_URL="https://pike.lysator.liu.se/builds/pike-${PIKE_VERSION}.tar.gz"
 
-            # Try apt repository first (may not have 8.1116)
-            sudo apt-get update
-
-            # Check if pike8.1116 is available via apt
-            if apt-cache show pike${PIKE_VERSION} >/dev/null 2>&1; then
-              sudo apt-get install -y pike${PIKE_VERSION}
-            else
-              # Build from source
-              sudo apt-get install -y build-essential libgmp-dev bison flex make
-              cd /tmp
-              wget "$PIKE_URL" -O pike.tar.gz || {
-                echo "Pike ${PIKE_VERSION} not found at ${PIKE_URL}"
-                echo "Falling back to pike8.0 from apt"
-                sudo apt-get install -y pike8.0
-                rm -f pike.tar.gz
-              }
-              if [ -f pike.tar.gz ]; then
-                tar -xzf pike.tar.gz
-                cd "pike-${PIKE_VERSION}"
-                make
-                sudo make install
-              fi
+            if [ -x "$PIKE_PREFIX/bin/pike" ]; then
+              echo "$PIKE_PREFIX/bin" >> "$GITHUB_PATH"
+              exit 0
             fi
-          else
-            # Install latest Pike from repository
+
+            mkdir -p "$PIKE_PREFIX" "$PIKE_DISTDIR"
             sudo apt-get update
-            # Try to get latest from pike PPA or build from latest
+            sudo apt-get install -y build-essential libgmp-dev bison flex make wget
+
+            if [ ! -f "$PIKE_ARCHIVE" ]; then
+              wget "$PIKE_URL" -O "$PIKE_ARCHIVE" || {
+                echo "Pike ${PIKE_VERSION} source archive unavailable, falling back to pike8.0"
+                sudo apt-get install -y pike8.0
+                exit 0
+              }
+            fi
+
+            BUILD_DIR="/tmp/pike-${PIKE_VERSION}-build"
+            rm -rf "$BUILD_DIR"
+            mkdir -p "$BUILD_DIR"
+            tar -xzf "$PIKE_ARCHIVE" -C "$BUILD_DIR" --strip-components=1
+            cd "$BUILD_DIR"
+            ./configure --prefix="$PIKE_PREFIX"
+            make -j"$(nproc)"
+            make install
+            echo "$PIKE_PREFIX/bin" >> "$GITHUB_PATH"
+          else
+            sudo apt-get update
             sudo apt-get install -y pike8.0 || {
-              # If pike8.0 fails, try to build latest from git
               sudo apt-get install -y build-essential libgmp-dev bison flex make git
               cd /tmp
               git clone https://github.com/pike-lang/pike.git


### PR DESCRIPTION
## Summary
This PR reduces repeated CI setup cost for Pike cross-version testing by caching the Pike 8.1116 toolchain and source archive in the `pike-test` matrix job. It keeps both matrix legs (`8.1116`, `latest`) on PRs while avoiding redundant rebuild/download work after cache warm-up.

## Linked Issue
closes #679

## Root Cause
The previous `8.1116` install path rebuilt or re-downloaded artifacts repeatedly because only apt archives were cached, not the compiled Pike toolchain prefix. This made setup time variable and unnecessarily expensive across runs.

## Changes
- `.github/workflows/test.yml`: added a dedicated `actions/cache` step for `~/.cache/pike/8.1116` and `~/.cache/pike/distfiles` in the `pike-test` job.
- `.github/workflows/test.yml`: updated `Install Pike` logic for `8.1116` to short-circuit on cached `bin/pike`, otherwise build once into cached prefix via `./configure --prefix=... && make install`.
- `.github/workflows/test.yml`: retained existing fallback to `pike8.0` apt install when the 8.1116 source archive is unavailable, preserving resilience.

## Verification
`bun run build` -> PASS
`bun run lint` -> PASS (0 errors, existing repo warnings only)
pre-commit hook (`Checking for anti-patterns`) -> PASS
pre-push hook (`TypeScript build check` and `Pike compile check`) -> PASS

## Notes for Reviewer
Expected impact is lower and more stable setup time for `pike-test (8.1116)` after first cache warm-up; this keeps PR matrix coverage intact instead of skipping the 8.1116 leg.