### PR TITLE
perf: bound uncached fallback scans for references and rename

### DIFF
--- a/packages/pike-lsp-server/src/features/editing/rename.ts
+++ b/packages/pike-lsp-server/src/features/editing/rename.ts
@@ -317,23 +317,68 @@ export function registerRenameHandlers(
 
         // Search workspace files not currently open
         if (services.workspaceScanner?.isReady()) {
-            const cachedUris = new Set(documentCache.keys());
-            const uncachedFiles = services.workspaceScanner.getUncachedFiles(cachedUris);
+            if (!matchingSymbol) {
+                log.debug('Rename: skipping uncached workspace search without matched symbol');
+            } else {
+                const cachedUris = new Set(documentCache.keys());
+                const uncachedFiles = services.workspaceScanner.getUncachedFiles(cachedUris);
+                const maxWorkspaceFiles = Math.max(
+                    1,
+                    Number.parseInt(process.env['PIKE_LSP_RENAME_MAX_WORKSPACE_FILES'] ?? '150', 10)
+                );
+                const boundedFiles = uncachedFiles.slice(0, maxWorkspaceFiles);
+                const BATCH_SIZE = 10;
+                const YIELD_EVERY_N_BATCHES = 4;
+                const requestVersion = document.version;
+                let cancelled = false;
 
-            log.debug('Rename: searching workspace files', { uncachedFileCount: uncachedFiles.length });
+                log.debug('Rename: searching workspace files', {
+                    uncachedFileCount: uncachedFiles.length,
+                    boundedFileCount: boundedFiles.length,
+                });
 
-            for (const file of uncachedFiles) {
-                try {
-                    const filePath = decodeURIComponent(file.uri.replace(/^file:\/\//, ''));
-                    const fileContent = await readFile(filePath, 'utf-8');
+                for (let i = 0; i < boundedFiles.length; i += BATCH_SIZE) {
+                    const latest = documents.get(uri);
+                    if (!latest || latest.version !== requestVersion) {
+                        cancelled = true;
+                        break;
+                    }
 
-                    // Quick text search fallback for uncached files
-                    // Note: We can't use symbolPositions here since files aren't parsed
-                    addEditsFromTextSearch(file.uri, fileContent);
-                } catch (err) {
-                    log.warn('Failed to read file for rename', {
-                        uri: file.uri,
-                        error: err instanceof Error ? err.message : String(err)
+                    const batch = boundedFiles.slice(i, Math.min(i + BATCH_SIZE, boundedFiles.length));
+
+                    for (const file of batch) {
+                        try {
+                            const latest = documents.get(uri);
+                            if (!latest || latest.version !== requestVersion) {
+                                cancelled = true;
+                                break;
+                            }
+
+                            const filePath = decodeURIComponent(file.uri.replace(/^file:\/\//, ''));
+                            const fileContent = await readFile(filePath, 'utf-8');
+
+                            if (!fileContent.includes(oldName)) {
+                                continue;
+                            }
+
+                            addEditsFromTextSearch(file.uri, fileContent);
+                        } catch (err) {
+                            log.warn('Failed to read file for rename', {
+                                uri: file.uri,
+                                error: err instanceof Error ? err.message : String(err)
+                            });
+                        }
+                    }
+
+                    if ((i / BATCH_SIZE) % YIELD_EVERY_N_BATCHES === 0 && i > 0) {
+                        await new Promise(resolve => setImmediate(resolve));
+                    }
+                }
+
+                if (cancelled) {
+                    log.debug('Rename: workspace scan cancelled due to document version change', {
+                        uri,
+                        requestVersion,
                     });
                 }
             }

--- a/packages/pike-lsp-server/src/features/navigation/references.ts
+++ b/packages/pike-lsp-server/src/features/navigation/references.ts
@@ -15,6 +15,7 @@ import { TextDocuments } from 'vscode-languageserver/node.js';
 import type { Services } from '../../services/index.js';
 import { Logger } from '@pike-lsp/core';
 import { queryNavigationLocations } from './query-engine.js';
+import { readFile } from 'node:fs/promises';
 
 /**
  * Register references handlers.
@@ -158,9 +159,9 @@ export function registerReferencesHandlers(
           const line = lines[lineNum];
           if (!line) continue;
           let searchStart = 0;
-          let matchIndex: number;
+          let matchIndex = line.indexOf(word, searchStart);
 
-          while ((matchIndex = line.indexOf(word, searchStart)) !== -1) {
+          while (matchIndex !== -1) {
             const beforeChar = matchIndex > 0 ? line[matchIndex - 1] : ' ';
             const afterChar =
               matchIndex + word.length < line.length ? line[matchIndex + word.length] : ' ';
@@ -176,6 +177,7 @@ export function registerReferencesHandlers(
               });
             }
             searchStart = matchIndex + 1;
+            matchIndex = line.indexOf(word, searchStart);
           }
         }
       }
@@ -212,9 +214,9 @@ export function registerReferencesHandlers(
                 const line = otherLines[lineNum];
                 if (!line) continue;
                 let searchStart = 0;
-                let matchIndex: number;
+                let matchIndex = line.indexOf(word, searchStart);
 
-                while ((matchIndex = line.indexOf(word, searchStart)) !== -1) {
+                while (matchIndex !== -1) {
                   const beforeChar = matchIndex > 0 ? line[matchIndex - 1] : ' ';
                   const afterChar =
                     matchIndex + word.length < line.length ? line[matchIndex + word.length] : ' ';
@@ -229,6 +231,7 @@ export function registerReferencesHandlers(
                     });
                   }
                   searchStart = matchIndex + 1;
+                  matchIndex = line.indexOf(word, searchStart);
                 }
               }
             }
@@ -248,9 +251,15 @@ export function registerReferencesHandlers(
         } else {
           const cachedUris = new Set(documentCache.keys());
           const uncachedFiles = services.workspaceScanner.getUncachedFiles(cachedUris);
+          const maxWorkspaceFiles = Math.max(
+            1,
+            Number.parseInt(process.env['PIKE_LSP_REFERENCES_MAX_WORKSPACE_FILES'] ?? '250', 10)
+          );
+          const boundedFiles = uncachedFiles.slice(0, maxWorkspaceFiles);
 
           log.debug('References: searching workspace files', {
             uncachedFileCount: uncachedFiles.length,
+            boundedFileCount: boundedFiles.length,
             word,
           });
 
@@ -263,11 +272,11 @@ export function registerReferencesHandlers(
           let progress: any = null;
 
           // Create progress token for large workspace scans
-          if (enableProgress && uncachedFiles.length > PROGRESS_THRESHOLD) {
+          if (enableProgress && boundedFiles.length > PROGRESS_THRESHOLD) {
             try {
               progress = await connection.window.createWorkDoneProgress();
-              progress.begin('Searching workspace...', 0, uncachedFiles.length);
-              log.debug('References: progress started', { totalFiles: uncachedFiles.length });
+              progress.begin('Searching workspace...', 0, boundedFiles.length);
+              log.debug('References: progress started', { totalFiles: boundedFiles.length });
             } catch (err) {
               // Client may not support workDoneProgress
               log.debug('References: failed to create progress', {
@@ -278,14 +287,28 @@ export function registerReferencesHandlers(
           }
 
           // Process workspace files in batches with yielding
-          for (let i = 0; i < uncachedFiles.length; i += BATCH_SIZE) {
-            const batch = uncachedFiles.slice(i, Math.min(i + BATCH_SIZE, uncachedFiles.length));
+          const requestVersion = document.version;
+          let cancelled = false;
+
+          for (let i = 0; i < boundedFiles.length; i += BATCH_SIZE) {
+            const latest = documents.get(uri);
+            if (!latest || latest.version !== requestVersion) {
+              cancelled = true;
+              break;
+            }
+
+            const batch = boundedFiles.slice(i, Math.min(i + BATCH_SIZE, boundedFiles.length));
 
             for (const file of batch) {
               try {
+                const latest = documents.get(uri);
+                if (!latest || latest.version !== requestVersion) {
+                  cancelled = true;
+                  break;
+                }
+
                 // Read file content
                 const filePath = decodeURIComponent(file.uri.replace(/^file:\/\//, ''));
-                const { readFile } = await import('node:fs/promises');
                 const content = await readFile(filePath, 'utf-8');
 
                 // Check if the word appears in the file (quick text search first)
@@ -302,9 +325,9 @@ export function registerReferencesHandlers(
                   const line = lines[lineNum];
                   if (!line) continue;
                   let searchStart = 0;
-                  let matchIndex: number;
+                  let matchIndex = line.indexOf(word, searchStart);
 
-                  while ((matchIndex = line.indexOf(word, searchStart)) !== -1) {
+                  while (matchIndex !== -1) {
                     const beforeChar = matchIndex > 0 ? line[matchIndex - 1] : ' ';
                     const afterChar =
                       matchIndex + word.length < line.length ? line[matchIndex + word.length] : ' ';
@@ -320,6 +343,7 @@ export function registerReferencesHandlers(
                       });
                     }
                     searchStart = matchIndex + 1;
+                    matchIndex = line.indexOf(word, searchStart);
                   }
                 }
               } catch (err) {
@@ -333,7 +357,7 @@ export function registerReferencesHandlers(
 
             // Report progress after each batch
             if (progress) {
-              const completed = Math.min(i + BATCH_SIZE, uncachedFiles.length);
+              const completed = Math.min(i + BATCH_SIZE, boundedFiles.length);
               progress.report(completed, `Scanned ${completed} files...`);
             }
 
@@ -347,6 +371,13 @@ export function registerReferencesHandlers(
           if (progress) {
             progress.done(`Found ${references.length} references`);
             log.debug('References: progress complete', { totalReferences: references.length });
+          }
+
+          if (cancelled) {
+            log.debug('References: workspace scan cancelled due to document version change', {
+              uri,
+              requestVersion,
+            });
           }
 
           log.debug('References: workspace search complete', {
@@ -489,9 +520,9 @@ export function registerReferencesHandlers(
         const line = lines[lineNum];
         if (!line) continue;
         let searchStart = 0;
-        let matchIndex: number;
+        let matchIndex = line.indexOf(word, searchStart);
 
-        while ((matchIndex = line.indexOf(word, searchStart)) !== -1) {
+        while (matchIndex !== -1) {
           const beforeChar = matchIndex > 0 ? line[matchIndex - 1] : ' ';
           const afterChar =
             matchIndex + word.length < line.length ? line[matchIndex + word.length] : ' ';
@@ -506,6 +537,7 @@ export function registerReferencesHandlers(
             });
           }
           searchStart = matchIndex + 1;
+          matchIndex = line.indexOf(word, searchStart);
         }
       }
 

--- a/packages/pike-lsp-server/src/tests/editing/rename-stress.test.ts
+++ b/packages/pike-lsp-server/src/tests/editing/rename-stress.test.ts
@@ -13,6 +13,9 @@
 
 import { describe, it, expect, beforeEach } from 'bun:test';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
     Range,
     Position,
@@ -22,7 +25,7 @@ import {
     OptionalVersionedTextDocumentIdentifier,
 } from 'vscode-languageserver/node.js';
 import type { PikeSymbol } from '@pike-lsp/pike-bridge';
-import type { DocumentCacheEntry } from '../core/types.js';
+import type { DocumentCacheEntry } from '../../core/types.js';
 import { registerRenameHandlers } from '../../features/editing/rename.js';
 
 // =============================================================================
@@ -92,6 +95,7 @@ interface SetupOptions {
     symbols?: PikeSymbol[];
     cacheExtra?: Partial<DocumentCacheEntry>;
     noCache?: boolean;
+    workspaceScanner?: any;
 }
 
 function setup(options: SetupOptions) {
@@ -100,6 +104,7 @@ function setup(options: SetupOptions) {
         uri = 'file:///test.pike',
         symbols = [],
         cacheExtra = {},
+        workspaceScanner = null,
     } = options;
 
     const mockConnection = createMockConnection();
@@ -121,9 +126,10 @@ function setup(options: SetupOptions) {
         documentCache: {
             get: (docUri: string) => documentCache.get(docUri),
             entries: () => documentCache.entries(),
+            keys: () => documentCache.keys(),
         },
         bridge: null, // Use fallback logic
-        workspaceScanner: null,
+        workspaceScanner,
         logger: silentLogger,
     } as any;
 
@@ -670,6 +676,54 @@ Stdio.File f = Stdio.File();`;
 
             const result = await rename(1, 12, 'FileHandle');
             expect(result).not.toBeNull();
+        });
+
+        it('limits uncached workspace fallback search to configured max files', async () => {
+            const previousMax = process.env['PIKE_LSP_RENAME_MAX_WORKSPACE_FILES'];
+            process.env['PIKE_LSP_RENAME_MAX_WORKSPACE_FILES'] = '1';
+
+            const dir = await mkdtemp(join(tmpdir(), 'pike-lsp-rename-'));
+            try {
+                const firstPath = join(dir, 'first.pmod');
+                const secondPath = join(dir, 'second.pmod');
+                await writeFile(firstPath, 'int sharedName = 1;\nsharedName++;\n', 'utf-8');
+                await writeFile(secondPath, 'int sharedName = 1;\nsharedName += 2;\n', 'utf-8');
+
+                const firstUri = `file://${firstPath}`;
+                const secondUri = `file://${secondPath}`;
+
+                const { rename } = setup({
+                    uri: 'file:///module.pmod',
+                    code: 'int sharedName = 0;\nsharedName++;\n',
+                    symbols: [sym('sharedName', 'variable')],
+                    workspaceScanner: {
+                        isReady: () => true,
+                        getUncachedFiles: () => [
+                            { uri: firstUri, path: firstPath },
+                            { uri: secondUri, path: secondPath },
+                        ],
+                    },
+                });
+
+                const result = await rename(0, 5, 'renamedSymbol');
+                const changedUris = new Set(
+                    (result?.documentChanges ?? [])
+                        .filter(
+                            (change): change is TextDocumentEdit => 'textDocument' in change
+                        )
+                        .map(change => change.textDocument.uri)
+                );
+
+                expect(changedUris.has(firstUri)).toBe(true);
+                expect(changedUris.has(secondUri)).toBe(false);
+            } finally {
+                if (previousMax === undefined) {
+                    delete process.env['PIKE_LSP_RENAME_MAX_WORKSPACE_FILES'];
+                } else {
+                    process.env['PIKE_LSP_RENAME_MAX_WORKSPACE_FILES'] = previousMax;
+                }
+                await rm(dir, { recursive: true, force: true });
+            }
         });
     });
 

--- a/packages/pike-lsp-server/src/tests/navigation/references-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/navigation/references-provider.test.ts
@@ -15,6 +15,9 @@ import { describe, it, expect } from 'bun:test';
 import { DocumentHighlightKind } from 'vscode-languageserver/node.js';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import type { PikeSymbol } from '@pike-lsp/pike-bridge';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { registerReferencesHandlers } from '../../features/navigation/references.js';
 import {
   createMockConnection,
@@ -219,6 +222,52 @@ describe('References Provider', () => {
     const baselineP95 = p95(baselineTimes);
     const queryP95 = p95(queryTimes);
     expect(queryP95).toBeLessThanOrEqual(baselineP95 * 2.0 + 1.0);
+  });
+
+  it('bounds workspace fallback search to configured max files', async () => {
+    const previousMax = process.env['PIKE_LSP_REFERENCES_MAX_WORKSPACE_FILES'];
+    process.env['PIKE_LSP_REFERENCES_MAX_WORKSPACE_FILES'] = '1';
+
+    const dir = await mkdtemp(join(tmpdir(), 'pike-lsp-refs-'));
+    try {
+      const firstPath = join(dir, 'first.pmod');
+      const secondPath = join(dir, 'second.pmod');
+      await writeFile(firstPath, 'int shared = 1;\nshared++;\n', 'utf-8');
+      await writeFile(secondPath, 'int shared = 1;\nshared += 2;\n', 'utf-8');
+
+      const firstUri = `file://${firstPath}`;
+      const secondUri = `file://${secondPath}`;
+      const scanner = createMockWorkspaceScanner([
+        { uri: firstUri, content: '' },
+        { uri: secondUri, content: '' },
+      ]);
+
+      const { references } = setup({
+        uri: 'file:///module.pmod',
+        code: 'int shared = 0;\nshared++;\n',
+        symbols: [
+          {
+            name: 'shared',
+            kind: 'variable',
+            modifiers: [],
+            position: { file: 'module.pmod', line: 1 },
+          },
+        ],
+        workspaceScanner: scanner,
+      });
+
+      const result = await references(0, 5);
+      const uris = new Set(result.map(item => item.uri));
+      expect(uris.has(firstUri)).toBe(true);
+      expect(uris.has(secondUri)).toBe(false);
+    } finally {
+      if (previousMax === undefined) {
+        delete process.env['PIKE_LSP_REFERENCES_MAX_WORKSPACE_FILES'];
+      } else {
+        process.env['PIKE_LSP_REFERENCES_MAX_WORKSPACE_FILES'] = previousMax;
+      }
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it('should not register implementation handler (owned by implementation.ts)', () => {


### PR DESCRIPTION
## Summary
This hardens uncached workspace fallback scans for references and rename by introducing bounded scan windows, cooperative yielding, and stale-request guards tied to document version. It also narrows cross-file rename fallback to symbol-backed requests to reduce low-confidence workspace edits.

## Linked Issue
closes #746

## Root Cause
Uncached fallback paths could scan arbitrarily many files and continue work even when the originating request had become stale due to document updates. Rename fallback also allowed broad uncached workspace edits without requiring symbol-level confidence.

## Changes
- `packages/pike-lsp-server/src/features/navigation/references.ts`
  - add `PIKE_LSP_REFERENCES_MAX_WORKSPACE_FILES` bound (default `250`) for uncached workspace files
  - add request-version stale checks during batched scanning to stop stale work
  - keep cooperative yielding and move file reads to static `readFile` import
- `packages/pike-lsp-server/src/features/editing/rename.ts`
  - require a matched symbol before uncached workspace fallback scanning
  - add `PIKE_LSP_RENAME_MAX_WORKSPACE_FILES` bound (default `150`)
  - add batched scanning + periodic yield + request-version stale checks
  - quick prefilter (`includes(oldName)`) before full text-scan edits
- `packages/pike-lsp-server/src/tests/navigation/references-provider.test.ts`
  - add regression test asserting workspace fallback obeys configured file cap
- `packages/pike-lsp-server/src/tests/editing/rename-stress.test.ts`
  - extend setup mocks (`workspaceScanner`, `documentCache.keys`) and add regression test for rename workspace cap behavior

## Verification
- `bun test src/tests/navigation/references-provider.test.ts src/tests/editing/rename-stress.test.ts` ✅ (83 pass, 0 fail)
- `bun run typecheck` ✅
- `bun run build` ✅
- `lsp_diagnostics` clean for modified source files ✅
- Pre-commit smoke + test-quality checks ✅
- Pre-push checks (node:test guard, TS build check, Pike compile check) ✅

## Notes for Reviewer
This keeps behavior intentionally incremental: no protocol shape changes, no query-engine rewrite, and no broad rename semantics redesign. The focus is bounded work + stale-request safety in fallback loops.