### PR TITLE
release: v0.1.0-alpha.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security** - Security vulnerability fixes
 - **Performance** - User-facing performance notes
 
+## [0.1.0-alpha.27] - 2026-03-15
+
+### Fixed
+
+- **Diagnostics debounce lifecycle cleanup** - Clear per-document `validationVersions` state on document close to prevent stale debounce metadata accumulation in long-running sessions.
+
+### Changed
+
+- **Definition fallback observability** - Replace silent include-traversal failures with debug logging to improve troubleshooting without changing navigation behavior.
+
+### Added
+
+- **Architecture regression guards** - Added source-level regression tests to prevent reintroduction of synchronous file reads in definition/rename hot paths and to enforce diagnostics close-path cleanup invariants.
+
 ## [0.1.0-alpha.25] - 2026-02-26
 
 ### Chore
@@ -51,5 +65,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security workflow** - Add workflow_dispatch trigger for manual Gitleaks runs
 
 [0.1.0-alpha.25]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.25
+[0.1.0-alpha.27]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.27
 [0.1.0-alpha.24]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.24
 [0.1.0-alpha.23]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.23

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pike-lsp",
-  "version": "0.1.0-alpha.25",
+  "version": "0.1.0-alpha.27",
   "private": true,
   "description": "Pike Language Server Protocol implementation and VSCode extension",
   "author": "Pike LSP Team",

--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-pike",
   "displayName": "Pike Language Support",
   "description": "Complete language support for Pike including IntelliSense, go-to-definition, find references, diagnostics, hover, signature help, code completion, semantic tokens, call hierarchy, and workspace symbols.",
-  "version": "0.1.0-alpha.25",
+  "version": "0.1.0-alpha.27",
   "publisher": "pike-lsp",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
## Summary
This prepares release `v0.1.0-alpha.27` by synchronizing repository version metadata with a new extension package cut and documenting the release in the changelog. It enables publishing a fresh VSIX artifact from the current release branch state.

## Linked Issue
closes #766

## Root Cause
Published release history had advanced beyond manifest/changelog metadata (`v0.1.0-alpha.26` existed while package versions remained at alpha.25), which creates release bookkeeping drift and ambiguous artifact provenance.

## Changes
- `package.json`: bump monorepo version to `0.1.0-alpha.27` to align release metadata.
- `packages/vscode-pike/package.json`: bump extension version to `0.1.0-alpha.27` so VSIX artifact version matches tag.
- `CHANGELOG.md`: add `0.1.0-alpha.27` release notes and release link.

## Verification
- `bun run package` in `packages/vscode-pike` (pass, generated `vscode-pike-0.1.0-alpha.27.vsix`)
- `scripts/test-agent.sh --fast` (pass)

## Notes for Reviewer
Main is PR-protected in this repository, so this release prep is routed through `release/v0.1.0-alpha.27`.
