### PR TITLE
fix: clear diagnostics debounce close-state leak and add regression guards

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics/index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/index.ts
@@ -940,6 +940,7 @@ export function registerDiagnosticsHandlers(
       clearTimeout(timer);
       validationTimers.delete(event.document.uri);
     }
+    validationVersions.delete(event.document.uri);
 
     // Clear diagnostics for closed document
     connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });

--- a/packages/pike-lsp-server/src/features/navigation/definition.ts
+++ b/packages/pike-lsp-server/src/features/navigation/definition.ts
@@ -701,7 +701,11 @@ async function findSymbolTextInIncludedFiles(
           };
         }
       }
-    } catch {
+    } catch (err) {
+      log.debug('Definition: failed to scan included file content', {
+        includePath: include.resolvedPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
       continue;
     }
   }

--- a/packages/pike-lsp-server/src/tests/architecture-regressions.test.ts
+++ b/packages/pike-lsp-server/src/tests/architecture-regressions.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from 'bun:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const serverSrcDir = path.resolve(testDir, '..');
+
+async function readServerFile(relativePath: string): Promise<string> {
+  return readFile(path.join(serverSrcDir, relativePath), 'utf-8');
+}
+
+describe('Architecture regressions', () => {
+  it('keeps definition and rename hot paths free of synchronous file reads', async () => {
+    const definitionSource = await readServerFile('features/navigation/definition.ts');
+    const renameSource = await readServerFile('features/editing/rename.ts');
+
+    assert.equal(
+      definitionSource.includes('readFileSync('),
+      false,
+      'definition hot path should not use readFileSync'
+    );
+    assert.equal(
+      renameSource.includes('readFileSync('),
+      false,
+      'rename hot path should not use readFileSync'
+    );
+  });
+
+  it('cleans validationVersions state on document close', async () => {
+    const diagnosticsSource = await readServerFile('features/diagnostics/index.ts');
+    const didCloseIndex = diagnosticsSource.indexOf('documents.onDidClose(event => {');
+    const cleanupIndex = diagnosticsSource.indexOf('validationVersions.delete(event.document.uri);');
+
+    assert.equal(didCloseIndex >= 0, true, 'expected diagnostics onDidClose handler block');
+    assert.equal(
+      cleanupIndex > didCloseIndex,
+      true,
+      'onDidClose must clear validationVersions entry'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
This change removes a stale diagnostics debounce state leak by clearing `validationVersions` on `didClose`, and adds regression guards for two architectural pitfalls: synchronous file I/O in definition/rename hot paths and diagnostics close-path state cleanup. It also replaces a silent include-traversal catch in definition fallback with debug logging so failures remain observable.

## Linked Issue
closes #762

## Root Cause
The diagnostics debounce pipeline tracked expected versions in `validationVersions`, but `documents.onDidClose` only cleared timers and other URI maps; the version map entry for closed documents persisted. Separately, architectural regressions (sync fs on request paths and silent catch blocks) were not guarded by tests, so prior optimizations could be accidentally reintroduced.

## Changes
- `packages/pike-lsp-server/src/features/diagnostics/index.ts`: clear `validationVersions` in `onDidClose` to fully release per-document debounce state.
- `packages/pike-lsp-server/src/features/navigation/definition.ts`: replace an empty include-traversal catch with debug logging to preserve observability without changing control flow.
- `packages/pike-lsp-server/src/tests/architecture-regressions.test.ts`: add regression tests asserting definition/rename hot paths remain free of `readFileSync` and that diagnostics `onDidClose` includes `validationVersions` cleanup.

## Verification
- `bun test src/tests/architecture-regressions.test.ts src/tests/navigation/definition-provider.test.ts` (pass)
- `bun run typecheck` (pass)
- `bun run build` (pass)
- `scripts/test-agent.sh --fast` (pass)
- pre-commit hook fast regression suite (pass)

## Notes for Reviewer
Issues #760 and #761 were created during initial scan but then revalidated against current `origin/main` and closed as already fixed upstream; this PR intentionally focuses on the still-open confirmed bug (#762) plus guardrails to prevent regression of already-fixed hot-path behavior.
