### PR TITLE
Feature/start lsp for restored files

### DIFF
--- a/packages/vscode-pike/src/constants.ts
+++ b/packages/vscode-pike/src/constants.ts
@@ -20,3 +20,12 @@ export const DEFAULT_DIAGNOSTIC_DELAY = 500;
  * Used when launching the LSP server in debug mode.
  */
 export const DEBUG_PORT = 6009;
+
+/**
+ * Language IDs handled by the Pike LSP.
+ *
+ * @remarks
+ * Must match the language IDs declared in package.json contributes.languages.
+ */
+export const PIKE_LANGUAGE_IDS = ['pike', 'rxml', 'rjs'] as const;
+


### PR DESCRIPTION
## Summary

The LSP does not attach to any files already open when the extension loads (such as when vscode restores the session at startup). This requires any such files to be closed then reopened in order for the language server to attach to them.

## Linked Issue

closes #716

## Root Cause

The extension waits for a pike file to be opened before starting. VSCode sends onDidOpenTextDocument events for open files, however this happens before the extension's activate() is called. 

## Changes

On activation, we check for any open pike files and if any exist, make sure the LSP server is running.

Also, as a minor cleanup task, we extract the documentIds this extension supports into a constant so that they're defined in one place, and then use that constant.

## Verification

<!-- Required: What did you run locally and what was the result?
     List the actual commands and their outcomes.
     CI will verify independently — this is for human reviewers to understand
     what you checked and how. -->

## Notes for Reviewer

<!-- Optional: Anything unusual, tradeoffs made, follow-up issues created, etc. -->
