### PR TITLE
perf: cache semantic tokens by document version

### DIFF
--- a/packages/pike-lsp-server/src/features/advanced/semantic-tokens.ts
+++ b/packages/pike-lsp-server/src/features/advanced/semantic-tokens.ts
@@ -67,7 +67,7 @@ export function registerSemanticTokensHandler(
 ): void {
   const { documentCache } = services;
   const log = new Logger('Advanced');
-  const tokenStateByUri = new Map<string, { resultId: string; data: number[] }>();
+  const tokenStateByUri = new Map<string, { resultId: string; data: number[]; version: number }>();
   let nextResultCounter = 0;
 
   const makeResultId = (): string => {
@@ -116,6 +116,22 @@ export function registerSemanticTokensHandler(
       deleteCount,
       data,
     };
+  };
+
+  const getOrBuildTokenState = (uri: string, document: TextDocument) => {
+    const existing = tokenStateByUri.get(uri);
+    if (existing && existing.version === document.version) {
+      return existing;
+    }
+
+    const tokens = buildTokens(uri, document);
+    const state = {
+      resultId: makeResultId(),
+      data: [...tokens.data],
+      version: document.version,
+    };
+    tokenStateByUri.set(uri, state);
+    return state;
   };
 
   /**
@@ -242,19 +258,17 @@ export function registerSemanticTokensHandler(
           continue;
         }
 
-        let match: RegExpExecArray | null;
-        while ((match = symbolRegex.exec(line)) !== null) {
+        let match = symbolRegex.exec(line);
+        while (match !== null) {
           const matchIndex = match.index;
 
-          if (isInsideComment(line, matchIndex) || isInsideString(line, matchIndex)) {
-            continue;
+          if (!(isInsideComment(line, matchIndex) || isInsideString(line, matchIndex))) {
+            const isDeclaration = symbol.position && symbol.position.line - 1 === lineNum;
+            const modifiers = isDeclaration ? declModifiers : 0;
+            builder.push(lineNum, matchIndex, symbol.name.length, tokenType, modifiers);
           }
 
-          const isDeclaration = symbol.position && symbol.position.line - 1 === lineNum;
-
-          const modifiers = isDeclaration ? declModifiers : 0;
-
-          builder.push(lineNum, matchIndex, symbol.name.length, tokenType, modifiers);
+          match = symbolRegex.exec(line);
         }
       }
     }
@@ -271,15 +285,15 @@ export function registerSemanticTokensHandler(
 
       for (const keyword of controlKeywords) {
         const keywordRegex = new RegExp(`\\b${keyword}\\b`, 'g');
-        let match: RegExpExecArray | null;
-        while ((match = keywordRegex.exec(line)) !== null) {
+        let match = keywordRegex.exec(line);
+        while (match !== null) {
           const matchIndex = match.index;
 
-          if (isInsideComment(line, matchIndex) || isInsideString(line, matchIndex)) {
-            continue;
+          if (!(isInsideComment(line, matchIndex) || isInsideString(line, matchIndex))) {
+            builder.push(lineNum, matchIndex, keyword.length, keywordTokenType, 0);
           }
 
-          builder.push(lineNum, matchIndex, keyword.length, keywordTokenType, 0);
+          match = keywordRegex.exec(line);
         }
       }
     }
@@ -313,12 +327,10 @@ export function registerSemanticTokensHandler(
         return { resultId: '0', data: [] };
       }
 
-      const tokens = buildTokens(uri, document);
-      const resultId = makeResultId();
-      tokenStateByUri.set(uri, { resultId, data: [...tokens.data] });
+      const state = getOrBuildTokenState(uri, document);
       return {
-        resultId,
-        data: tokens.data,
+        resultId: state.resultId,
+        data: state.data,
       };
     } catch (err) {
       log.error(
@@ -342,30 +354,40 @@ export function registerSemanticTokensHandler(
         return { resultId: '0', edits: [] };
       }
 
-      const tokens = buildTokens(uri, document);
-      const newResultId = makeResultId();
-      const nextData = [...tokens.data];
+      const nextState = getOrBuildTokenState(uri, document);
 
-      if (!previousState || previousState.resultId !== params.previousResultId) {
-        tokenStateByUri.set(uri, { resultId: newResultId, data: nextData });
+      if (previousState && previousState.resultId === nextState.resultId) {
+        if (params.previousResultId === nextState.resultId) {
+          return {
+            resultId: nextState.resultId,
+            edits: [],
+          };
+        }
+
         return {
-          resultId: newResultId,
-          edits: [{ start: 0, deleteCount: 0, data: nextData }],
+          resultId: nextState.resultId,
+          edits: [{ start: 0, deleteCount: 0, data: nextState.data }],
         };
       }
 
-      const edit = computeDeltaEdit(previousState.data, nextData);
-      tokenStateByUri.set(uri, { resultId: newResultId, data: nextData });
+      if (!previousState || previousState.resultId !== params.previousResultId) {
+        return {
+          resultId: nextState.resultId,
+          edits: [{ start: 0, deleteCount: 0, data: nextState.data }],
+        };
+      }
+
+      const edit = computeDeltaEdit(previousState.data, nextState.data);
 
       if (!edit) {
         return {
-          resultId: newResultId,
+          resultId: nextState.resultId,
           edits: [],
         };
       }
 
       return {
-        resultId: newResultId,
+        resultId: nextState.resultId,
         edits: [edit],
       };
     } catch (err) {

--- a/packages/pike-lsp-server/src/tests/advanced/semantic-tokens-delta.test.ts
+++ b/packages/pike-lsp-server/src/tests/advanced/semantic-tokens-delta.test.ts
@@ -195,6 +195,33 @@ int main() { return x; }`;
       expect(result).toBeDefined();
       expect(result.data).toEqual([]);
     });
+
+    it('reuses full semantic token result for unchanged document version', () => {
+      const uri = 'file:///cached-full.pike';
+      const code = `int cached = 1;`;
+
+      const doc = TextDocument.create(uri, 'pike', 1, code);
+      const docsMap = new Map<string, TextDocument>();
+      docsMap.set(uri, doc);
+
+      const cacheEntry: DocumentCacheEntry = makeCacheEntry({
+        symbols: [sym('cached', 'variable', { position: { line: 1, character: 4 } })],
+      });
+
+      const services = createMockServices({
+        cacheEntries: new Map([[uri, cacheEntry]]),
+      });
+      const documents = createMockDocuments(docsMap);
+      const conn = createMockConnection();
+
+      registerSemanticTokensHandler(conn as any, services as any, documents as any);
+
+      const first = conn.semanticTokensHandler({ textDocument: { uri } });
+      const second = conn.semanticTokensHandler({ textDocument: { uri } });
+
+      expect(second.resultId).toBe(first.resultId);
+      expect(second.data).toEqual(first.data);
+    });
   });
 
   describe('Delta Edits Format', () => {
@@ -302,6 +329,64 @@ int b = 2;`;
 
       expect(delta.edits.length).toBe(1);
       expect(delta.edits[0].start).toBe(0);
+    });
+
+    it('reuses delta state for unchanged version and matching previousResultId', () => {
+      const uri = 'file:///cached-delta.pike';
+      const code = `int token = 1;`;
+
+      const doc = TextDocument.create(uri, 'pike', 1, code);
+      const docsMap = new Map<string, TextDocument>();
+      docsMap.set(uri, doc);
+
+      const cacheEntry: DocumentCacheEntry = makeCacheEntry({
+        symbols: [sym('token', 'variable', { position: { line: 1, character: 4 } })],
+      });
+
+      const services = createMockServices({
+        cacheEntries: new Map([[uri, cacheEntry]]),
+      });
+      const documents = createMockDocuments(docsMap);
+      const conn = createMockConnection();
+
+      registerSemanticTokensHandler(conn as any, services as any, documents as any);
+
+      const full = conn.semanticTokensHandler({ textDocument: { uri } });
+      const delta = conn.semanticTokensDeltaHandler({
+        textDocument: { uri },
+        previousResultId: full.resultId,
+      });
+
+      expect(delta.resultId).toBe(full.resultId);
+      expect(delta.edits).toEqual([]);
+    });
+
+    it('invalidates semantic token cache when document version changes', () => {
+      const uri = 'file:///cached-invalidate.pike';
+      const firstCode = `int invalidate = 1;`;
+      const secondCode = `int invalidate = 2;`;
+
+      const docsMap = new Map<string, TextDocument>();
+      docsMap.set(uri, TextDocument.create(uri, 'pike', 1, firstCode));
+
+      const cacheEntry: DocumentCacheEntry = makeCacheEntry({
+        symbols: [sym('invalidate', 'variable', { position: { line: 1, character: 4 } })],
+      });
+
+      const services = createMockServices({
+        cacheEntries: new Map([[uri, cacheEntry]]),
+      });
+      const documents = createMockDocuments(docsMap);
+      const conn = createMockConnection();
+
+      registerSemanticTokensHandler(conn as any, services as any, documents as any);
+
+      const first = conn.semanticTokensHandler({ textDocument: { uri } });
+
+      docsMap.set(uri, TextDocument.create(uri, 'pike', 2, secondCode));
+      const second = conn.semanticTokensHandler({ textDocument: { uri } });
+
+      expect(second.resultId).not.toBe(first.resultId);
     });
   });
 });


### PR DESCRIPTION
## Summary
This adds document-version-aware caching to semantic token full/delta handlers so repeated requests on unchanged documents reuse cached token payloads instead of rebuilding token arrays. It reduces redundant regex/symbol scans while keeping existing delta semantics.

## Linked Issue
closes #750

## Root Cause
Semantic token full and delta handlers rebuilt token arrays on every request (`buildTokens`) even when the document version was unchanged. Existing state tracked only `resultId` and `data`, so cache validity could not be determined by version.

## Changes
- `packages/pike-lsp-server/src/features/advanced/semantic-tokens.ts`
  - extend token state to include `version`
  - add `getOrBuildTokenState(uri, document)` helper
  - full handler now reuses cached result for unchanged version
  - delta handler short-circuits unchanged-version requests and only recomputes on version change
  - keep `onDidClose` cache eviction behavior
- `packages/pike-lsp-server/src/tests/advanced/semantic-tokens-delta.test.ts`
  - add test that full requests reuse `resultId` on unchanged version
  - add test that delta requests return empty edits and reuse `resultId` when unchanged
  - add test that cache invalidates when document version changes

## Verification
- `bun test src/tests/advanced/semantic-tokens-delta.test.ts` ✅ (13 pass, 0 fail)
- `bun run typecheck` ✅
- `bun run build` ✅
- `bash scripts/test-agent.sh --fast` ✅ (pike-compile/bridge/server all pass)
- Pre-commit and pre-push hooks ✅

## Notes for Reviewer
The broader semantic token stress/provider suites are heavy and were not required for this focused change; delta suite coverage was extended to directly validate cache reuse/invalidation behavior introduced here.