### PR TITLE
perf: remove sync file reads from definition/rename hot paths

### DIFF
--- a/packages/pike-lsp-server/src/features/editing/rename.ts
+++ b/packages/pike-lsp-server/src/features/editing/rename.ts
@@ -24,7 +24,7 @@ import {
     OptionalVersionedTextDocumentIdentifier,
 } from 'vscode-languageserver/node.js';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import * as fs from 'fs';
+import { readFile } from 'node:fs/promises';
 import type { Services } from '../../services/index.js';
 import { Logger } from '@pike-lsp/core';
 
@@ -255,9 +255,9 @@ export function registerRenameHandlers(
                 const line = lines[lineNum];
                 if (!line) continue;
                 let searchStart = 0;
-                let matchIndex: number;
+                let matchIndex = line.indexOf(oldName, searchStart);
 
-                while ((matchIndex = line.indexOf(oldName, searchStart)) !== -1) {
+                while (matchIndex !== -1) {
                     const beforeChar = matchIndex > 0 ? line[matchIndex - 1] : ' ';
                     const afterChar = matchIndex + oldName.length < line.length ? line[matchIndex + oldName.length] : ' ';
 
@@ -272,6 +272,7 @@ export function registerRenameHandlers(
                         });
                     }
                     searchStart = matchIndex + 1;
+                    matchIndex = line.indexOf(oldName, searchStart);
                 }
             }
 
@@ -324,7 +325,7 @@ export function registerRenameHandlers(
             for (const file of uncachedFiles) {
                 try {
                     const filePath = decodeURIComponent(file.uri.replace(/^file:\/\//, ''));
-                    const fileContent = fs.readFileSync(filePath, 'utf-8');
+                    const fileContent = await readFile(filePath, 'utf-8');
 
                     // Quick text search fallback for uncached files
                     // Note: We can't use symbolPositions here since files aren't parsed

--- a/packages/pike-lsp-server/src/features/navigation/definition.ts
+++ b/packages/pike-lsp-server/src/features/navigation/definition.ts
@@ -15,7 +15,7 @@ import { Logger } from '@pike-lsp/core';
 import { extractExpressionAtPosition } from './expression-utils.js';
 import { queryNavigationLocations } from './query-engine.js';
 import type { ExpressionInfo, PikeSymbol, InheritanceInfo } from '@pike-lsp/pike-bridge';
-import { readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 
 /**
  * Convert a file:// URI to a filesystem path.
@@ -158,7 +158,7 @@ export function registerDefinitionHandlers(
           };
         }
 
-        const includedTextMatch = findSymbolTextInIncludedFiles(
+        const includedTextMatch = await findSymbolTextInIncludedFiles(
           wordAtCursor,
           cached,
           services,
@@ -669,12 +669,12 @@ function getWordAtPosition(
   return text.slice(start, end);
 }
 
-function findSymbolTextInIncludedFiles(
+async function findSymbolTextInIncludedFiles(
   symbolName: string,
   cached: DocumentCacheEntry,
   services: Services,
   log: Logger
-): { filePath: string; line: number; character: number } | null {
+): Promise<{ filePath: string; line: number; character: number } | null> {
   if (!symbolName || !cached.dependencies?.includes || !services.includeResolver) {
     return null;
   }
@@ -682,7 +682,7 @@ function findSymbolTextInIncludedFiles(
   const pattern = new RegExp(`\\b${symbolName}\\b`);
   for (const include of cached.dependencies.includes) {
     try {
-      const content = readFileSync(include.resolvedPath, 'utf-8');
+      const content = await readFile(include.resolvedPath, 'utf-8');
       const lines = content.split('\n');
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i] ?? '';
@@ -731,7 +731,7 @@ async function findSymbolInDirectIncludes(
     try {
       const resolved = await services.bridge.bridge.resolveInclude(includePath, currentFilePath);
       if (resolved.exists && resolved.path) {
-        const includeContent = readFileSync(resolved.path, 'utf-8');
+        const includeContent = await readFile(resolved.path, 'utf-8');
         const lines = includeContent.split('\n');
         for (let i = 0; i < lines.length; i++) {
           const line = lines[i] ?? '';
@@ -752,7 +752,12 @@ async function findSymbolInDirectIncludes(
           }
         }
       }
-    } catch {}
+    } catch (err) {
+      log.debug('Definition: include traversal failed', {
+        includePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
 
     includeMatch = includeRegex.exec(source);
   }
@@ -1065,9 +1070,9 @@ function findReferencesForSymbol(
       const line = lines[lineNum];
       if (!line) continue;
       let searchStart = 0;
-      let matchIndex: number;
+      let matchIndex = line.indexOf(symbolName, searchStart);
 
-      while ((matchIndex = line.indexOf(symbolName, searchStart)) !== -1) {
+      while (matchIndex !== -1) {
         const beforeChar = matchIndex > 0 ? line[matchIndex - 1] : ' ';
         const afterChar =
           matchIndex + symbolName.length < line.length ? line[matchIndex + symbolName.length] : ' ';
@@ -1083,6 +1088,7 @@ function findReferencesForSymbol(
           });
         }
         searchStart = matchIndex + 1;
+        matchIndex = line.indexOf(symbolName, searchStart);
       }
     }
   }
@@ -1115,9 +1121,9 @@ function findReferencesForSymbol(
           const line = otherLines[lineNum];
           if (!line) continue;
           let searchStart = 0;
-          let matchIndex: number;
+          let matchIndex = line.indexOf(symbolName, searchStart);
 
-          while ((matchIndex = line.indexOf(symbolName, searchStart)) !== -1) {
+          while (matchIndex !== -1) {
             const beforeChar = matchIndex > 0 ? line[matchIndex - 1] : ' ';
             const afterChar =
               matchIndex + symbolName.length < line.length
@@ -1134,6 +1140,7 @@ function findReferencesForSymbol(
               });
             }
             searchStart = matchIndex + 1;
+            matchIndex = line.indexOf(symbolName, searchStart);
           }
         }
       }


### PR DESCRIPTION
## Summary
This change removes synchronous filesystem reads from definition and rename fallback paths so navigation requests do not block the Node.js event loop during include/workspace scans. The behavior of returned locations/edits remains the same, but I/O now runs through async APIs.

## Linked Issue
closes #744

## Root Cause
`textDocument/definition` and `textDocument/rename` still used `readFileSync` on request paths that can scan many files. Because these handlers execute on the server request loop, synchronous reads can stall other incoming LSP work and increase editor latency.

## Changes
- `packages/pike-lsp-server/src/features/navigation/definition.ts`: replaced sync include-file reads with `node:fs/promises.readFile`, made included-file text lookup async, and added explicit debug logging for include traversal read failures.
- `packages/pike-lsp-server/src/features/editing/rename.ts`: replaced sync workspace fallback reads with async `readFile` to avoid event-loop blocking during uncached-file scans.
- `packages/pike-lsp-server/src/features/navigation/definition.ts` and `packages/pike-lsp-server/src/features/editing/rename.ts`: normalized `while ((x = ... ) !== -1)` loops into assignment-free form to satisfy TS diagnostics/lint constraints.

## Verification
- `bun run typecheck` ✅
- `bun test src/tests/navigation/definition-provider.test.ts src/tests/editing/rename-provider.test.ts src/tests/editing/rename-stress.test.ts` ✅ (122 pass, 0 fail)
- `bun run build` ✅
- `bun run lint` ✅ (passes with pre-existing warnings in `packages/vscode-pike/__mocks__/vscode.js`)
- Pre-commit hook smoke suite ✅
- Pre-push checks (node:test guard, TS build check, Pike compile check) ✅

## Notes for Reviewer
The scope is intentionally narrow to keep risk low: no protocol-shape changes, only I/O strategy in fallback scanning code paths.