### PR TITLE
refactor: normalize scheduler metrics logging payload

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics/index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/index.ts
@@ -26,6 +26,7 @@ import { DIAGNOSTIC_DELAY_DEFAULT, DEFAULT_MAX_PROBLEMS } from '../../constants/
 import { computeContentHash, computeLineHashes } from '../../services/document-cache.js';
 import { RequestScheduler, RequestSupersededError } from '../../services/request-scheduler.js';
 import { detectRoxenModule, provideRoxenDiagnostics } from '../roxen/index.js';
+import { toSchedulerMetricsLogPayload } from '../utils/scheduler-metrics.js';
 
 interface PendingChangeState {
   range: Range | undefined;
@@ -732,15 +733,7 @@ export function registerDiagnosticsHandlers(
         log.debug('Diagnostics scheduler metrics', {
           uri,
           samples: validationCompletions,
-          maxConcurrent: schedulerMetrics.maxConcurrent,
-          activeWorkers: schedulerMetrics.activeWorkers,
-          queueDepth: schedulerMetrics.queueDepth,
-          inFlightByClass: schedulerMetrics.inFlightByClass,
-          scheduled: schedulerMetrics.scheduled,
-          started: schedulerMetrics.started,
-          completed: schedulerMetrics.completed,
-          failed: schedulerMetrics.failed,
-          canceled: schedulerMetrics.canceled,
+          ...toSchedulerMetricsLogPayload(schedulerMetrics),
         });
       }
 

--- a/packages/pike-lsp-server/src/features/editing/completion.ts
+++ b/packages/pike-lsp-server/src/features/editing/completion.ts
@@ -27,6 +27,7 @@ import {
   getRXMLTagCompletions,
   getRXMLAttributeCompletions,
 } from '../rxml/mixed-content.js';
+import { toSchedulerMetricsLogPayload } from '../utils/scheduler-metrics.js';
 
 const inFlightCompletionRequests = new Map<string, string>();
 const completionRequestSequence = new Map<string, number>();
@@ -64,15 +65,7 @@ export function registerCompletionHandlers(
       uri,
       outcome,
       samples: completionRequestsObserved,
-      maxConcurrent: schedulerMetrics.maxConcurrent,
-      activeWorkers: schedulerMetrics.activeWorkers,
-      queueDepth: schedulerMetrics.queueDepth,
-      inFlightByClass: schedulerMetrics.inFlightByClass,
-      scheduled: schedulerMetrics.scheduled,
-      started: schedulerMetrics.started,
-      completed: schedulerMetrics.completed,
-      failed: schedulerMetrics.failed,
-      canceled: schedulerMetrics.canceled,
+      ...toSchedulerMetricsLogPayload(schedulerMetrics),
     });
   }
 

--- a/packages/pike-lsp-server/src/features/utils/index.ts
+++ b/packages/pike-lsp-server/src/features/utils/index.ts
@@ -6,3 +6,4 @@
 
 export { formatPikeType, extractTypeName } from './pike-type-formatter.js';
 export { buildHoverContent } from './hover-builder.js';
+export { toSchedulerMetricsLogPayload } from './scheduler-metrics.js';

--- a/packages/pike-lsp-server/src/features/utils/scheduler-metrics.ts
+++ b/packages/pike-lsp-server/src/features/utils/scheduler-metrics.ts
@@ -1,0 +1,17 @@
+import type { RequestSchedulerMetrics } from '../../services/request-scheduler.js';
+
+export function toSchedulerMetricsLogPayload(
+  schedulerMetrics: RequestSchedulerMetrics
+): Record<string, unknown> {
+  return {
+    maxConcurrent: schedulerMetrics.maxConcurrent,
+    activeWorkers: schedulerMetrics.activeWorkers,
+    queueDepth: schedulerMetrics.queueDepth,
+    inFlightByClass: schedulerMetrics.inFlightByClass,
+    scheduled: schedulerMetrics.scheduled,
+    started: schedulerMetrics.started,
+    completed: schedulerMetrics.completed,
+    failed: schedulerMetrics.failed,
+    canceled: schedulerMetrics.canceled,
+  };
+}

--- a/packages/pike-lsp-server/src/tests/scheduler-metrics-log-payload.test.ts
+++ b/packages/pike-lsp-server/src/tests/scheduler-metrics-log-payload.test.ts
@@ -1,0 +1,55 @@
+import { describe, it } from 'bun:test';
+import assert from 'node:assert/strict';
+
+import { toSchedulerMetricsLogPayload } from '../features/utils/scheduler-metrics.js';
+import type { RequestSchedulerMetrics } from '../services/request-scheduler.js';
+
+describe('scheduler metrics log payload', () => {
+  it('normalizes live scheduler metrics into a stable log schema', () => {
+    const metrics: RequestSchedulerMetrics = {
+      scheduled: 12,
+      started: 10,
+      completed: 9,
+      failed: 1,
+      canceled: 2,
+      maxConcurrent: 2,
+      activeWorkers: 1,
+      queueDepth: {
+        typing: 3,
+        interactive: 1,
+        background: 2,
+      },
+      inFlightByClass: {
+        typing: 1,
+        interactive: 0,
+        background: 0,
+      },
+      queueWaitMs: {
+        typing: [1, 2],
+        interactive: [3],
+        background: [4],
+      },
+    };
+
+    const payload = toSchedulerMetricsLogPayload(metrics);
+    assert.deepEqual(payload, {
+      maxConcurrent: 2,
+      activeWorkers: 1,
+      queueDepth: {
+        typing: 3,
+        interactive: 1,
+        background: 2,
+      },
+      inFlightByClass: {
+        typing: 1,
+        interactive: 0,
+        background: 0,
+      },
+      scheduled: 12,
+      started: 10,
+      completed: 9,
+      failed: 1,
+      canceled: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
PR #742 was merged already. This follow-up PR carries the remaining observability normalization change that was pushed afterward: diagnostics and completion now share the exact same scheduler-metrics log schema via a common helper, with a focused unit test locking the payload shape.

## Context
- Merged baseline: #742
- This PR includes only the post-merge normalization slice that is still missing on `main`.

## Changes

- Added shared helper:
  - `packages/pike-lsp-server/src/features/utils/scheduler-metrics.ts`
  - `toSchedulerMetricsLogPayload(RequestSchedulerMetrics)`
- Exported helper via:
  - `packages/pike-lsp-server/src/features/utils/index.ts`
- Refactored handlers to use shared payload formatter:
  - `packages/pike-lsp-server/src/features/diagnostics/index.ts`
  - `packages/pike-lsp-server/src/features/editing/completion.ts`
- Added schema-locking test:
  - `packages/pike-lsp-server/src/tests/scheduler-metrics-log-payload.test.ts`

## Verification

- `bun test ./packages/pike-lsp-server/src/tests/scheduler-metrics-log-payload.test.ts` ✅
- `bun test ./packages/pike-lsp-server/src/tests/request-scheduler.test.ts` ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- pre-push checks (`node:test` guard, TypeScript build check, Pike compile check) ✅

## Notes for Reviewer

This PR intentionally does not change scheduler behavior. It only removes logging payload drift by centralizing formatting for diagnostics and completion scheduler metrics.

Fixes #738