### PR TITLE
fix: reject in-flight requests during bridge stop

### DIFF
--- a/packages/pike-bridge/src/bridge.test.ts
+++ b/packages/pike-bridge/src/bridge.test.ts
@@ -592,6 +592,46 @@ foo(@args);
     );
   });
 
+  it('should reject pending requests on stop even without exit event', async () => {
+    const localBridge = new PikeBridge();
+    let rejectedMessage = '';
+    const timeout = setTimeout(() => undefined, 10000);
+
+    try {
+      (localBridge as any).pendingRequests.set(999, {
+        resolve: () => undefined,
+        reject: (error: Error) => {
+          rejectedMessage = error.message;
+        },
+        timeout,
+      });
+
+      (localBridge as any).process = {
+        kill: () => undefined,
+        isAlive: () => true,
+      };
+      (localBridge as any).started = true;
+
+      await localBridge.stop();
+
+      assert.equal(
+        (localBridge as any).pendingRequests.size,
+        0,
+        'pendingRequests should be cleared during stop()'
+      );
+      if (!rejectedMessage) {
+        throw new Error('Pending request should be rejected during stop()');
+      }
+      assert.match(
+        rejectedMessage,
+        /stopped while requests were in flight/,
+        'Stop rejection should include deterministic shutdown message'
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
+
   it('should resolve local modules with currentFile context', async () => {
     const modulePath = '.SHA256';
     const currentFile = '/tmp/project/RSA.pmod';

--- a/packages/pike-bridge/src/bridge.ts
+++ b/packages/pike-bridge/src/bridge.ts
@@ -338,14 +338,7 @@ export class PikeBridge extends EventEmitter {
         this.process = null;
         this.emit('close', code);
 
-        // Reject all pending requests
-        for (const [_id, pending] of this.pendingRequests) {
-          clearTimeout(pending.timeout);
-          const error = new PikeError(`Pike process exited with code ${code}`);
-          this.debugLog(`Rejecting pending request: ${error.message}`);
-          pending.reject(error);
-        }
-        this.pendingRequests.clear();
+        this.rejectAllPendingRequests(`Pike process exited with code ${code}`);
       });
 
       // Spawn the process
@@ -385,6 +378,8 @@ export class PikeBridge extends EventEmitter {
       this.debugLog('Stopping Pike subprocess...');
       const proc = this.process;
 
+      this.rejectAllPendingRequests('Pike bridge stopped while requests were in flight');
+
       // Graceful shutdown via PikeProcess
       proc.kill();
 
@@ -395,9 +390,23 @@ export class PikeBridge extends EventEmitter {
       this.process = null;
       this.started = false;
     }
+    this.rejectAllPendingRequests('Pike bridge stopped while requests were in flight');
     this.requestCache.clear();
     this.clearResolutionCaches();
     this.emit('stopped');
+  }
+
+  private rejectAllPendingRequests(message: string): void {
+    if (this.pendingRequests.size === 0) {
+      return;
+    }
+
+    for (const [_id, pending] of this.pendingRequests) {
+      clearTimeout(pending.timeout);
+      pending.reject(new PikeError(message));
+    }
+
+    this.pendingRequests.clear();
   }
 
   private clearResolutionCaches(): void {


### PR DESCRIPTION
## Summary
This makes bridge shutdown deterministic by rejecting and clearing in-flight requests as part of `stop()`, instead of relying only on asynchronous process-exit timing. It prevents stale pending state from lingering until timeout when shutdown paths are delayed.

## Linked Issue
closes #792

## Root Cause
Pending request cleanup was tied to the process `exit` handler. During stop flows where exit can be delayed or not emitted promptly, callers could wait on request timeouts and `pendingRequests` could remain populated longer than intended.

## Changes
- `packages/pike-bridge/src/bridge.ts`: introduced `rejectAllPendingRequests(message)` to centralize pending request timeout clearing + rejection + map cleanup.
- `packages/pike-bridge/src/bridge.ts`: invoke the shared pending cleanup helper in both the process `exit` path and `stop()` so shutdown behavior is deterministic.
- `packages/pike-bridge/src/bridge.test.ts`: added regression test asserting `stop()` rejects and clears pending requests even when using a mock process path without an emitted `exit` event.

## Verification
- `cd packages/pike-bridge && bun run typecheck` ✅
- `cd packages/pike-bridge && bun run build` ✅
- `cd packages/pike-bridge && bun test ./src/bridge.test.ts` ✅ (56 pass)
- `cd packages/pike-bridge && bun run test` ✅ (112 pass, 8 skip)
- `bun run typecheck` (workspace root) ✅
- `bun run build` (workspace root) ✅
- `git commit` pre-commit hook fast regression ✅ (`pike-compile`, `bridge`, `server` all pass)
- `git push` pre-push checks ✅ (`node:test` guard, TS build check, Pike compile check)

## Notes for Reviewer
This change is intentionally scoped to shutdown lifecycle consistency and does not alter request payload semantics or query-engine protocol behavior.