### PR TITLE
feat: add LSP crash report anonymizer pipeline

### DIFF
--- a/packages/core/src/crash-report-anonymizer.ts
+++ b/packages/core/src/crash-report-anonymizer.ts
@@ -1,0 +1,440 @@
+import { createHash } from 'node:crypto';
+
+const PREHASHED_IDENTIFIER = /^sym_[0-9a-f]{12}$/;
+
+function hashHex(value: string, length = 12): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, length);
+}
+
+function normalizeSlashes(value: string): string {
+  return value.replace(/\\/g, '/');
+}
+
+function trimTrailingSlash(value: string): string {
+  if (value.length <= 1) {
+    return value;
+  }
+  return value.replace(/[\\/]+$/, '');
+}
+
+function isWindowsAbsolutePath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value);
+}
+
+function isUnixAbsolutePath(value: string): boolean {
+  return value.startsWith('/');
+}
+
+function isAbsolutePath(value: string): boolean {
+  return isWindowsAbsolutePath(value) || isUnixAbsolutePath(value);
+}
+
+function normalizeForComparison(pathValue: string, windowsStyle: boolean): string {
+  const normalized = trimTrailingSlash(normalizeSlashes(pathValue));
+  return windowsStyle ? normalized.toLowerCase() : normalized;
+}
+
+function splitBaseAndParent(pathValue: string): { basename: string; parent: string } {
+  const normalized = trimTrailingSlash(pathValue);
+  const pieces = normalized.split(/[\\/]/).filter(Boolean);
+  const basename = pieces.length > 0 ? pieces[pieces.length - 1]! : '';
+  const parent = pieces.length > 1 ? pieces.slice(0, -1).join('/') : normalized;
+  return { basename, parent };
+}
+
+function sanitizeAbsolutePath(pathValue: string, workspaceRoot: string): string {
+  const windowsStyle = isWindowsAbsolutePath(pathValue) || isWindowsAbsolutePath(workspaceRoot);
+  const separator = windowsStyle ? '\\' : '/';
+  const normalizedPath = normalizeForComparison(pathValue, windowsStyle);
+  const normalizedRoot = normalizeForComparison(workspaceRoot, windowsStyle);
+  const withSlash = `${normalizedRoot}/`;
+
+  if (normalizedPath === normalizedRoot || normalizedPath.startsWith(withSlash)) {
+    const relative = normalizedPath.slice(normalizedRoot.length).replace(/^\//, '');
+    if (!relative) {
+      return '<workspace>';
+    }
+    const relativeWithSeparator = relative.replace(/\//g, separator);
+    return `<workspace>${separator}${relativeWithSeparator}`;
+  }
+
+  const { basename, parent } = splitBaseAndParent(pathValue);
+  const hash = hashHex(normalizeSlashes(parent), 8);
+  return `<external:${hash}>${separator}${basename}`;
+}
+
+function sanitizeFileUri(uri: string, workspaceRoot: string): string {
+  const rawPath = uri.slice('file://'.length);
+  const decoded = decodeURIComponent(rawPath);
+  const normalized =
+    decoded.startsWith('/') && isWindowsAbsolutePath(decoded.slice(1)) ? decoded.slice(1) : decoded;
+  const normalizedWithoutLeadingSlash = normalized.replace(/^\//, '');
+  if (
+    normalizedWithoutLeadingSlash.startsWith('<workspace>') ||
+    normalizedWithoutLeadingSlash.startsWith('<external:')
+  ) {
+    return `file:///${normalizedWithoutLeadingSlash.replace(/\\/g, '/')}`;
+  }
+  const sanitized = sanitizeAbsolutePath(normalized, workspaceRoot).replace(/\\/g, '/');
+  return `file:///${sanitized}`;
+}
+
+export const PathSanitizer = {
+  sanitizePath(inputPath: string, workspaceRoot: string): string {
+    if (!inputPath) {
+      return inputPath;
+    }
+
+    if (inputPath.startsWith('file:///')) {
+      return sanitizeFileUri(inputPath, workspaceRoot);
+    }
+
+    if (!isAbsolutePath(inputPath)) {
+      return inputPath;
+    }
+
+    return sanitizeAbsolutePath(inputPath, workspaceRoot);
+  },
+
+  sanitizePathsInText(value: string, workspaceRoot: string): string {
+    if (!value) {
+      return value;
+    }
+
+    const pattern =
+      /(^|[\s([{'"=:])((?:file:\/\/\/[^\s"')\]]+)|(?:[A-Za-z]:\\[^\s"')\]]+)|(?:\/(?:[^\s"')\]/]+\/)+[^\s"')\]]+))/g;
+    return value.replace(pattern, (_match, prefix: string, pathPart: string) => {
+      return `${prefix}${PathSanitizer.sanitizePath(pathPart, workspaceRoot)}`;
+    });
+  },
+};
+
+export const StackTraceSanitizer = {
+  sanitizeStackTrace(trace: string, workspaceRoot: string): string {
+    return PathSanitizer.sanitizePathsInText(trace, workspaceRoot);
+  },
+
+  stripFrameSource<T>(framePayload: T): T {
+    if (framePayload === null || framePayload === undefined) {
+      return framePayload;
+    }
+    if (Array.isArray(framePayload)) {
+      return framePayload.map(item => StackTraceSanitizer.stripFrameSource(item)) as T;
+    }
+    if (typeof framePayload !== 'object') {
+      return framePayload;
+    }
+
+    const input = framePayload as Record<string, unknown>;
+    const output: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input)) {
+      if (key === 'source' && typeof value === 'string') {
+        output[key] = null;
+      } else {
+        output[key] = StackTraceSanitizer.stripFrameSource(value);
+      }
+    }
+    return output as T;
+  },
+};
+
+function shouldKeepIdentifier(token: string, allowList: ReadonlySet<string>): boolean {
+  if (allowList.has(token)) {
+    return true;
+  }
+  if (PREHASHED_IDENTIFIER.test(token)) {
+    return true;
+  }
+  if (token === 'prototype' || token === 'from') {
+    return true;
+  }
+  return false;
+}
+
+function hashIdentifierToken(token: string): string {
+  return `sym_${hashHex(token, 12)}`;
+}
+
+export const IdentifierHasher = {
+  hashIdentifier(identifier: string): string {
+    if (PREHASHED_IDENTIFIER.test(identifier)) {
+      return identifier;
+    }
+    return hashIdentifierToken(identifier);
+  },
+
+  hashSensitiveSegments(value: string, allowList: string[] = []): string {
+    const allow = new Set(allowList);
+
+    const quoteSanitized = value.replace(/'([A-Za-z_][A-Za-z0-9_]*)'/g, (_match, ident: string) => {
+      if (shouldKeepIdentifier(ident, allow)) {
+        return `'${ident}'`;
+      }
+      return `'${hashIdentifierToken(ident)}'`;
+    });
+
+    return quoteSanitized.replace(/\(([A-Za-z_][A-Za-z0-9_.]*)\)/g, (_match, chain: string) => {
+      const mapped = chain
+        .split('.')
+        .map(part => (shouldKeepIdentifier(part, allow) ? part : hashIdentifierToken(part)));
+      return `(${mapped.join('.')})`;
+    });
+  },
+};
+
+function redactTextContent(text: string): string {
+  if (/^<redacted:\d+ chars>$/.test(text)) {
+    return text;
+  }
+  return `<redacted:${text.length} chars>`;
+}
+
+function redactPathLikeName(name: string): string {
+  return name ? '<workspace>' : name;
+}
+
+type JsonValue = string | number | boolean | null | JsonObject | JsonArray;
+interface JsonObject {
+  [key: string]: JsonValue;
+}
+type JsonArray = JsonValue[];
+
+export const JsonRpcRedactor = {
+  redactMessage<T>(payload: T, workspaceRoot: string, allowList: string[] = []): T {
+    const redact = (value: unknown, keyName?: string): unknown => {
+      if (typeof value === 'string') {
+        if (keyName === 'text') {
+          return redactTextContent(value);
+        }
+        const pathRedacted = PathSanitizer.sanitizePathsInText(value, workspaceRoot);
+        if (keyName === 'message') {
+          return IdentifierHasher.hashSensitiveSegments(pathRedacted, allowList);
+        }
+        if (keyName === 'uri' || keyName === 'rootUri' || keyName === 'rootPath') {
+          return PathSanitizer.sanitizePath(pathRedacted, workspaceRoot);
+        }
+        return pathRedacted;
+      }
+
+      if (Array.isArray(value)) {
+        return value.map(item => redact(item));
+      }
+
+      if (value && typeof value === 'object') {
+        const input = value as Record<string, unknown>;
+        const output: Record<string, unknown> = {};
+        for (const [nestedKey, nestedValue] of Object.entries(input)) {
+          if (nestedKey === 'workspaceFolders' && Array.isArray(nestedValue)) {
+            output[nestedKey] = nestedValue.map(item => {
+              if (!item || typeof item !== 'object') {
+                return item;
+              }
+              const folder = item as Record<string, unknown>;
+              const folderOutput: Record<string, unknown> = {};
+              for (const [folderKey, folderValue] of Object.entries(folder)) {
+                if (folderKey === 'uri' && typeof folderValue === 'string') {
+                  folderOutput[folderKey] = PathSanitizer.sanitizePath(folderValue, workspaceRoot);
+                } else if (folderKey === 'name' && typeof folderValue === 'string') {
+                  folderOutput[folderKey] = redactPathLikeName(folderValue);
+                } else {
+                  folderOutput[folderKey] = redact(folderValue, folderKey);
+                }
+              }
+              return folderOutput;
+            });
+            continue;
+          }
+          output[nestedKey] = redact(nestedValue, nestedKey);
+        }
+        return output;
+      }
+
+      return value;
+    };
+
+    return redact(payload) as T;
+  },
+};
+
+const SENSITIVE_ENV_KEYS = new Set([
+  'HOME',
+  'USERPROFILE',
+  'API_KEY',
+  'SECRET_TOKEN',
+  'TOKEN',
+  'PASSWORD',
+  'PASS',
+  'AUTH',
+]);
+
+function isSensitiveKey(key: string): boolean {
+  const upper = key.toUpperCase();
+  if (SENSITIVE_ENV_KEYS.has(upper)) {
+    return true;
+  }
+  return /SECRET|TOKEN|KEY|PASSWORD|PASS|AUTH/.test(upper);
+}
+
+export const EnvironmentScrubber = {
+  scrubEnv(env: Record<string, string>, allowList: string[] = []): Record<string, string> {
+    const allow = new Set(allowList.map(item => item.toUpperCase()));
+    const output: Record<string, string> = {};
+    for (const [key, value] of Object.entries(env)) {
+      const upper = key.toUpperCase();
+      if (allow.size > 0 && !allow.has(upper)) {
+        output[key] = '<redacted>';
+        continue;
+      }
+      if (isSensitiveKey(key)) {
+        output[key] = '<redacted>';
+        continue;
+      }
+      output[key] = value;
+    }
+    return output;
+  },
+
+  scrubArgs(args: string[], workspaceRoot: string): string[] {
+    return args.map(arg => {
+      if (/^--[A-Za-z0-9_-]*(key|token|secret|password)/i.test(arg) && arg.includes('=')) {
+        const [name] = arg.split('=', 1);
+        return `${name}=<redacted>`;
+      }
+      if (isAbsolutePath(arg) || arg.startsWith('file:///')) {
+        return PathSanitizer.sanitizePath(arg, workspaceRoot);
+      }
+      return arg;
+    });
+  },
+};
+
+export const CatchAllScanner = {
+  scan(value: string): string {
+    if (!value) {
+      return value;
+    }
+
+    const emailReplaced = value.replace(
+      /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+      email => {
+        return `<email:${hashHex(email, 8)}>`;
+      }
+    );
+
+    const pathReplaced = emailReplaced.replace(
+      /(?<!>)\/(?:[A-Za-z0-9._-]+\/)+([A-Za-z0-9._-]+)/g,
+      (match, fileName: string) => {
+        const hash = hashHex(match, 8);
+        return `<path:${hash}>/${fileName}`;
+      }
+    );
+
+    return pathReplaced.replace(
+      /(?<![\/<])\b((?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}|(?:\d{1,3}\.){3}\d{1,3})(?::(\d+))?/g,
+      (_all, host: string, port: string | undefined) => {
+        const suffix = port ? `:${port}` : '';
+        return `<host:${hashHex(host, 8)}>${suffix}`;
+      }
+    );
+  },
+};
+
+interface PipelineOptions {
+  workspaceRoot: string;
+  identifierAllowList?: string[];
+  envAllowList?: string[];
+  createLocalMap?: boolean;
+}
+
+interface PipelineResult<T> {
+  payload: T;
+  localMap?: Record<string, string>;
+}
+
+function sanitizeAllStrings(value: unknown, fn: (value: string) => string): unknown {
+  if (typeof value === 'string') {
+    return fn(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => sanitizeAllStrings(item, fn));
+  }
+  if (value && typeof value === 'object') {
+    const input = value as Record<string, unknown>;
+    const output: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(input)) {
+      output[key] = sanitizeAllStrings(item, fn);
+    }
+    return output;
+  }
+  return value;
+}
+
+export const AnonymizerPipeline = {
+  anonymize<T extends Record<string, unknown>>(
+    payload: T,
+    options: PipelineOptions
+  ): PipelineResult<T> {
+    const identifierAllowList = options.identifierAllowList ?? [
+      'String',
+      'Array',
+      'Object',
+      'Promise',
+    ];
+
+    const stage1 = JsonRpcRedactor.redactMessage(
+      payload,
+      options.workspaceRoot,
+      identifierAllowList
+    );
+    const stage2 = sanitizeAllStrings(stage1, value =>
+      PathSanitizer.sanitizePathsInText(value, options.workspaceRoot)
+    ) as T;
+    const stage3 = sanitizeAllStrings(stage2, value =>
+      IdentifierHasher.hashSensitiveSegments(value, identifierAllowList)
+    ) as T;
+
+    const stage4Input = stage3 as Record<string, unknown>;
+    const env = stage4Input['env'];
+    const args = stage4Input['args'];
+    const stage4 = {
+      ...stage4Input,
+      ...(env && typeof env === 'object'
+        ? {
+            env: EnvironmentScrubber.scrubEnv(
+              env as Record<string, string>,
+              options.envAllowList ?? []
+            ),
+          }
+        : {}),
+      ...(Array.isArray(args)
+        ? {
+            args: EnvironmentScrubber.scrubArgs(
+              args.filter((arg): arg is string => typeof arg === 'string'),
+              options.workspaceRoot
+            ),
+          }
+        : {}),
+    } as T;
+
+    const stage5 = StackTraceSanitizer.stripFrameSource(
+      sanitizeAllStrings(stage4, value =>
+        StackTraceSanitizer.sanitizeStackTrace(value, options.workspaceRoot)
+      )
+    ) as T;
+
+    const stage6 = sanitizeAllStrings(stage5, CatchAllScanner.scan) as T;
+
+    if (!options.createLocalMap) {
+      return { payload: stage6 };
+    }
+
+    const localMap: Record<string, string> = {
+      '<workspace>': options.workspaceRoot,
+    };
+
+    return {
+      payload: stage6,
+      localMap,
+    };
+  },
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@
 
 export * from './errors.js';
 export * from './logging.js';
+export * from './crash-report-anonymizer.js';

--- a/packages/pike-lsp-server/src/tests/crash-report-anonymizer.test.ts
+++ b/packages/pike-lsp-server/src/tests/crash-report-anonymizer.test.ts
@@ -1,0 +1,334 @@
+import { describe, it } from 'bun:test';
+import assert from 'node:assert';
+import {
+  PathSanitizer,
+  StackTraceSanitizer,
+  IdentifierHasher,
+  JsonRpcRedactor,
+  EnvironmentScrubber,
+  CatchAllScanner,
+  AnonymizerPipeline,
+} from '../../../core/src/crash-report-anonymizer.js';
+
+describe('PathSanitizer', () => {
+  it('replaces absolute workspace prefix with placeholder', () => {
+    const input = '/home/john/secret-project/src/parser.ts';
+    const root = '/home/john/secret-project';
+    assert.strictEqual(PathSanitizer.sanitizePath(input, root), '<workspace>/src/parser.ts');
+  });
+
+  it('preserves relative paths unchanged', () => {
+    assert.strictEqual(
+      PathSanitizer.sanitizePath('src/parser.ts', '/home/john/secret-project'),
+      'src/parser.ts'
+    );
+  });
+
+  it('handles nested workspace paths', () => {
+    const input = '/home/john/secret-project/node_modules/.cache/tsserver/file.js';
+    const root = '/home/john/secret-project';
+    assert.strictEqual(
+      PathSanitizer.sanitizePath(input, root),
+      '<workspace>/node_modules/.cache/tsserver/file.js'
+    );
+  });
+
+  it('handles URI-encoded paths', () => {
+    const input = 'file:///home/john/secret-project/src/parser.ts';
+    const root = '/home/john/secret-project';
+    assert.strictEqual(
+      PathSanitizer.sanitizePath(input, root),
+      'file:///<workspace>/src/parser.ts'
+    );
+  });
+
+  it('handles Windows-style paths', () => {
+    const input = 'C:\\Users\\john\\project\\src\\main.rs';
+    const root = 'C:\\Users\\john\\project';
+    assert.strictEqual(PathSanitizer.sanitizePath(input, root), '<workspace>\\src\\main.rs');
+  });
+
+  it('paths outside workspace are fully hashed with filename preserved', () => {
+    const input = '/usr/local/lib/node_modules/typescript/lib/tsserver.js';
+    const root = '/home/john/secret-project';
+    const output = PathSanitizer.sanitizePath(input, root);
+    assert.match(output, /^<external:[0-9a-f]{8}>\/tsserver\.js$/);
+  });
+});
+
+describe('StackTraceSanitizer', () => {
+  it('rewrites file paths in stack frames and keeps line/col', () => {
+    const input = 'at Parser.parse (/home/john/secret-project/src/parser.ts:42:13)';
+    const output = StackTraceSanitizer.sanitizeStackTrace(input, '/home/john/secret-project');
+    assert.strictEqual(output, 'at Parser.parse (<workspace>/src/parser.ts:42:13)');
+  });
+
+  it('preserves function names and anonymous markers', () => {
+    const input = 'at <anonymous> (/home/john/secret-project/src/index.ts:1:1)';
+    const output = StackTraceSanitizer.sanitizeStackTrace(input, '/home/john/secret-project');
+    assert.strictEqual(output, 'at <anonymous> (<workspace>/src/index.ts:1:1)');
+  });
+
+  it('strips embedded source snippets from frame payloads', () => {
+    const input = { frame: 'parser.ts:42', source: "const apiKey = 'sk-abc123'" };
+    assert.deepStrictEqual(StackTraceSanitizer.stripFrameSource(input), {
+      frame: 'parser.ts:42',
+      source: null,
+    });
+  });
+
+  it('handles multi-line stack traces end to end', () => {
+    const input = [
+      'Error: Unexpected token',
+      '    at Parser.parse (/home/john/project/src/parser.ts:42:13)',
+      '    at Object.handle (/home/john/project/src/server.ts:10:5)',
+      '    at node:internal/modules/cjs/loader:1234:14',
+    ].join('\n');
+    const output = StackTraceSanitizer.sanitizeStackTrace(input, '/home/john/project');
+    const expected = [
+      'Error: Unexpected token',
+      '    at Parser.parse (<workspace>/src/parser.ts:42:13)',
+      '    at Object.handle (<workspace>/src/server.ts:10:5)',
+      '    at node:internal/modules/cjs/loader:1234:14',
+    ].join('\n');
+    assert.strictEqual(output, expected);
+  });
+});
+
+describe('IdentifierHasher', () => {
+  it('hashes symbol names deterministically', () => {
+    assert.match(
+      IdentifierHasher.hashIdentifier('MySecretClass.proprietary_method'),
+      /^sym_[0-9a-f]{12}$/
+    );
+  });
+
+  it('same input always produces same hash', () => {
+    assert.strictEqual(
+      IdentifierHasher.hashIdentifier('MySecretClass'),
+      IdentifierHasher.hashIdentifier('MySecretClass')
+    );
+  });
+
+  it('different inputs produce different hashes', () => {
+    assert.notStrictEqual(
+      IdentifierHasher.hashIdentifier('MySecretClass'),
+      IdentifierHasher.hashIdentifier('MyOtherClass')
+    );
+  });
+
+  it('preserves allowlisted names', () => {
+    const output = IdentifierHasher.hashSensitiveSegments('String.prototype.split', [
+      'String',
+      'Array',
+      'Object',
+      'Promise',
+    ]);
+    assert.strictEqual(output, 'String.prototype.split');
+  });
+
+  it('hashes only confidential segments', () => {
+    const output = IdentifierHasher.hashSensitiveSegments('Array.from(SecretFactory.create)', [
+      'Array',
+    ]);
+    assert.match(output, /^Array\.from\(sym_[0-9a-f]{12}\.sym_[0-9a-f]{12}\)$/);
+  });
+});
+
+describe('JsonRpcRedactor', () => {
+  it('redacts uri fields in LSP messages', () => {
+    const input = {
+      method: 'textDocument/didOpen',
+      params: {
+        textDocument: {
+          uri: 'file:///home/john/project/src/main.rs',
+        },
+      },
+    };
+    const output = JsonRpcRedactor.redactMessage(input, '/home/john/project');
+    assert.strictEqual(output.params.textDocument.uri, 'file:///<workspace>/src/main.rs');
+  });
+
+  it('strips text/document content fields', () => {
+    const input = {
+      params: { textDocument: { uri: 'file:///tmp/x', text: 'fn secret_algo() { ... }' } },
+    };
+    const output = JsonRpcRedactor.redactMessage(input, '/tmp');
+    assert.strictEqual(output.params.textDocument.text, '<redacted:24 chars>');
+  });
+
+  it('preserves diagnostic structure but redacts message content', () => {
+    const input = {
+      diagnostics: [
+        {
+          range: { start: { line: 5, character: 0 } },
+          message: "Variable 'secretKey' is unused",
+          severity: 2,
+        },
+      ],
+    };
+    const output = JsonRpcRedactor.redactMessage(input, '/home/john/project');
+    assert.match(output.diagnostics[0].message, /^Variable 'sym_[0-9a-f]{12}' is unused$/);
+    assert.strictEqual(output.diagnostics[0].severity, 2);
+    assert.deepStrictEqual(output.diagnostics[0].range.start, { line: 5, character: 0 });
+  });
+
+  it('preserves method names and error codes while sanitizing message paths', () => {
+    const input = {
+      method: 'textDocument/completion',
+      error: { code: -32600, message: 'some detail about /home/john/file' },
+    };
+    const output = JsonRpcRedactor.redactMessage(input, '/home/john');
+    assert.strictEqual(output.method, 'textDocument/completion');
+    assert.strictEqual(output.error.code, -32600);
+    assert.strictEqual(output.error.message, 'some detail about <workspace>/file');
+  });
+
+  it('recursively redacts rootUri, rootPath, workspaceFolders', () => {
+    const input = {
+      params: {
+        rootUri: 'file:///home/john/project',
+        rootPath: '/home/john/project',
+        workspaceFolders: [{ uri: 'file:///home/john/project', name: 'project' }],
+      },
+    };
+    const output = JsonRpcRedactor.redactMessage(input, '/home/john/project');
+    assert.strictEqual(output.params.rootUri, 'file:///<workspace>');
+    assert.strictEqual(output.params.rootPath, '<workspace>');
+    assert.deepStrictEqual(output.params.workspaceFolders, [
+      { uri: 'file:///<workspace>', name: '<workspace>' },
+    ]);
+  });
+});
+
+describe('EnvironmentScrubber', () => {
+  it('strips known sensitive env vars', () => {
+    const input = { HOME: '/home/john', API_KEY: 'sk-123', LANG: 'en_US.UTF-8' };
+    assert.deepStrictEqual(EnvironmentScrubber.scrubEnv(input), {
+      HOME: '<redacted>',
+      API_KEY: '<redacted>',
+      LANG: 'en_US.UTF-8',
+    });
+  });
+
+  it('allowlists safe env vars only', () => {
+    const input = { PATH: '/usr/bin:...', SECRET_TOKEN: 'abc', SHELL: '/bin/zsh' };
+    const output = EnvironmentScrubber.scrubEnv(input, [
+      'LANG',
+      'TERM',
+      'SHELL',
+      'NODE_VERSION',
+      'PATH',
+    ]);
+    assert.deepStrictEqual(output, {
+      PATH: '/usr/bin:...',
+      SECRET_TOKEN: '<redacted>',
+      SHELL: '/bin/zsh',
+    });
+  });
+
+  it('redacts command-line args containing paths or secret flags', () => {
+    const input = ['node', '/home/john/project/server.js', '--key=abc123', '--stdio'];
+    const output = EnvironmentScrubber.scrubArgs(input, '/home/john/project');
+    assert.deepStrictEqual(output, [
+      'node',
+      '<workspace>/server.js',
+      '--key=<redacted>',
+      '--stdio',
+    ]);
+  });
+});
+
+describe('CatchAllScanner', () => {
+  it('catches email addresses', () => {
+    const output = CatchAllScanner.scan('Error reported by john.doe@company.com at 10:42');
+    assert.match(output, /^Error reported by <email:[0-9a-f]{8}> at 10:42$/);
+  });
+
+  it('catches hostnames and IPs', () => {
+    const output = CatchAllScanner.scan('Connection refused: internal-api.company.com:8080');
+    assert.match(output, /^Connection refused: <host:[0-9a-f]{8}>:8080$/);
+  });
+
+  it('catches residual absolute paths missed by first pass', () => {
+    const output = CatchAllScanner.scan('See also /var/log/john/debug.log for details');
+    assert.match(output, /^See also <path:[0-9a-f]{8}>\/debug\.log for details$/);
+  });
+
+  it('does not false-positive on safe patterns', () => {
+    const input = 'Error code: -32600 at line 42';
+    assert.strictEqual(CatchAllScanner.scan(input), input);
+  });
+});
+
+describe('AnonymizerPipeline', () => {
+  it('full pipeline applies all stages in order and keeps preserved fields', () => {
+    const raw = {
+      method: 'textDocument/completion',
+      server: { name: 'pike-lsp', version: '0.1.0' },
+      languageId: 'pike',
+      document: { uri: 'file:///home/john/project/src/main.rs', text: 'fn secret() {}', size: 14 },
+      diagnostics: [
+        {
+          range: { start: { line: 5, character: 0 } },
+          message: "Variable 'secretKey' is unused",
+          severity: 2,
+        },
+      ],
+      error: {
+        code: -32600,
+        message: 'failed at /home/john/project/src/main.rs',
+        stack: 'at Parser.parse (/home/john/project/src/parser.ts:42:13)',
+      },
+      env: { HOME: '/home/john', LANG: 'en_US.UTF-8', API_KEY: 'sk-abc' },
+      args: ['node', '/home/john/project/server.js', '--key=abc123', '--stdio'],
+    };
+
+    const result = AnonymizerPipeline.anonymize(raw, {
+      workspaceRoot: '/home/john/project',
+      identifierAllowList: ['String', 'Array', 'Object', 'Promise'],
+      envAllowList: ['LANG', 'PATH', 'TERM', 'SHELL', 'NODE_VERSION'],
+      createLocalMap: true,
+    });
+
+    const output = result.payload;
+    assert.strictEqual(output.method, 'textDocument/completion');
+    assert.strictEqual(output.error.code, -32600);
+    assert.strictEqual(output.server.name, 'pike-lsp');
+    assert.strictEqual(output.server.version, '0.1.0');
+    assert.strictEqual(output.languageId, 'pike');
+    assert.strictEqual(output.document.size, 14);
+    assert.strictEqual(output.diagnostics[0].severity, 2);
+    assert.deepStrictEqual(output.diagnostics[0].range.start, { line: 5, character: 0 });
+
+    assert.strictEqual(output.document.text, '<redacted:14 chars>');
+    assert.strictEqual(output.document.uri, 'file:///<workspace>/src/main.rs');
+    assert.strictEqual(output.error.message, 'failed at <workspace>/src/main.rs');
+    assert.strictEqual(output.args[1], '<workspace>/server.js');
+    assert.strictEqual(output.args[2], '--key=<redacted>');
+    assert.strictEqual(output.env.HOME, '<redacted>');
+    assert.strictEqual(output.env.API_KEY, '<redacted>');
+    assert.strictEqual(output.env.LANG, 'en_US.UTF-8');
+
+    assert.ok(result.localMap);
+    assert.strictEqual(result.localMap?.['<workspace>'], '/home/john/project');
+  });
+
+  it('is idempotent when anonymized twice', () => {
+    const payload = {
+      method: 'textDocument/didOpen',
+      params: {
+        textDocument: { uri: 'file:///home/john/project/src/main.rs', text: 'let secret = 1;' },
+      },
+      error: { code: -32600, message: 'john.doe@company.com /var/log/a.log' },
+    };
+
+    const once = AnonymizerPipeline.anonymize(payload, {
+      workspaceRoot: '/home/john/project',
+    }).payload;
+    const twice = AnonymizerPipeline.anonymize(once, {
+      workspaceRoot: '/home/john/project',
+    }).payload;
+    assert.deepStrictEqual(twice, once);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable crash report anonymizer module in `@pike-lsp/core` with staged sanitizers for paths, stack traces, identifiers, JSON-RPC payloads, environment data, and catch-all residual scanning
- add integration pipeline support for ordered anonymization and optional local de-anonymization mapping
- add comprehensive TDD coverage in `pike-lsp-server` for all requested module behaviors, preserved fields, and idempotency

## Problem / Root Cause
LSP crash payloads can leak workspace paths, identifiers, source snippets, and environment secrets, making issue reports risky to share externally.

## File-Level Rationale
- `packages/core/src/crash-report-anonymizer.ts`: production implementation of all anonymizer modules and pipeline stages
- `packages/core/src/index.ts`: export the new anonymizer API for package consumers
- `packages/pike-lsp-server/src/tests/crash-report-anonymizer.test.ts`: end-to-end TDD coverage for specified acceptance criteria

## Verification
- `bun test src/tests/crash-report-anonymizer.test.ts` (packages/pike-lsp-server)
- `bun run typecheck`
- `bun run build`

Closes #728