### PR TITLE
ci: allow benchmark publication for trusted manual runs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -21,6 +21,7 @@ on:
       - '.omc/**'
       - 'docusaurus.config.ts'
       - 'sidebars.ts'
+  workflow_dispatch:
 
 concurrency:
   group: bench-${{ github.ref }}
@@ -79,11 +80,11 @@ jobs:
           COMPILE_SPEEDUP_THRESHOLD: 50 # Expect >50% speedup for cache hits
 
       - name: Fetch gh-pages for historical data
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         run: git fetch origin gh-pages:gh-pages || true
 
       - name: Check performance regression (rolling average)
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         run: node scripts/apply-rolling-average.js 5
         env:
           BENCHMARK_RESULTS: benchmark-results.json
@@ -101,14 +102,14 @@ jobs:
           bun test src/tests/query-engine-perf-gates.test.ts
 
       - name: Prepare for benchmark storage
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         run: |
           # Stash benchmark results so git switch doesn't fail
           cp benchmark-results.json /tmp/benchmark-results.json
           git stash --include-untracked || true
 
       - name: Store benchmark result
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Pike LSP Performance


### PR DESCRIPTION
## Summary
- add workflow_dispatch trigger for benchmark workflow
- run benchmark publication/history steps for trusted non-PR events (not pull_request)

Fixes #726.

## Root Cause
Publication steps were gated only on push, which is safe for forks but blocks trusted manual benchmark publication runs.

## Verification
- confirmed pull_request still skips gh-pages fetch, rolling average, and benchmark storage
- confirmed workflow_dispatch is now supported and follows trusted-event publication path
