### PR TITLE
fix: harden bridge startup and send failure handling

### DIFF
--- a/packages/pike-bridge/src/bridge.test.ts
+++ b/packages/pike-bridge/src/bridge.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, beforeAll, afterAll } from 'bun:test';
 import assert from 'node:assert/strict';
 import { PikeBridge } from './bridge.js';
+import { PikeProcess } from './process.js';
 
 describe('PikeBridge', () => {
   let bridge: PikeBridge;
@@ -543,6 +544,52 @@ foo(@args);
     // All should return the same results
     assert.deepEqual(result1, result2, 'Results should be identical');
     assert.deepEqual(result2, result3, 'Results should be identical');
+  });
+
+  it('should reject startup when subprocess exits during startup delay', async () => {
+    const originalSpawn = PikeProcess.prototype.spawn;
+
+    PikeProcess.prototype.spawn = function mockedSpawn(this: PikeProcess): void {
+      setTimeout(() => this.emit('exit', 1), 0);
+    };
+
+    const localBridge = new PikeBridge();
+
+    try {
+      await assert.rejects(
+        localBridge.start(),
+        /exited during startup|not alive after startup delay/,
+        'start() should reject when process exits before readiness'
+      );
+      assert.equal(localBridge.isRunning(), false, 'Bridge should not be running after failed start');
+    } finally {
+      PikeProcess.prototype.spawn = originalSpawn;
+    }
+  });
+
+  it('should clean pending request state when send throws synchronously', async () => {
+    const localBridge = new PikeBridge();
+    const failingProcess = {
+      isAlive: () => true,
+      send: () => {
+        throw new Error('stdin closed');
+      },
+    };
+
+    (localBridge as any).process = failingProcess;
+    (localBridge as any).started = true;
+
+    await assert.rejects(
+      (localBridge as any).sendRequest('parse', { code: 'int x = 1;', filename: 'test.pike' }),
+      /Failed to send request/,
+      'sendRequest should reject immediately on synchronous send failure'
+    );
+
+    assert.equal(
+      (localBridge as any).pendingRequests.size,
+      0,
+      'pendingRequests should be cleaned up after send failure'
+    );
   });
 
   it('should resolve local modules with currentFile context', async () => {

--- a/packages/pike-bridge/src/bridge.ts
+++ b/packages/pike-bridge/src/bridge.ts
@@ -251,12 +251,61 @@ export class PikeBridge extends EventEmitter {
     const pikeProc = new PikeProcess();
 
     return new Promise((resolve, reject) => {
-      // Set up event handlers before spawning
-      pikeProc.once('error', err => {
-        this.debugLog(`Process error event: ${err.message}`);
+      let startupSettled = false;
+      let startupTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const cleanupStartupHandlers = (): void => {
+        pikeProc.removeListener('error', onStartupError);
+        pikeProc.removeListener('exit', onStartupExit);
+      };
+
+      const rejectStartup = (message: string): void => {
+        if (startupSettled) {
+          return;
+        }
+
+        startupSettled = true;
+        if (startupTimer) {
+          clearTimeout(startupTimer);
+          startupTimer = null;
+        }
         this.started = false;
-        reject(new Error(`Failed to start Pike subprocess: ${err.message}`));
-      });
+        this.process = null;
+        cleanupStartupHandlers();
+        reject(new Error(message));
+      };
+
+      const resolveStartup = (): void => {
+        if (startupSettled) {
+          return;
+        }
+
+        startupSettled = true;
+        startupTimer = null;
+        this.started = true;
+        cleanupStartupHandlers();
+        this.debugLog('Pike subprocess started successfully');
+        this.emit('started');
+        resolve();
+      };
+
+      const onStartupError = (err: Error): void => {
+        this.debugLog(`Process error event: ${err.message}`);
+        rejectStartup(`Failed to start Pike subprocess: ${err.message}`);
+      };
+
+      const onStartupExit = (code: number | null): void => {
+        if (startupSettled) {
+          return;
+        }
+
+        this.debugLog(`Process exited during startup with code: ${code}`);
+        rejectStartup(`Pike subprocess exited during startup with code ${code}`);
+      };
+
+      // Set up event handlers before spawning
+      pikeProc.on('error', onStartupError);
+      pikeProc.on('exit', onStartupExit);
 
       // Forward stderr events
       pikeProc.on('stderr', data => {
@@ -306,16 +355,18 @@ export class PikeBridge extends EventEmitter {
         this.process = pikeProc;
 
         // Give the process a moment to start
-        setTimeout(() => {
-          this.started = true;
-          this.debugLog('Pike subprocess started successfully');
-          this.emit('started');
-          resolve();
+        startupTimer = setTimeout(() => {
+          if (!this.process || !this.process.isAlive()) {
+            rejectStartup('Pike subprocess is not alive after startup delay');
+            return;
+          }
+
+          resolveStartup();
         }, PROCESS_STARTUP_DELAY);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         this.debugLog(`Exception during start: ${message}`);
-        reject(new Error(`Failed to start Pike bridge: ${message}`));
+        rejectStartup(`Failed to start Pike bridge: ${message}`);
       }
     });
   }
@@ -426,8 +477,23 @@ export class PikeBridge extends EventEmitter {
 
       const request: PikeRequest = { id, method: method as PikeRequest['method'], params };
       const json = JSON.stringify(request);
+      const process = this.process;
 
-      this.process?.send(json);
+      if (!process) {
+        clearTimeout(timeout);
+        this.pendingRequests.delete(id);
+        reject(new PikeError('Pike process is not running'));
+        return;
+      }
+
+      try {
+        process.send(json);
+      } catch (err) {
+        clearTimeout(timeout);
+        this.pendingRequests.delete(id);
+        const message = err instanceof Error ? err.message : String(err);
+        reject(new PikeError(`Failed to send request ${id}: ${message}`));
+      }
     });
 
     // Track as inflight
@@ -436,11 +502,16 @@ export class PikeBridge extends EventEmitter {
     }
 
     // Remove from inflight when done (success or failure)
-    promise.finally(() => {
-      if (requestKey) {
-        this.requestCache.delete(requestKey);
-      }
-    });
+    if (requestKey) {
+      promise.then(
+        () => {
+          this.requestCache.delete(requestKey);
+        },
+        () => {
+          this.requestCache.delete(requestKey);
+        }
+      );
+    }
 
     // Apply runtime response validation if provided
     if (validate) {


### PR DESCRIPTION
## Summary
This hardens `PikeBridge` lifecycle handling so startup and request-send race failures fail fast with deterministic cleanup instead of degrading into delayed timeouts or stale in-flight state. It also adds regression coverage for startup-exit and synchronous send-failure paths.

## Linked Issue
closes #790

## Root Cause
`start()` previously used a fixed delay to mark readiness and did not explicitly fail on subprocess exit during the startup window. `sendRequest()` added pending bookkeeping before IPC send, but synchronous `send()` failures relied on fragile behavior and request-cache cleanup used `finally` in a way that could produce unobserved rejection chains.

## Changes
- `packages/pike-bridge/src/bridge.ts`: added guarded startup settlement (`startupSettled`) with startup-only `error`/`exit` handlers, timer/listener cleanup, and explicit early-exit rejection so failed startup cannot be marked as ready.
- `packages/pike-bridge/src/bridge.ts`: updated `sendRequest()` to validate process presence, wrap `process.send()` in `try/catch`, and immediately clear timeout/pending state on send failure.
- `packages/pike-bridge/src/bridge.ts`: replaced inflight cache cleanup from `promise.finally(...)` to explicit success/failure handlers to avoid unhandled rejection noise.
- `packages/pike-bridge/src/bridge.test.ts`: added regression tests for startup exit during delay and for synchronous send failure pending-state cleanup.

## Verification
- `cd packages/pike-bridge && bun run typecheck` ✅
- `cd packages/pike-bridge && bun run build` ✅
- `cd packages/pike-bridge && bun test ./src/bridge.test.ts` ✅ (55 pass)
- `cd packages/pike-bridge && bun run test` ✅ (111 pass, 8 skip)
- `bun run typecheck` (workspace root) ✅
- `bun run build` (workspace root) ✅
- `git commit` pre-commit hook fast regression ✅ (`pike-compile`, `bridge`, `server` all pass)
- `git push` pre-push checks ✅ (`node:test` guard, TS build check, Pike compile check)

## Notes for Reviewer
This scope is intentionally limited to bridge startup/send robustness and regression safety; it does not alter query-engine-v2 branch policy or protocol behavior.