### PR TITLE
release: v0.1.0-alpha.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security** - Security vulnerability fixes
 - **Performance** - User-facing performance notes
 
+## [0.1.0-alpha.28] - 2026-03-15
+
+### Performance
+
+- **Bounded scheduler observability metrics** - Request scheduler queue-wait samples are now retained in a fixed-size rolling window to prevent unbounded memory growth during long editing sessions.
+- **Non-blocking workspace file discovery** - Workspace index file discovery now uses async directory and stat traversal, reducing event-loop blocking before parse/index phases.
+
+### Added
+
+- **Performance regression guards** - Added stress/regression coverage for scheduler sample bounding and synchronous workspace discovery prevention.
+
 ## [0.1.0-alpha.27] - 2026-03-15
 
 ### Fixed
@@ -65,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security workflow** - Add workflow_dispatch trigger for manual Gitleaks runs
 
 [0.1.0-alpha.25]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.25
+[0.1.0-alpha.28]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.28
 [0.1.0-alpha.27]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.27
 [0.1.0-alpha.24]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.24
 [0.1.0-alpha.23]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.23

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pike-lsp",
-  "version": "0.1.0-alpha.27",
+  "version": "0.1.0-alpha.28",
   "private": true,
   "description": "Pike Language Server Protocol implementation and VSCode extension",
   "author": "Pike LSP Team",

--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-pike",
   "displayName": "Pike Language Support",
   "description": "Complete language support for Pike including IntelliSense, go-to-definition, find references, diagnostics, hover, signature help, code completion, semantic tokens, call hierarchy, and workspace symbols.",
-  "version": "0.1.0-alpha.27",
+  "version": "0.1.0-alpha.28",
   "publisher": "pike-lsp",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
## Summary
Prepare and publish release `v0.1.0-alpha.28` after merging performance fixes for scheduler metric retention and workspace file discovery traversal.

## Changes
- `package.json`: bump repository version to `0.1.0-alpha.28`.
- `packages/vscode-pike/package.json`: bump extension version to `0.1.0-alpha.28`.
- `CHANGELOG.md`: add alpha.28 notes for bounded scheduler metrics, async workspace discovery, and regression guard coverage.

## Verification
- `bun run package` in `packages/vscode-pike` (generated `vscode-pike-0.1.0-alpha.28.vsix`)
- `scripts/test-agent.sh --fast` (pass)

## Notes
Main is PR-protected in this repository, so this release prep is routed through `release/v0.1.0-alpha.28`.
