### PR TITLE
perf: avoid full line-hash rebuild on incremental edits

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics/change-detection.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/change-detection.ts
@@ -7,7 +7,7 @@
 
 import type { Range } from 'vscode-languageserver/node.js';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import { computeContentHash, computeLineHashes } from '../../services/document-cache.js';
+import { computeContentHash, computeSemanticLineHash } from '../../services/document-cache.js';
 import type { DocumentCacheEntry } from '../../core/types.js';
 
 /**
@@ -69,22 +69,20 @@ export function classifyChange(
 
     // Strategy 2: Check if change overlaps with any symbol positions
     if (cachedEntry.lineHashes) {
-      const newLineHashes = computeLineHashes(text);
+      const lines = text.split('\n');
 
-      if (cachedEntry.lineHashes.length !== newLineHashes.length) {
+      if (cachedEntry.lineHashes.length !== lines.length) {
         return {
           canSkip: false,
           reason: 'line_count_changed',
-          newHash: computeContentHash(text),
-          newLineHashes,
         };
       }
 
       // Check if any line in the change range has different semantic content
       let hasSemanticChange = false;
-      for (let i = startLine; i <= endLine && i < newLineHashes.length; i++) {
+      for (let i = startLine; i <= endLine && i < lines.length; i++) {
         const cachedHash = cachedEntry.lineHashes[i];
-        const newHash = newLineHashes[i];
+        const newHash = computeSemanticLineHash(lines[i] ?? '');
 
         if (cachedHash !== newHash) {
           hasSemanticChange = true;
@@ -96,16 +94,13 @@ export function classifyChange(
         return {
           canSkip: true,
           reason: 'semantic_unchanged',
-          newHash: computeContentHash(text),
-          newLineHashes,
+          newLineHashes: cachedEntry.lineHashes,
         };
       }
 
       return {
         canSkip: false,
         reason: 'semantic_changed',
-        newHash: computeContentHash(text),
-        newLineHashes,
       };
     }
   }

--- a/packages/pike-lsp-server/src/services/document-cache.ts
+++ b/packages/pike-lsp-server/src/services/document-cache.ts
@@ -31,13 +31,15 @@ export function computeLineHashes(content: string): number[] {
     const hashes: number[] = [];
 
     for (const line of lines) {
-        // Remove comments and normalize whitespace
-        const semantic = stripComments(line.trim());
-        // Simple hash for quick comparison
-        hashes.push(simpleHash(semantic));
+        hashes.push(computeSemanticLineHash(line));
     }
 
     return hashes;
+}
+
+export function computeSemanticLineHash(line: string): number {
+    const semantic = stripComments(line.trim());
+    return simpleHash(semantic);
 }
 
 /**

--- a/packages/pike-lsp-server/src/tests/features/diagnostics/change-detection.test.ts
+++ b/packages/pike-lsp-server/src/tests/features/diagnostics/change-detection.test.ts
@@ -70,6 +70,7 @@ describe('classifyChange', () => {
 
     expect(result.canSkip).toBe(true);
     expect(result.reason).toBe('semantic_unchanged');
+    expect(result.newLineHashes).toBe(cachedEntry.lineHashes);
   });
 
   it('does not skip when incremental edit changes total line count', () => {
@@ -89,5 +90,26 @@ describe('classifyChange', () => {
 
     expect(result.canSkip).toBe(false);
     expect(result.reason).toBe('line_count_changed');
+    expect(result.newLineHashes).toBeUndefined();
+  });
+
+  it('does not return line hashes when semantic content changed', () => {
+    const previousText = 'int x = 1;\n';
+    const currentText = 'int x = 2;\n';
+    const cachedEntry = makeCachedEntry(previousText);
+    const document = TextDocument.create('file:///test.pike', 'pike', 2, currentText);
+
+    const result = classifyChange(
+      document,
+      {
+        start: { line: 0, character: 8 },
+        end: { line: 0, character: 9 },
+      },
+      cachedEntry
+    );
+
+    expect(result.canSkip).toBe(false);
+    expect(result.reason).toBe('semantic_changed');
+    expect(result.newLineHashes).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
This reduces per-edit diagnostics classification cost by removing full-document line-hash recomputation from the incremental change path. For range-based edits, the classifier now evaluates only changed lines for semantic deltas and reuses existing line-hash state when content is semantically unchanged.

## Linked Issue
closes #745

## Root Cause
`classifyChange` rebuilt line hashes for the entire file (`computeLineHashes(text)`) on each incremental edit before checking just the changed range. That made typing cost scale with file length even for tiny edits.

## Changes
- `packages/pike-lsp-server/src/features/diagnostics/change-detection.ts`: replaced full-document hash rebuild with range-focused semantic hash checks via per-line hashing of only the changed span; removed unnecessary full-content hash work from incremental range branches.
- `packages/pike-lsp-server/src/services/document-cache.ts`: added `computeSemanticLineHash` and reused it from `computeLineHashes` to share semantic line hash logic.
- `packages/pike-lsp-server/src/tests/features/diagnostics/change-detection.test.ts`: added regression assertions ensuring semantic-unchanged edits reuse existing line hash arrays and semantic-changed/line-count-changed edits do not produce rebuilt hash arrays.

## Verification
- `bun run typecheck` ✅
- `bun test src/tests/features/diagnostics/change-detection.test.ts` ✅ (5 pass, 0 fail)
- `bun run build` ✅
- Pre-commit smoke + test-quality checks ✅
- Pre-push checks (node:test guard, TS build check, Pike compile check) ✅

## Notes for Reviewer
This intentionally leaves full-document replacement behavior unchanged. The optimization targets only incremental edit classification paths where range metadata is available.