### PR TITLE
fix: keep workspace and diagnostics caches consistent

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics/index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/index.ts
@@ -51,6 +51,20 @@ export {
   type ChangeClassification,
 } from './change-detection.js';
 
+export function applySkippedValidationCacheUpdate(
+  cachedEntry: DocumentCacheEntry,
+  currentVersion: number,
+  classification: { newHash?: string; newLineHashes?: number[] }
+): void {
+  if (classification.newHash) {
+    cachedEntry.contentHash = classification.newHash;
+  }
+  if (classification.newLineHashes) {
+    cachedEntry.lineHashes = classification.newLineHashes;
+  }
+  cachedEntry.version = currentVersion;
+}
+
 /**
  * Register diagnostics handlers with the LSP connection.
  *
@@ -146,13 +160,8 @@ export function registerDiagnosticsHandlers(
 
       if (classification.canSkip) {
         // Skip parsing entirely - just update cache metadata
-        if (cachedEntry && classification.newHash) {
-          // Update hash metadata without full reparse
-          cachedEntry.contentHash = classification.newHash;
-          if (classification.newLineHashes) {
-            cachedEntry.lineHashes = classification.newLineHashes;
-          }
-          cachedEntry.version = currentVersion;
+        if (cachedEntry) {
+          applySkippedValidationCacheUpdate(cachedEntry, currentVersion, classification);
         }
 
         // Clear the pending change range

--- a/packages/pike-lsp-server/src/services/workspace-scanner.ts
+++ b/packages/pike-lsp-server/src/services/workspace-scanner.ts
@@ -92,11 +92,26 @@ export class WorkspaceScanner {
      */
     removeFolder(folder: string): void {
         this.logger.debug('WorkspaceScanner: removing folder', { folder });
-        this.workspaceRoots.delete(folder);
+        const stripTrailingSlash = (value: string): string => {
+            if (value.length > 1) {
+                return value.replace(/\/+$/, '');
+            }
+            return value;
+        };
+
+        const normalizedFolder = stripTrailingSlash(folder);
+        const normalizedPath = normalizedFolder.startsWith('file://')
+            ? stripTrailingSlash(decodeURIComponent(normalizedFolder.replace(/^file:\/\//, '')))
+            : normalizedFolder;
+        const folderUri = `file://${normalizedPath}`;
+        const folderUriWithSlash = `${folderUri}/`;
+
+        this.workspaceRoots.delete(normalizedPath);
+        this.workspaceRoots.delete(folderUri);
 
         // Remove all files from this folder
         for (const [uri, info] of this.files) {
-            if (info.path.startsWith(folder)) {
+            if (info.path === folderUri || info.path.startsWith(folderUriWithSlash)) {
                 this.files.delete(uri);
             }
         }

--- a/packages/pike-lsp-server/src/tests/features/diagnostics/change-detection.test.ts
+++ b/packages/pike-lsp-server/src/tests/features/diagnostics/change-detection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { classifyChange } from '../../../features/diagnostics/change-detection.js';
+import { applySkippedValidationCacheUpdate } from '../../../features/diagnostics/index.js';
 import { computeContentHash, computeLineHashes } from '../../../services/document-cache.js';
 import type { DocumentCacheEntry } from '../../../core/types.js';
 
@@ -111,5 +112,37 @@ describe('classifyChange', () => {
     expect(result.canSkip).toBe(false);
     expect(result.reason).toBe('semantic_changed');
     expect(result.newLineHashes).toBeUndefined();
+  });
+});
+
+describe('applySkippedValidationCacheUpdate', () => {
+  it('updates cache version when skip classification has no newHash', () => {
+    const previousText = 'int x = 1;\n';
+    const cacheEntry = makeCachedEntry(previousText);
+    const previousHash = cacheEntry.contentHash;
+
+    applySkippedValidationCacheUpdate(cacheEntry, 2, {
+      newLineHashes: cacheEntry.lineHashes,
+    });
+
+    expect(cacheEntry.version).toBe(2);
+    expect(cacheEntry.contentHash).toBe(previousHash);
+  });
+
+  it('updates content and line hashes when provided', () => {
+    const previousText = 'int x = 1;\n';
+    const updatedText = 'int x = 10;\n';
+    const cacheEntry = makeCachedEntry(previousText);
+    const newHash = computeContentHash(updatedText);
+    const newLineHashes = computeLineHashes(updatedText);
+
+    applySkippedValidationCacheUpdate(cacheEntry, 3, {
+      newHash,
+      newLineHashes,
+    });
+
+    expect(cacheEntry.version).toBe(3);
+    expect(cacheEntry.contentHash).toBe(newHash);
+    expect(cacheEntry.lineHashes).toEqual(newLineHashes);
   });
 });

--- a/packages/pike-lsp-server/src/tests/services/workspace-scanner.test.ts
+++ b/packages/pike-lsp-server/src/tests/services/workspace-scanner.test.ts
@@ -184,17 +184,42 @@ describe('WorkspaceScanner - 26.3 Multi-folder workspace', () => {
         assert.equal(stats.rootCount, 2);
     });
 
-    it('26.3.3 should remove folder and its files', () => {
-        // Arrange
+    it('26.3.3 should remove folder and its files', async () => {
         const logger = createMockLogger();
         const scanner = new WorkspaceScanner(logger, () => ({}));
+        const os = await import('node:os');
+        const fs = await import('node:fs/promises');
+        const path = await import('node:path');
 
-        // Act
-        scanner.removeFolder('/workspace');
+        const rootA = path.join(os.tmpdir(), `ws-remove-a-${Date.now()}`);
+        const rootB = path.join(os.tmpdir(), `ws-remove-b-${Date.now()}`);
+        const nestedA = path.join(rootA, 'nested');
 
-        // Assert
-        const stats = scanner.getStats();
-        assert.equal(stats.rootCount, 0);
+        await fs.mkdir(nestedA, { recursive: true });
+        await fs.mkdir(rootB, { recursive: true });
+        await fs.writeFile(path.join(rootA, 'a.pike'), 'int a;');
+        await fs.writeFile(path.join(nestedA, 'b.pike'), 'int b;');
+        await fs.writeFile(path.join(rootB, 'c.pike'), 'int c;');
+
+        try {
+            await scanner.initialize([rootA, rootB]);
+
+            const beforeRemove = scanner.getAllFiles();
+            assert.ok(beforeRemove.some(f => f.path.startsWith(`file://${rootA}`)));
+            assert.ok(beforeRemove.some(f => f.path.startsWith(`file://${rootB}`)));
+
+            scanner.removeFolder(rootA);
+
+            const afterRemove = scanner.getAllFiles();
+            assert.ok(!afterRemove.some(f => f.path.startsWith(`file://${rootA}`)));
+            assert.ok(afterRemove.some(f => f.path.startsWith(`file://${rootB}`)));
+
+            const stats = scanner.getStats();
+            assert.equal(stats.rootCount, 1);
+        } finally {
+            await fs.rm(rootA, { recursive: true, force: true });
+            await fs.rm(rootB, { recursive: true, force: true });
+        }
     });
 
     it('26.3.4 should scan all folders on scanAll', async () => {
@@ -230,6 +255,33 @@ describe('WorkspaceScanner - 26.3 Multi-folder workspace', () => {
         assert.equal(scanner.isReady(), true, 'Scanner should remain ready after concurrent scans');
         const stats = scanner.getStats();
         assert.ok(typeof stats.fileCount === 'number', 'Stats should be available');
+    });
+
+    it('26.3.6 should remove files when folder is passed as file URI', async () => {
+        const logger = createMockLogger();
+        const scanner = new WorkspaceScanner(logger, () => ({}));
+        const os = await import('node:os');
+        const fs = await import('node:fs/promises');
+        const path = await import('node:path');
+
+        const root = path.join(os.tmpdir(), `ws-remove-uri-${Date.now()}`);
+        await fs.mkdir(root, { recursive: true });
+        await fs.writeFile(path.join(root, 'one.pike'), 'int one;');
+
+        try {
+            await scanner.initialize([root]);
+            assert.ok(scanner.getAllFiles().some(f => f.path.startsWith(`file://${root}`)));
+
+            scanner.removeFolder(`file://${root}`);
+
+            assert.ok(!scanner.getAllFiles().some(f => f.path.startsWith(`file://${root}`)));
+            assert.equal(scanner.getStats().rootCount, 0);
+
+            await scanner.scanAll();
+            assert.ok(!scanner.getAllFiles().some(f => f.path.startsWith(`file://${root}`)));
+        } finally {
+            await fs.rm(root, { recursive: true, force: true });
+        }
     });
 });
 

--- a/packages/pike-lsp-server/src/tests/workspace-index-file-loading.test.ts
+++ b/packages/pike-lsp-server/src/tests/workspace-index-file-loading.test.ts
@@ -44,4 +44,48 @@ describe('WorkspaceIndex file loading', () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it('keeps symbol lookup consistent after removing one document', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'workspace-index-remove-'));
+    try {
+      const fileA = join(dir, 'a.pike');
+      const fileB = join(dir, 'b.pike');
+      await writeFile(fileA, 'int shared = 1;\n', 'utf-8');
+      await writeFile(fileB, 'int shared = 2;\n', 'utf-8');
+
+      const bridge = {
+        isRunning: () => true,
+        batchParse: async (files: Array<{ code: string; filename: string }>) => ({
+          results: files.map(file => ({
+            filename: file.filename,
+            symbols: [
+              {
+                name: 'shared',
+                kind: 'variable',
+                position: { line: 1 },
+              },
+            ],
+          })),
+        }),
+        parse: async (_code: string, filename: string) => ({
+          filename,
+          symbols: [{ name: 'shared', kind: 'variable', position: { line: 1 } }],
+        }),
+      };
+
+      const index = new WorkspaceIndex(bridge as any);
+      await index.indexDirectory(dir, false);
+
+      const beforeRemoval = index.searchSymbols('sh');
+      expect(beforeRemoval.length).toBe(2);
+
+      index.removeDocument(`file://${fileA}`);
+
+      const afterRemoval = index.searchSymbols('sh');
+      expect(afterRemoval.length).toBe(1);
+      expect(afterRemoval[0].location.uri).toBe(`file://${fileB}`);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/pike-lsp-server/src/workspace-index.ts
+++ b/packages/pike-lsp-server/src/workspace-index.ts
@@ -714,6 +714,12 @@ export class WorkspaceIndex {
     // Private helpers
 
     private addToLookup(uri: string, symbols: PikeSymbol[]): void {
+        let symbolNames = this.uriToSymbols.get(uri);
+        if (!symbolNames) {
+            symbolNames = new Set<string>();
+            this.uriToSymbols.set(uri, symbolNames);
+        }
+
         for (const symbol of symbols) {
             // Skip symbols with null names (can occur with certain Pike constructs)
             if (!symbol.name) {
@@ -736,6 +742,22 @@ export class WorkspaceIndex {
                 this.symbolLookup.set(nameLower, entriesByUri);
             }
             entriesByUri.set(uri, entry);
+
+            if (!symbolNames.has(nameLower)) {
+                symbolNames.add(nameLower);
+
+                if (nameLower.length >= 2) {
+                    for (let i = 2; i <= nameLower.length; i++) {
+                        const prefix = nameLower.slice(0, i);
+                        let prefixSet = this.prefixIndex.get(prefix);
+                        if (!prefixSet) {
+                            prefixSet = new Set<string>();
+                            this.prefixIndex.set(prefix, prefixSet);
+                        }
+                        prefixSet.add(nameLower);
+                    }
+                }
+            }
         }
     }
 
@@ -749,16 +771,18 @@ export class WorkspaceIndex {
         // Remove each symbol entry for this URI
         for (const nameLower of symbolNames) {
             const entriesByUri = this.symbolLookup.get(nameLower);
+            let removeNameFromPrefixIndex = false;
+
             if (entriesByUri) {
                 entriesByUri.delete(uri);
                 // Clean up empty name entries
                 if (entriesByUri.size === 0) {
                     this.symbolLookup.delete(nameLower);
+                    removeNameFromPrefixIndex = true;
                 }
             }
 
-            // PERF-XXX: Remove from prefix index
-            if (nameLower.length >= 2) {
+            if (removeNameFromPrefixIndex && nameLower.length >= 2) {
                 for (let i = 2; i <= nameLower.length; i++) {
                     const prefix = nameLower.slice(0, i);
                     const prefixSet = this.prefixIndex.get(prefix);


### PR DESCRIPTION
## Summary
- synchronize WorkspaceIndex reverse and prefix indexes so add/remove operations keep lookup state consistent
- normalize WorkspaceScanner removeFolder for both filesystem and file URI inputs and ensure root tracking stays correct
- update diagnostics skip-path cache metadata handling so skipped validations still advance cache version; add regression coverage

## Root Cause
Multiple cache and index structures were updated inconsistently across add/remove and skip-validation flows, which could leave stale entries or stale metadata.

## File-level rationale
- packages/pike-lsp-server/src/workspace-index.ts: maintain uriToSymbols and prefixIndex on add, and only remove prefix names when no URI keeps the symbol
- packages/pike-lsp-server/src/services/workspace-scanner.ts: normalize folder path/URI before removing file entries and workspace roots
- packages/pike-lsp-server/src/features/diagnostics/index.ts: centralize and apply skip-path cache updates without requiring newHash
- tests updated in:
  - packages/pike-lsp-server/src/tests/workspace-index-file-loading.test.ts
  - packages/pike-lsp-server/src/tests/services/workspace-scanner.test.ts
  - packages/pike-lsp-server/src/tests/features/diagnostics/change-detection.test.ts

## Verification
- bun test packages/pike-lsp-server/src/tests/features/diagnostics/change-detection.test.ts packages/pike-lsp-server/src/tests/workspace-index-file-loading.test.ts packages/pike-lsp-server/src/tests/services/workspace-scanner.test.ts
- bun run typecheck
- bun run build

Closes #778
Closes #779
Closes #780