### PR TITLE
perf: cache RXML includeDeclaration tag declarations

### DIFF
--- a/packages/pike-lsp-server/src/features/rxml/references-provider.ts
+++ b/packages/pike-lsp-server/src/features/rxml/references-provider.ts
@@ -27,6 +27,13 @@ const tagReferenceIndexCache = new Map<
     byTag: Map<string, Location[]>;
   }
 >();
+const tagDeclarationIndexCache = new Map<
+  string,
+  {
+    builtAt: number;
+    byTag: Map<string, Location[]>;
+  }
+>();
 const fileContentCache = new Map<string, { mtimeMs: number; content: string }>();
 
 function uriToFilePath(uri: string): string {
@@ -84,6 +91,54 @@ async function getTagReferenceIndex(workspaceFolders: string[]): Promise<Map<str
   return byTag;
 }
 
+async function getTagDeclarationIndex(
+  workspaceFolders: string[]
+): Promise<Map<string, Location[]>> {
+  const key = makeWorkspaceKey(workspaceFolders);
+  const now = Date.now();
+  const cached = tagDeclarationIndexCache.get(key);
+  if (cached && now - cached.builtAt < TAG_REFERENCE_INDEX_TTL_MS) {
+    return cached.byTag;
+  }
+
+  const byTag = new Map<string, Location[]>();
+  const pikeFiles = await findPikeFiles(workspaceFolders);
+
+  for (const file of pikeFiles) {
+    const content = await readFileCached(file);
+    const patterns = [
+      /\bsimpletag\s+([A-Za-z_][A-Za-z0-9_]*)\b/g,
+      /\bcontainer\s+([A-Za-z_][A-Za-z0-9_]*)\b/g,
+    ];
+
+    for (const pattern of patterns) {
+      let match = pattern.exec(content);
+      while (match !== null) {
+        const matchedTag = match[1];
+        if (matchedTag) {
+          const keyName = matchedTag.toLowerCase();
+          const locations = byTag.get(keyName) ?? [];
+          const position = findPositionForMatch(content, match);
+
+          locations.push({
+            uri: fileToUri(file),
+            range: {
+              start: position,
+              end: { line: position.line, character: position.character + matchedTag.length },
+            },
+          });
+          byTag.set(keyName, locations);
+        }
+
+        match = pattern.exec(content);
+      }
+    }
+  }
+
+  tagDeclarationIndexCache.set(key, { builtAt: now, byTag });
+  return byTag;
+}
+
 /**
  * Find all references to a tag in workspace
  *
@@ -109,31 +164,9 @@ export async function findTagReferences(
 
   // Also search in .pike files for tag function references
   if (includeDeclaration) {
-    const pikeFiles = await findPikeFiles(workspaceFolders);
-
-    for (const file of pikeFiles) {
-      const content = await readFileCached(file);
-
-      // Look for simpletag_* or container_* function definitions
-      const patterns = [
-        new RegExp(`\\bsimpletag\\s+${escapeRegExp(tagName)}\\b`, 'g'),
-        new RegExp(`\\bcontainer\\s+${escapeRegExp(tagName)}\\b`, 'g'),
-      ];
-
-      for (const pattern of patterns) {
-        let match;
-        while ((match = pattern.exec(content)) !== null) {
-          const position = findPositionForMatch(content, match);
-          locations.push({
-            uri: fileToUri(file),
-            range: {
-              start: position,
-              end: { line: position.line, character: position.character + tagName.length },
-            },
-          });
-        }
-      }
-    }
+    const declarationIndex = await getTagDeclarationIndex(workspaceFolders);
+    const declarationLocations = declarationIndex.get(tagName.toLowerCase()) ?? [];
+    locations.push(...declarationLocations);
   }
 
   return locations;
@@ -141,6 +174,7 @@ export async function findTagReferences(
 
 export function invalidateRXMLReferenceCaches(uri?: string): void {
   tagReferenceIndexCache.clear();
+  tagDeclarationIndexCache.clear();
   templateGlobCache.clear();
   pikeGlobCache.clear();
 
@@ -184,8 +218,8 @@ export async function findDefvarReferences(
     ];
 
     for (const pattern of patterns) {
-      let match;
-      while ((match = pattern.exec(content)) !== null) {
+      let match = pattern.exec(content);
+      while (match !== null) {
         const position = findPositionForMatch(content, match);
         locations.push({
           uri: fileToUri(file),
@@ -194,6 +228,7 @@ export async function findDefvarReferences(
             end: { line: position.line, character: position.character + defvarName.length },
           },
         });
+        match = pattern.exec(content);
       }
     }
   }

--- a/packages/pike-lsp-server/src/tests/rxml-cache-invalidation.test.ts
+++ b/packages/pike-lsp-server/src/tests/rxml-cache-invalidation.test.ts
@@ -73,6 +73,28 @@ describe('RXML cache invalidation', () => {
     expect(refreshedSet.length).toBeGreaterThan(0);
   });
 
+  it('clears declaration reference cache for changed module files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pike-rxml-ref-decl-'));
+    createdDirs.push(root);
+
+    const modulePath = join(root, 'module.pike');
+    await writeFile(modulePath, 'simpletag foo() { return 1; }', 'utf-8');
+
+    const first = await findTagReferences('foo', [root], true);
+    expect(first.length).toBeGreaterThan(0);
+
+    await writeFile(modulePath, 'simpletag bar() { return 1; }', 'utf-8');
+    const stale = await findTagReferences('foo', [root], true);
+    expect(stale.length).toBeGreaterThan(0);
+
+    invalidateRXMLReferenceCaches(`file://${modulePath}`);
+
+    const refreshedFoo = await findTagReferences('foo', [root], true);
+    const refreshedBar = await findTagReferences('bar', [root], true);
+    expect(refreshedFoo.length).toBe(0);
+    expect(refreshedBar.length).toBeGreaterThan(0);
+  });
+
   it('invalidates RXML caches on document content change events', async () => {
     const root = await mkdtemp(join(tmpdir(), 'pike-rxml-hook-'));
     createdDirs.push(root);


### PR DESCRIPTION
## Summary
This adds a workspace-level declaration index cache for `findTagReferences(..., includeDeclaration=true)` so repeated RXML include-declaration lookups reuse indexed Pike tag declarations instead of rescanning all Pike files each request.

## Linked Issue
closes #752

## Root Cause
Include-declaration references rebuilt declaration matches by iterating all Pike files and regex-scanning each file on every request, despite existing RXML cache infrastructure.

## Changes
- `packages/pike-lsp-server/src/features/rxml/references-provider.ts`
  - add `tagDeclarationIndexCache` keyed by workspace set with TTL
  - add `getTagDeclarationIndex(workspaceFolders)` that indexes `simpletag`/`container` declarations once per TTL window
  - update `findTagReferences(..., includeDeclaration=true)` to reuse declaration index
  - include declaration index in `invalidateRXMLReferenceCaches`
- `packages/pike-lsp-server/src/tests/rxml-cache-invalidation.test.ts`
  - add regression test proving declaration-reference cache refreshes after module change + invalidation

## Verification
- `bun test src/tests/rxml-cache-invalidation.test.ts` ✅ (5 pass, 0 fail)
- `bun run typecheck` ✅
- `bun run build` ✅
- `bash scripts/test-agent.sh --fast` ✅
- Pre-commit and pre-push hooks ✅

## Notes for Reviewer
Scope is intentionally narrow to includeDeclaration declaration lookup only; template usage index behavior remains unchanged.