### PR TITLE
perf: make workspace index chunk reads non-blocking

### DIFF
--- a/packages/pike-lsp-server/src/tests/workspace-index-file-loading.test.ts
+++ b/packages/pike-lsp-server/src/tests/workspace-index-file-loading.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { WorkspaceIndex } from '../workspace-index.js';
+
+describe('WorkspaceIndex file loading', () => {
+  it('indexes files from disk through chunk loading path', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'workspace-index-'));
+    try {
+      const fileA = join(dir, 'a.pike');
+      const fileB = join(dir, 'b.pike');
+      await writeFile(fileA, 'int alpha = 1;\n', 'utf-8');
+      await writeFile(fileB, 'int beta = 2;\n', 'utf-8');
+
+      const bridge = {
+        isRunning: () => true,
+        batchParse: async (files: Array<{ code: string; filename: string }>) => ({
+          results: files.map(file => ({
+            filename: file.filename,
+            symbols: [
+              {
+                name: file.filename.includes('a.pike') ? 'alpha' : 'beta',
+                kind: 'variable',
+                position: { line: 1 },
+              },
+            ],
+          })),
+        }),
+        parse: async (_code: string, filename: string) => ({
+          filename,
+          symbols: [{ name: 'fallback', kind: 'variable', position: { line: 1 } }],
+        }),
+      };
+
+      const index = new WorkspaceIndex(bridge as any);
+      const indexed = await index.indexDirectory(dir, false);
+
+      expect(indexed).toBe(2);
+      const stats = index.getStats();
+      expect(stats.documents).toBe(2);
+      expect(stats.symbols).toBeGreaterThanOrEqual(2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/pike-lsp-server/src/workspace-index.ts
+++ b/packages/pike-lsp-server/src/workspace-index.ts
@@ -8,6 +8,7 @@
 import { PikeSymbol, PikeBridge } from '@pike-lsp/pike-bridge';
 import { SymbolInformation, SymbolKind } from 'vscode-languageserver';
 import * as fs from 'fs';
+import { readFile } from 'node:fs/promises';
 import * as path from 'path';
 import { LSP } from './constants/index.js';
 import { Logger } from '@pike-lsp/core';
@@ -539,7 +540,7 @@ export class WorkspaceIndex {
             const chunkData: Array<{ code: string; filename: string; lastModified: number }> = [];
             for (const fileInfo of chunk) {
                 try {
-                    const content = fs.readFileSync(fileInfo.path, 'utf-8');
+                    const content = await readFile(fileInfo.path, 'utf-8');
                     chunkData.push({
                         code: content,
                         filename: fileInfo.path,


### PR DESCRIPTION
## Summary
This replaces synchronous chunk file reads in workspace indexing with async reads, reducing event-loop blocking while preserving chunking, progress reporting, and parse/index behavior.

## Linked Issue
closes #758

## Root Cause
`WorkspaceIndex.indexDirectory` read each file in a chunk via `fs.readFileSync` before batch parsing, which can block the server during large incremental indexing operations.

## Changes
- `packages/pike-lsp-server/src/workspace-index.ts`
  - import async `readFile` from `node:fs/promises`
  - replace sync `fs.readFileSync` in chunk loading loop with `await readFile`
- `packages/pike-lsp-server/src/tests/workspace-index-file-loading.test.ts`
  - add focused regression test exercising chunk loading/indexing path against real temp files

## Verification
- `bun test src/tests/workspace-index-file-loading.test.ts` ✅ (1 pass, 0 fail)
- `bun run typecheck` ✅
- `bun run build` ✅
- `bash scripts/test-agent.sh --fast` ✅
- Pre-commit and pre-push hooks ✅

## Notes for Reviewer
This is intentionally narrow: filesystem discovery (`readdirSync`/`statSync`) remains unchanged in this PR to keep risk low and review scope tight.