### PR TITLE
fix: propagate LSP cancellation tokens to query-engine requests

### DIFF
--- a/packages/pike-lsp-server/src/features/editing/completion.ts
+++ b/packages/pike-lsp-server/src/features/editing/completion.ts
@@ -156,7 +156,7 @@ export function registerCompletionHandlers(
   /**
    * Code completion handler
    */
-  connection.onCompletion(async (params): Promise<CompletionList> => {
+  connection.onCompletion(async (params, cancellationToken): Promise<CompletionList> => {
     const bridge = services.bridge;
     const uri = params.textDocument.uri;
     const document = documents.get(uri);
@@ -167,11 +167,20 @@ export function registerCompletionHandlers(
       return toCompletionList([]);
     }
 
+    if (cancellationToken?.isCancellationRequested) {
+      return toCompletionList([]);
+    }
+
     if (useQueryEngineCompletions && bridge?.isRunning?.()) {
       const nextSequence = (completionRequestSequence.get(uri) ?? 0) + 1;
       completionRequestSequence.set(uri, nextSequence);
       const requestId = `completion:${uri}:${document.version}:${Date.now()}:${nextSequence}`;
       const filename = decodeURIComponent(uri.replace(/^file:\/\//, ''));
+      let cancelledByToken = false;
+      const cancellationDisposable = cancellationToken?.onCancellationRequested(() => {
+        cancelledByToken = true;
+        void bridge.engineCancelRequest({ requestId }).catch(() => undefined);
+      });
       const clearInFlight = (): void => {
         if (inFlightCompletionRequests.get(uri) === requestId) {
           inFlightCompletionRequests.delete(uri);
@@ -183,6 +192,9 @@ export function registerCompletionHandlers(
           key: `completion:${uri}`,
           run: async checkpoint => {
             checkpoint();
+            if (cancelledByToken || cancellationToken?.isCancellationRequested) {
+              throw new RequestSupersededError('Completion request cancelled by LSP token');
+            }
             const previousRequestId = inFlightCompletionRequests.get(uri);
             if (previousRequestId && previousRequestId !== requestId) {
               try {
@@ -212,6 +224,10 @@ export function registerCompletionHandlers(
             });
             checkpoint();
 
+            if (cancelledByToken || cancellationToken?.isCancellationRequested) {
+              throw new RequestSupersededError('Completion request cancelled by LSP token');
+            }
+
             const directItems = toCompletionItemArray(qeResponse.result['items']);
             if (directItems && directItems.length > 0) {
               return directItems;
@@ -230,6 +246,7 @@ export function registerCompletionHandlers(
         });
 
         clearInFlight();
+        cancellationDisposable?.dispose();
         if (scheduledItems && scheduledItems.length > 0) {
           const completions = [...scheduledItems];
           const text = document.getText();
@@ -366,6 +383,7 @@ export function registerCompletionHandlers(
         maybeLogCompletionSchedulerMetrics(uri, 'qe_empty');
       } catch (err) {
         clearInFlight();
+        cancellationDisposable?.dispose();
         if (err instanceof RequestSupersededError) {
           maybeLogCompletionSchedulerMetrics(uri, 'superseded');
           return toCompletionList([]);

--- a/packages/pike-lsp-server/src/features/navigation/definition.ts
+++ b/packages/pike-lsp-server/src/features/navigation/definition.ts
@@ -51,7 +51,7 @@ export function registerDefinitionHandlers(
    * - Module path resolution (Stdio.File -> Pike stdlib)
    * - Member access navigation (file->read -> method definition)
    */
-  connection.onDefinition(async (params): Promise<Location | Location[] | null> => {
+  connection.onDefinition(async (params, cancellationToken): Promise<Location | Location[] | null> => {
     log.debug('Definition request', { uri: params.textDocument.uri });
     try {
       const uri = params.textDocument.uri;
@@ -66,7 +66,9 @@ export function registerDefinitionHandlers(
         'definition',
         uri,
         document,
-        params.position
+        params.position,
+        {},
+        cancellationToken
       );
       if (queryLocations && queryLocations.length > 0) {
         return queryLocations;

--- a/packages/pike-lsp-server/src/features/navigation/query-engine.ts
+++ b/packages/pike-lsp-server/src/features/navigation/query-engine.ts
@@ -1,4 +1,4 @@
-import type { Location } from 'vscode-languageserver/node.js';
+import type { CancellationToken, Location } from 'vscode-languageserver/node.js';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Services } from '../../services/index.js';
 
@@ -62,15 +62,26 @@ export async function queryNavigationLocations(
   uri: string,
   document: TextDocument,
   position: { line: number; character: number },
-  extraParams: Record<string, unknown> = {}
+  extraParams: Record<string, unknown> = {},
+  cancellationToken?: CancellationToken
 ): Promise<Location[] | undefined> {
   const bridge = services.bridge;
   if (!bridge || !bridge.isRunning()) {
     return undefined;
   }
 
+  if (cancellationToken?.isCancellationRequested) {
+    return undefined;
+  }
+
   const requestId = `${feature}:${uri}:${document.version}:${Date.now()}`;
   const filename = decodeURIComponent(uri.replace(/^file:\/\//, ''));
+
+  let cancelled = false;
+  const cancellationDisposable = cancellationToken?.onCancellationRequested(() => {
+    cancelled = true;
+    void bridge.engineCancelRequest({ requestId }).catch(() => undefined);
+  });
 
   try {
     const response = await bridge.engineQuery({
@@ -86,6 +97,10 @@ export async function queryNavigationLocations(
         ...extraParams,
       },
     });
+
+    if (cancelled || cancellationToken?.isCancellationRequested) {
+      return undefined;
+    }
 
     const directLocations = parseLocationArray(response.result['locations']);
     if (directLocations && directLocations.length > 0) {
@@ -113,6 +128,8 @@ export async function queryNavigationLocations(
     }
   } catch {
     return undefined;
+  } finally {
+    cancellationDisposable?.dispose();
   }
 
   return undefined;

--- a/packages/pike-lsp-server/src/features/navigation/references.ts
+++ b/packages/pike-lsp-server/src/features/navigation/references.ts
@@ -38,7 +38,7 @@ export function registerReferencesHandlers(
    *   (LIMITATION: No symbol table available for uncached files)
    * - Progress reporting is enabled for workspace scans of 20+ files
    */
-  connection.onReferences(async (params): Promise<Location[]> => {
+  connection.onReferences(async (params, cancellationToken): Promise<Location[]> => {
     log.debug('References request', { uri: params.textDocument.uri, position: params.position });
     try {
       const uri = params.textDocument.uri;
@@ -57,7 +57,8 @@ export function registerReferencesHandlers(
         params.position,
         {
           includeDeclaration: params.context.includeDeclaration ?? true,
-        }
+        },
+        cancellationToken
       );
       if (queryLocations && queryLocations.length > 0) {
         return queryLocations;

--- a/packages/pike-lsp-server/src/tests/navigation/query-engine-cancellation.test.ts
+++ b/packages/pike-lsp-server/src/tests/navigation/query-engine-cancellation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'bun:test';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { queryNavigationLocations } from '../../features/navigation/query-engine.js';
+
+class FakeCancellationToken {
+  private callbacks: Array<() => void> = [];
+  isCancellationRequested = false;
+
+  onCancellationRequested(callback: () => void): { dispose: () => void } {
+    this.callbacks.push(callback);
+    return {
+      dispose: () => {
+        this.callbacks = this.callbacks.filter(entry => entry !== callback);
+      },
+    };
+  }
+
+  cancel(): void {
+    this.isCancellationRequested = true;
+    for (const callback of this.callbacks) {
+      callback();
+    }
+  }
+}
+
+describe('query-engine cancellation wiring', () => {
+  it('forwards cancellation to engineCancelRequest for in-flight navigation query', async () => {
+    const document = TextDocument.create('file:///test.pike', 'pike', 1, 'int value = 1;');
+    const cancellationToken = new FakeCancellationToken();
+
+    let resolveQuery: ((value: unknown) => void) | null = null;
+    const cancelledRequestIds: string[] = [];
+
+    const services = {
+      bridge: {
+        isRunning: () => true,
+        engineQuery: async (_params: unknown) =>
+          await new Promise(resolve => {
+            resolveQuery = resolve;
+          }),
+        engineCancelRequest: async ({ requestId }: { requestId: string }) => {
+          cancelledRequestIds.push(requestId);
+          return { cancelled: true };
+        },
+      },
+    };
+
+    const queryPromise = queryNavigationLocations(
+      services as any,
+      'definition',
+      document.uri,
+      document,
+      { line: 0, character: 4 },
+      {},
+      cancellationToken as any
+    );
+
+    cancellationToken.cancel();
+
+    expect(cancelledRequestIds.length).toBe(1);
+    expect(cancelledRequestIds[0]?.startsWith(`definition:${document.uri}:${document.version}:`)).toBe(
+      true
+    );
+
+    resolveQuery?.({
+      result: {
+        location: {
+          uri: document.uri,
+          range: {
+            start: { line: 0, character: 4 },
+            end: { line: 0, character: 9 },
+          },
+        },
+      },
+    });
+
+    const result = await queryPromise;
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
This wires LSP cancellation tokens to in-flight query-engine requests for completion/definition/references so cancelled editor requests proactively call `engineCancelRequest` and avoid stale work.

## Linked Issue
closes #771

## Root Cause
Query-engine requests used internally generated request IDs, while cancellation handling relied on separate pathways. Handlers did not consistently bind LSP request cancellation tokens to those in-flight engine IDs.

## Changes
- `packages/pike-lsp-server/src/features/navigation/query-engine.ts`: added optional cancellation token support and cancellation forwarding to `engineCancelRequest` for navigation queries.
- `packages/pike-lsp-server/src/features/navigation/definition.ts`: passes handler cancellation token into query-engine navigation helper.
- `packages/pike-lsp-server/src/features/navigation/references.ts`: passes handler cancellation token into query-engine navigation helper.
- `packages/pike-lsp-server/src/features/editing/completion.ts`: binds completion token cancellation to active engine request and treats token-cancel as superseded flow.
- `packages/pike-lsp-server/src/tests/navigation/query-engine-cancellation.test.ts`: regression test verifies cancellation forwards to `engineCancelRequest` for in-flight navigation query.

## Verification
- `bun test packages/pike-lsp-server/src/tests/navigation/query-engine-cancellation.test.ts` ✅
- `bun test packages/pike-lsp-server/src/tests/navigation/references-provider.test.ts` ✅
- `bun run typecheck` ✅
- `scripts/test-agent.sh --fast` ✅

## Notes for Reviewer
This change intentionally uses LSP cancellation tokens in handlers instead of relying on `$ /cancelRequest` request-id identity matching for query-engine IDs.