### PR TITLE
fix: sanitize path logs and improve completion dependency behavior

### DIFF
--- a/packages/core/src/logging.ts
+++ b/packages/core/src/logging.ts
@@ -21,6 +21,70 @@ export enum LogLevel {
   TRACE = 5,
 }
 
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getSensitivePathPrefixes(): string[] {
+  const prefixes = new Set<string>();
+  const home = process.env['HOME'];
+  const userProfile = process.env['USERPROFILE'];
+
+  if (home) {
+    prefixes.add(home.replace(/\\/g, '/'));
+  }
+  if (userProfile) {
+    prefixes.add(userProfile.replace(/\\/g, '/'));
+  }
+
+  return [...prefixes].sort((a, b) => b.length - a.length);
+}
+
+const sensitivePathPrefixes = getSensitivePathPrefixes();
+
+export function anonymizeSensitivePaths(value: string): string {
+  if (!value || sensitivePathPrefixes.length === 0) {
+    return value;
+  }
+
+  let output = value;
+  for (const prefix of sensitivePathPrefixes) {
+    if (!prefix) {
+      continue;
+    }
+    const normalizedPrefix = prefix.replace(/\\/g, '/');
+    const exact = new RegExp(escapeRegex(normalizedPrefix), 'g');
+    output = output.replace(exact, '$HOME');
+
+    const windowsPrefix = prefix.replace(/\//g, '\\\\');
+    const windowsExact = new RegExp(escapeRegex(windowsPrefix), 'g');
+    output = output.replace(windowsExact, '$HOME');
+  }
+
+  return output;
+}
+
+function sanitizeContextValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return anonymizeSensitivePaths(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => sanitizeContextValue(item));
+  }
+
+  if (value && typeof value === 'object') {
+    const input = value as Record<string, unknown>;
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(input)) {
+      sanitized[key] = sanitizeContextValue(entry);
+    }
+    return sanitized;
+  }
+
+  return value;
+}
+
 /**
  * Logger class with component-based namespacing.
  *
@@ -68,8 +132,10 @@ export class Logger {
     }
 
     const timestamp = new Date().toISOString();
-    const contextStr = context ? ` ${JSON.stringify(context)}` : '';
-    const output = `[${timestamp}][${levelName}][${this.component}] ${message}${contextStr}`;
+    const sanitizedMessage = anonymizeSensitivePaths(message);
+    const sanitizedContext = context ? sanitizeContextValue(context) : undefined;
+    const contextStr = sanitizedContext ? ` ${JSON.stringify(sanitizedContext)}` : '';
+    const output = `[${timestamp}][${levelName}][${this.component}] ${sanitizedMessage}${contextStr}`;
 
     // All logs go to stderr (console.error) where LSP servers emit diagnostics
     console.error(output);

--- a/packages/pike-lsp-server/src/features/editing/completion.ts
+++ b/packages/pike-lsp-server/src/features/editing/completion.ts
@@ -62,6 +62,22 @@ export function registerCompletionHandlers(
     };
   }
 
+  function dedupeCompletionItems(items: CompletionItem[]): CompletionItem[] {
+    const seen = new Set<string>();
+    const deduped: CompletionItem[] = [];
+
+    for (const item of items) {
+      const key = `${item.label}:${item.kind ?? 0}:${item.detail ?? ''}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      deduped.push(item);
+    }
+
+    return deduped;
+  }
+
   /**
    * Parse completion trigger context from LSP params
    */
@@ -126,6 +142,7 @@ export function registerCompletionHandlers(
     const bridge = services.bridge;
     const uri = params.textDocument.uri;
     const document = documents.get(uri);
+    const cached = documentCache.get(uri);
 
     if (!document) {
       logger.debug('Completion request - no document found', { uri });
@@ -196,7 +213,136 @@ export function registerCompletionHandlers(
 
         clearInFlight();
         if (scheduledItems && scheduledItems.length > 0) {
-          return toCompletionList(scheduledItems);
+          const completions = [...scheduledItems];
+          const text = document.getText();
+          const offset = document.offsetAt(params.position);
+          const prefix = getWordAtPosition(text, offset);
+          const prefixLower = prefix.toLowerCase();
+          const lineStart = text.lastIndexOf('\n', offset - 1) + 1;
+          const lineText = text.slice(lineStart, offset);
+          const completionContext = getCompletionContext(lineText);
+
+          if (cached) {
+            const existingNames = new Set<string>();
+            for (const item of completions) {
+              existingNames.add(item.label);
+            }
+            for (const symbol of cached.symbols) {
+              if (symbol.name) {
+                existingNames.add(symbol.name);
+              }
+            }
+
+            if (services.includeResolver && cached.dependencies?.includes) {
+              for (const include of cached.dependencies.includes) {
+                for (const symbol of include.symbols) {
+                  if (!symbol.name || existingNames.has(symbol.name)) continue;
+                  if (!prefix || symbol.name.toLowerCase().startsWith(prefixLower)) {
+                    const item = buildCompletionItem(
+                      symbol.name,
+                      symbol,
+                      `From ${include.originalPath}`,
+                      undefined,
+                      completionContext
+                    );
+                    item.data = { uri: include.resolvedPath, name: symbol.name };
+                    completions.push(item);
+                    existingNames.add(symbol.name);
+                  }
+                }
+              }
+            }
+
+            if (cached.dependencies?.imports) {
+              for (const imp of cached.dependencies.imports) {
+                if (imp.isStdlib && services.stdlibIndex) {
+                  try {
+                    const moduleInfo = await services.stdlibIndex.getModule(imp.modulePath);
+                    if (moduleInfo?.symbols) {
+                      for (const [name, symbol] of moduleInfo.symbols) {
+                        if (existingNames.has(name)) continue;
+                        if (!prefix || name.toLowerCase().startsWith(prefixLower)) {
+                          completions.push(
+                            buildCompletionItem(
+                              name,
+                              symbol,
+                              `From ${imp.modulePath}`,
+                              undefined,
+                              completionContext
+                            )
+                          );
+                          existingNames.add(name);
+                        }
+                      }
+                    }
+                  } catch (err) {
+                    logger.debug('Failed to get stdlib import symbols', {
+                      modulePath: imp.modulePath,
+                      error: err instanceof Error ? err.message : String(err),
+                    });
+                  }
+                }
+
+                if (!imp.isStdlib && imp.symbols) {
+                  for (const symbol of imp.symbols) {
+                    if (!symbol.name || existingNames.has(symbol.name)) continue;
+                    if (!prefix || symbol.name.toLowerCase().startsWith(prefixLower)) {
+                      completions.push(
+                        buildCompletionItem(
+                          symbol.name,
+                          symbol,
+                          `From ${imp.modulePath}`,
+                          undefined,
+                          completionContext
+                        )
+                      );
+                      existingNames.add(symbol.name);
+                    }
+                  }
+                }
+              }
+            }
+
+            const shouldFetchWaterfall =
+              prefixLower.length > 0 &&
+              !!(cached.dependencies?.includes?.length || cached.dependencies?.imports?.length);
+
+            if (shouldFetchWaterfall && moduleContext && services.bridge?.bridge) {
+              try {
+                const waterfallResult = await moduleContext.getWaterfallSymbolsForDocument(
+                  uri,
+                  text,
+                  services.bridge.bridge,
+                  3
+                );
+
+                for (const symbol of waterfallResult.symbols) {
+                  if (!symbol.name || existingNames.has(symbol.name)) continue;
+                  if (!prefix || symbol.name.toLowerCase().startsWith(prefixLower)) {
+                    const provenance = symbol.provenance_file
+                      ? `From ${symbol.provenance_file}`
+                      : 'Imported symbol';
+                    completions.push(
+                      buildCompletionItem(
+                        symbol.name,
+                        symbol,
+                        provenance,
+                        undefined,
+                        completionContext
+                      )
+                    );
+                    existingNames.add(symbol.name);
+                  }
+                }
+              } catch (err) {
+                logger.debug('Failed to get waterfall symbols', {
+                  error: err instanceof Error ? err.message : String(err),
+                });
+              }
+            }
+          }
+
+          return toCompletionList(dedupeCompletionItems(completions));
         }
       } catch (err) {
         clearInFlight();
@@ -210,7 +356,6 @@ export function registerCompletionHandlers(
       }
     }
 
-    const cached = documentCache.get(uri);
     if (!cached) {
       logger.debug('Completion request - no cached document', { uri });
       return toCompletionList([]);
@@ -735,7 +880,11 @@ export function registerCompletionHandlers(
 
       // Add waterfall symbols from imports/include/inherit/require using ModuleContext
       // This provides symbols from transitive dependencies with provenance tracking
-      if (moduleContext && services.bridge?.bridge) {
+      const shouldFetchWaterfall =
+        prefixLower.length > 0 &&
+        !!(cached.dependencies?.includes?.length || cached.dependencies?.imports?.length);
+
+      if (shouldFetchWaterfall && moduleContext && services.bridge?.bridge) {
         try {
           const waterfallResult = await moduleContext.getWaterfallSymbolsForDocument(
             uri,
@@ -981,7 +1130,7 @@ export function registerCompletionHandlers(
       }
     }
 
-    return toCompletionList(completions);
+    return toCompletionList(dedupeCompletionItems(completions));
   });
 
   /**

--- a/packages/pike-lsp-server/src/tests/editing/completion-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/editing/completion-provider.test.ts
@@ -306,6 +306,34 @@ describe('Completion Provider', () => {
       expect(names).toContain('int');
     });
 
+    it('augments query-engine completions with imported module symbols', async () => {
+      const moduleSymbols = new Map<string, IntrospectedSymbol>();
+      moduleSymbols.set('File', {
+        name: 'File',
+        type: { kind: 'program' },
+        kind: 'class',
+        modifiers: ['public'],
+      });
+
+      const { complete } = setup({
+        code: 'import Stdio;\nFi',
+        queryItems: [
+          {
+            label: 'qeItem',
+            kind: CompletionItemKind.Variable,
+            detail: 'From query engine',
+          },
+        ],
+        importModules: [{ modulePath: 'Stdio', isStdlib: true }],
+        stdlibModules: { Stdio: moduleSymbols },
+      });
+
+      const result = await complete(1, 2);
+      const names = labels(result);
+      expect(names).toContain('qeItem');
+      expect(names).toContain('File');
+    });
+
     it('forwards cancellation for superseded completion requests during rapid edits', async () => {
       const cancelled: string[] = [];
       const bridge = {

--- a/packages/vscode-pike/src/extension.ts
+++ b/packages/vscode-pike/src/extension.ts
@@ -36,6 +36,21 @@ import {
   TransportKind,
 } from 'vscode-languageclient/node';
 
+function anonymizeSensitivePaths(value: string): string {
+  const home = process.env['HOME'];
+  const userProfile = process.env['USERPROFILE'];
+  const prefixes = [home, userProfile].filter((v): v is string => Boolean(v));
+
+  let output = value;
+  for (const prefix of prefixes) {
+    const normalized = prefix.replace(/\\/g, '/');
+    output = output.replaceAll(normalized, '$HOME');
+    output = output.replaceAll(prefix, '$HOME');
+  }
+
+  return output;
+}
+
 let activeRuntime: ExtensionRuntime | undefined;
 
 class ExtensionRuntime {
@@ -406,9 +421,10 @@ class ExtensionRuntime {
         window.showInformationMessage('Pike Language Server started');
       }
     } catch (err) {
+      const safeMessage = anonymizeSensitivePaths(err instanceof Error ? err.message : String(err));
       console.error('Failed to start Pike Language Client:', err);
-      this.setStatusBar('error', err instanceof Error ? err.message : String(err));
-      window.showErrorMessage(`Failed to start Pike language server: ${err}`);
+      this.setStatusBar('error', safeMessage);
+      window.showErrorMessage(`Failed to start Pike language server: ${safeMessage}`);
     }
   }
 
@@ -578,9 +594,12 @@ async function activateInternal(
               );
           }
         } catch (err) {
+          const safeMessage = anonymizeSensitivePaths(String(err));
           runtime
             .getOutputChannel()
-            .appendLine(`[pike.showReferences] Could not adjust position for symbol: ${err}`);
+            .appendLine(
+              `[pike.showReferences] Could not adjust position for symbol: ${safeMessage}`
+            );
         }
       }
 
@@ -696,9 +715,10 @@ async function activateInternal(
       runtime.getOutputChannel().appendLine(healthText);
       window.showInformationMessage('Pike server health printed to output channel.');
     } catch (err) {
+      const safeMessage = anonymizeSensitivePaths(String(err));
       runtime
         .getOutputChannel()
-        .appendLine(`[pike.lsp.showHealth] Failed to request server health: ${String(err)}`);
+        .appendLine(`[pike.lsp.showHealth] Failed to request server health: ${safeMessage}`);
       window.showErrorMessage('Failed to fetch Pike server health.');
     }
   });
@@ -809,15 +829,15 @@ async function activateInternal(
   });
   runtime.track(fileOpenDisposable);
 
-    // Check for Pike files already open in editor tabs (e.g., restored session).
-    // Their onDidOpenTextDocument events fired before activate(), so we missed them.
-    const alreadyOpenPikeDoc = workspace.textDocuments.find(
-        doc => runtime.isTrackedLanguage(doc.languageId)
-    );
-    if (alreadyOpenPikeDoc) {
-        fileOpenDisposable.dispose();
-        await runtime.ensureLspStarted();
-    }
+  // Check for Pike files already open in editor tabs (e.g., restored session).
+  // Their onDidOpenTextDocument events fired before activate(), so we missed them.
+  const alreadyOpenPikeDoc = workspace.textDocuments.find(doc =>
+    runtime.isTrackedLanguage(doc.languageId)
+  );
+  if (alreadyOpenPikeDoc) {
+    fileOpenDisposable.dispose();
+    await runtime.ensureLspStarted();
+  }
 
   // Also start LSP when configuration changes (if already opened a Pike file)
   context.subscriptions.push(


### PR DESCRIPTION
## Summary
- Anonymize user-specific absolute paths in logger output and extension-facing error messages.
- Augment query-engine completion results with imported/include symbols so import content appears in autocomplete.
- Limit waterfall dependency completion fetches to dependency contexts with a typed prefix to avoid expensive broad scans during edit flows.

## Linked Issue
closes #718
closes #719
closes #720

## Root Cause
- Error/log output serialized raw paths from local environments, exposing user home directories.
- Query-engine completion short-circuited before legacy dependency augmentation, so import/include symbols were omitted when query-engine returned items.
- Waterfall dependency symbol fetch ran too broadly, including contexts where no dependency expansion was needed.

## File-level Rationale
- `packages/core/src/logging.ts`: add path anonymization for messages and structured contexts.
- `packages/vscode-pike/src/extension.ts`: sanitize user-visible/startup and command error strings before display/output.
- `packages/pike-lsp-server/src/features/editing/completion.ts`: merge dependency-based completions into query-engine path, dedupe items, and gate waterfall fetches.
- `packages/pike-lsp-server/src/tests/editing/completion-provider.test.ts`: add regression test for query-engine + imported symbol augmentation.

## Verification
- `bun run typecheck` ✅
- `bun run build` ✅
- `cd packages/pike-lsp-server && bun test src/tests/editing/completion-provider.test.ts` ✅