### PR TITLE
ci: skip benchmark publication steps on pull requests

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -79,9 +79,11 @@ jobs:
           COMPILE_SPEEDUP_THRESHOLD: 50 # Expect >50% speedup for cache hits
 
       - name: Fetch gh-pages for historical data
+        if: github.event_name == 'push'
         run: git fetch origin gh-pages:gh-pages || true
 
       - name: Check performance regression (rolling average)
+        if: github.event_name == 'push'
         run: node scripts/apply-rolling-average.js 5
         env:
           BENCHMARK_RESULTS: benchmark-results.json
@@ -99,12 +101,14 @@ jobs:
           bun test src/tests/query-engine-perf-gates.test.ts
 
       - name: Prepare for benchmark storage
+        if: github.event_name == 'push'
         run: |
           # Stash benchmark results so git switch doesn't fail
           cp benchmark-results.json /tmp/benchmark-results.json
           git stash --include-untracked || true
 
       - name: Store benchmark result
+        if: github.event_name == 'push'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Pike LSP Performance


### PR DESCRIPTION
## Summary
- prevent benchmark workflow from pushing to gh-pages during pull_request runs
- keep benchmark publication and rolling-history steps on push only

Fixes #726.

## Root Cause
Fork PRs run with a read-only GITHUB_TOKEN, but the benchmark publication step attempted git push to gh-pages, causing a hard CI failure.

## Verification
- inspected failing run 22708643020 and confirmed 403 on github-actions[bot] push to gh-pages
- validated workflow diff only gates publication/history steps behind github.event_name == 'push'
