### PR TITLE
perf: parallelize bounded uncached fallback scans for references and rename

### DIFF
--- a/packages/pike-lsp-server/src/features/editing/rename.ts
+++ b/packages/pike-lsp-server/src/features/editing/rename.ts
@@ -331,6 +331,10 @@ export function registerRenameHandlers(
                 const YIELD_EVERY_N_BATCHES = 4;
                 const requestVersion = document.version;
                 let cancelled = false;
+                const isRequestCurrent = (): boolean => {
+                    const latest = documents.get(uri);
+                    return !!latest && latest.version === requestVersion;
+                };
 
                 log.debug('Rename: searching workspace files', {
                     uncachedFileCount: uncachedFiles.length,
@@ -338,36 +342,50 @@ export function registerRenameHandlers(
                 });
 
                 for (let i = 0; i < boundedFiles.length; i += BATCH_SIZE) {
-                    const latest = documents.get(uri);
-                    if (!latest || latest.version !== requestVersion) {
+                    if (!isRequestCurrent()) {
                         cancelled = true;
                         break;
                     }
 
                     const batch = boundedFiles.slice(i, Math.min(i + BATCH_SIZE, boundedFiles.length));
 
-                    for (const file of batch) {
+                    const batchEdits = await Promise.all(batch.map(async file => {
                         try {
-                            const latest = documents.get(uri);
-                            if (!latest || latest.version !== requestVersion) {
+                            if (!isRequestCurrent()) {
                                 cancelled = true;
-                                break;
+                                return null;
                             }
 
                             const filePath = decodeURIComponent(file.uri.replace(/^file:\/\//, ''));
                             const fileContent = await readFile(filePath, 'utf-8');
 
-                            if (!fileContent.includes(oldName)) {
-                                continue;
+                            if (!isRequestCurrent()) {
+                                cancelled = true;
+                                return null;
                             }
 
-                            addEditsFromTextSearch(file.uri, fileContent);
+                            if (!fileContent.includes(oldName)) {
+                                return null;
+                            }
+
+                            return { uri: file.uri, content: fileContent };
                         } catch (err) {
                             log.warn('Failed to read file for rename', {
                                 uri: file.uri,
                                 error: err instanceof Error ? err.message : String(err)
                             });
+                            return null;
                         }
+                    }));
+
+                    for (const entry of batchEdits) {
+                        if (entry) {
+                            addEditsFromTextSearch(entry.uri, entry.content);
+                        }
+                    }
+
+                    if (cancelled) {
+                        break;
                     }
 
                     if ((i / BATCH_SIZE) % YIELD_EVERY_N_BATCHES === 0 && i > 0) {

--- a/packages/pike-lsp-server/src/features/navigation/references.ts
+++ b/packages/pike-lsp-server/src/features/navigation/references.ts
@@ -289,70 +289,84 @@ export function registerReferencesHandlers(
           // Process workspace files in batches with yielding
           const requestVersion = document.version;
           let cancelled = false;
+          const isRequestCurrent = (): boolean => {
+            const latest = documents.get(uri);
+            return !!latest && latest.version === requestVersion;
+          };
 
           for (let i = 0; i < boundedFiles.length; i += BATCH_SIZE) {
-            const latest = documents.get(uri);
-            if (!latest || latest.version !== requestVersion) {
+            if (!isRequestCurrent()) {
               cancelled = true;
               break;
             }
 
             const batch = boundedFiles.slice(i, Math.min(i + BATCH_SIZE, boundedFiles.length));
-
-            for (const file of batch) {
-              try {
-                const latest = documents.get(uri);
-                if (!latest || latest.version !== requestVersion) {
-                  cancelled = true;
-                  break;
-                }
-
-                // Read file content
-                const filePath = decodeURIComponent(file.uri.replace(/^file:\/\//, ''));
-                const content = await readFile(filePath, 'utf-8');
-
-                // Check if the word appears in the file (quick text search first)
-                if (!content.includes(word)) {
-                  continue;
-                }
-
-                // Word appears in file, do proper search
-                // NOTE: Workspace-only results are NOT filtered by includeDeclaration
-                // This is a documented limitation - we don't have symbol position info
-                // for uncached files, so we can't identify which occurrence is the declaration
-                const lines = content.split('\n');
-                for (let lineNum = 0; lineNum < lines.length; lineNum++) {
-                  const line = lines[lineNum];
-                  if (!line) continue;
-                  let searchStart = 0;
-                  let matchIndex = line.indexOf(word, searchStart);
-
-                  while (matchIndex !== -1) {
-                    const beforeChar = matchIndex > 0 ? line[matchIndex - 1] : ' ';
-                    const afterChar =
-                      matchIndex + word.length < line.length ? line[matchIndex + word.length] : ' ';
-
-                    // Check word boundaries
-                    if (!/\w/.test(beforeChar ?? '') && !/\w/.test(afterChar ?? '')) {
-                      references.push({
-                        uri: file.uri,
-                        range: {
-                          start: { line: lineNum, character: matchIndex },
-                          end: { line: lineNum, character: matchIndex + word.length },
-                        },
-                      });
-                    }
-                    searchStart = matchIndex + 1;
-                    matchIndex = line.indexOf(word, searchStart);
+            const batchResults = await Promise.all(
+              batch.map(async file => {
+                try {
+                  if (!isRequestCurrent()) {
+                    cancelled = true;
+                    return [] as Location[];
                   }
+
+                  const filePath = decodeURIComponent(file.uri.replace(/^file:\/\//, ''));
+                  const content = await readFile(filePath, 'utf-8');
+
+                  if (!isRequestCurrent()) {
+                    cancelled = true;
+                    return [] as Location[];
+                  }
+
+                  if (!content.includes(word)) {
+                    return [] as Location[];
+                  }
+
+                  const fileReferences: Location[] = [];
+                  const lines = content.split('\n');
+                  for (let lineNum = 0; lineNum < lines.length; lineNum++) {
+                    const line = lines[lineNum];
+                    if (!line) continue;
+                    let searchStart = 0;
+                    let matchIndex = line.indexOf(word, searchStart);
+
+                    while (matchIndex !== -1) {
+                      const beforeChar = matchIndex > 0 ? line[matchIndex - 1] : ' ';
+                      const afterChar =
+                        matchIndex + word.length < line.length ? line[matchIndex + word.length] : ' ';
+
+                      if (!/\w/.test(beforeChar ?? '') && !/\w/.test(afterChar ?? '')) {
+                        fileReferences.push({
+                          uri: file.uri,
+                          range: {
+                            start: { line: lineNum, character: matchIndex },
+                            end: { line: lineNum, character: matchIndex + word.length },
+                          },
+                        });
+                      }
+                      searchStart = matchIndex + 1;
+                      matchIndex = line.indexOf(word, searchStart);
+                    }
+                  }
+
+                  return fileReferences;
+                } catch (err) {
+                  log.debug('References: failed to read workspace file', {
+                    uri: file.uri,
+                    error: err instanceof Error ? err.message : String(err),
+                  });
+                  return [] as Location[];
                 }
-              } catch (err) {
-                // File might not exist or be readable, skip
-                log.debug('References: failed to read workspace file', {
-                  uri: file.uri,
-                  error: err instanceof Error ? err.message : String(err),
-                });
+              })
+            );
+
+            for (const fileReferences of batchResults) {
+              if (fileReferences.length > 0) {
+                references.push(...fileReferences);
               }
+            }
+
+            if (cancelled) {
+              break;
             }
 
             // Report progress after each batch


### PR DESCRIPTION
## Summary
This improves uncached workspace fallback latency in references and rename by parallelizing per-batch file reads/searches while keeping existing bounded limits, version-based cancellation checks, and periodic yielding.

## Linked Issue
closes #772

## Root Cause
Fallback paths in references/rename scanned uncached workspace files sequentially inside each batch, creating avoidable IO serialization and higher p95 under larger workspaces.

## Changes
- `packages/pike-lsp-server/src/features/navigation/references.ts`: process each bounded batch with `Promise.all`, aggregate per-file matches, and keep request-version cancellation checks before/after IO.
- `packages/pike-lsp-server/src/features/editing/rename.ts`: process each bounded batch with `Promise.all`, aggregate candidate file contents, then apply existing text-search edit builder.

## Verification
- `bun test packages/pike-lsp-server/src/tests/navigation/references-provider.test.ts` ✅
- `bun test packages/pike-lsp-server/src/tests/editing/rename-provider.test.ts` ✅
- `bun test packages/pike-lsp-server/src/tests/editing/rename-stress.test.ts` ✅
- `bun run typecheck` ✅
- `scripts/test-agent.sh --fast` ✅

## Notes for Reviewer
Concurrency remains bounded by existing `BATCH_SIZE` and file-count caps. No unbounded fan-out was introduced.