### PR TITLE
fix(vscode-e2e): resolve command id collision blocking LSP startup

### DIFF
--- a/packages/pike-lsp-server/src/server.ts
+++ b/packages/pike-lsp-server/src/server.ts
@@ -261,7 +261,7 @@ connection.onInitialize(async (params: InitializeParams): Promise<InitializeResu
           triggerCharacters: ['.', ':', '>', '-', '!'],
         },
         executeCommandProvider: {
-          commands: ['pike.lsp.showDiagnostics'],
+          commands: ['pike.lsp.serverHealth'],
         },
         signatureHelpProvider: {
           triggerCharacters: ['(', ','],
@@ -325,7 +325,7 @@ connection.onInitialized(async () => {
 
   // Register health check command handler
   connection.onExecuteCommand(async params => {
-    if (params.command === 'pike.lsp.showDiagnostics') {
+    if (params.command === 'pike.lsp.serverHealth') {
       const health = await bridgeManager?.getHealth();
 
       // Format health status as readable output


### PR DESCRIPTION
## Summary
- Rename the server execute-command id from `pike.lsp.showDiagnostics` to `pike.lsp.serverHealth` to avoid colliding with the extension's local command registration.
- Keep diagnostics command behavior in the extension unchanged while preserving server health-command functionality under a dedicated id.
- Restore language client startup so symbol-dependent E2E features return valid results again.

## Linked Issues
- closes #685
- closes #686

## Verification
- `cd packages/vscode-pike && bun run test:e2e -- --grep \"Document symbols returns valid symbol tree\"` -> PASS
- `cd packages/vscode-pike && bun run test:e2e -- --grep \"P.2\"` -> PASS
- `bun run build` -> PASS
- `cd packages/vscode-pike && bun run test:e2e` -> 113 passing, 10 pending, 4 failing (existing include/import/inherit navigation failures unrelated to this command collision)