### PR TITLE
perf: remove sync include-resolver file reads

### DIFF
--- a/packages/pike-lsp-server/src/services/include-resolver.ts
+++ b/packages/pike-lsp-server/src/services/include-resolver.ts
@@ -9,7 +9,7 @@ import type { PikeSymbol } from '@pike-lsp/pike-bridge';
 import type { BridgeManager } from './bridge-manager.js';
 import type { ResolvedInclude, ResolvedImport, DocumentDependencies } from '../core/types.js';
 import { Logger } from '@pike-lsp/core';
-import { readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 
 /**
  * Cache for resolved includes with their symbols.
@@ -204,7 +204,7 @@ export class IncludeResolver {
 
     try {
       // Read file content
-      const content = readFileSync(filePath, 'utf-8');
+      const content = await readFile(filePath, 'utf-8');
 
       // Use analyze to get symbols (parse operation only)
       const response = await this.bridge.bridge.analyze(content, ['parse'], filePath);

--- a/packages/pike-lsp-server/src/tests/services/include-resolver.test.ts
+++ b/packages/pike-lsp-server/src/tests/services/include-resolver.test.ts
@@ -12,6 +12,9 @@
 
 import { describe, it } from 'bun:test';
 import * as assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { IncludeResolver } from '../../services/include-resolver.js';
 import type { PikeSymbol } from '@pike-lsp/pike-bridge';
 import type { Logger } from '@pike-lsp/core';
@@ -503,5 +506,40 @@ describe('IncludeResolver - Cache Management', () => {
         // Assert
         assert.ok(result1);
         assert.ok(result2);
+    });
+
+    it('should resolve include symbols from real file content', async () => {
+        const dir = await mkdtemp(join(tmpdir(), 'include-resolver-'));
+        try {
+            const includePath = join(dir, 'existing.h');
+            await writeFile(includePath, 'int local_symbol = 1;\n', 'utf-8');
+
+            const bridge = {
+                bridge: {
+                    resolveInclude: async () => ({
+                        exists: true,
+                        path: includePath,
+                        originalPath: '"existing.h"',
+                    }),
+                    resolveStdlib: async () => ({ found: 0 }),
+                    analyze: async (_content: string, _operations: string[], filename: string) => ({
+                        result: {
+                            parse: {
+                                symbols: [{ name: `symbol_from_${filename}`, kind: 'variable' as const }],
+                            },
+                        },
+                    }),
+                },
+            };
+
+            const resolver = new IncludeResolver(bridge as any, createMockLogger());
+            const resolved = await resolver.resolveInclude('"existing.h"', 'file:///test.pike');
+
+            assert.ok(resolved);
+            assert.equal(resolved!.resolvedPath, includePath);
+            assert.equal(resolved!.symbols.length, 1);
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
     });
 });


### PR DESCRIPTION
## Summary
This removes synchronous file reads from include resolver parsing so include/import dependency resolution no longer blocks the Node.js event loop while loading include files.

## Linked Issue
closes #756

## Root Cause
`IncludeResolver.parseIncludedFile` used `readFileSync` inside an async request path (`resolveInclude` / `resolveWorkspaceImport`), introducing avoidable event-loop blocking during include graph resolution.

## Changes
- `packages/pike-lsp-server/src/services/include-resolver.ts`
  - replace `readFileSync` with async `readFile` from `node:fs/promises`
- `packages/pike-lsp-server/src/tests/services/include-resolver.test.ts`
  - add regression test that resolves symbols from a real temporary include file via resolver flow

## Verification
- `bun test src/tests/services/include-resolver.test.ts` ✅ (26 pass, 0 fail)
- `bun run typecheck` ✅
- `bun run build` ✅
- `bash scripts/test-agent.sh --fast` ✅
- Pre-commit and pre-push hooks ✅

## Notes for Reviewer
Behavior/output are unchanged; only the file-read strategy in include parsing changed from blocking to non-blocking I/O.