### PR TITLE
fix: sync workspace scanner files after addFolder

### DIFF
--- a/packages/pike-lsp-server/src/services/workspace-scanner.ts
+++ b/packages/pike-lsp-server/src/services/workspace-scanner.ts
@@ -84,7 +84,10 @@ export class WorkspaceScanner {
     async addFolder(folder: string): Promise<void> {
         this.logger.debug('WorkspaceScanner: adding folder', { folder });
         this.workspaceRoots.add(folder);
-        await this.scanFolder(folder);
+        const files = await this.scanFolder(folder);
+        for (const file of files) {
+            this.files.set(file.uri, file);
+        }
     }
 
     /**

--- a/packages/pike-lsp-server/src/tests/services/workspace-scanner.test.ts
+++ b/packages/pike-lsp-server/src/tests/services/workspace-scanner.test.ts
@@ -171,17 +171,41 @@ describe('WorkspaceScanner - 26.3 Multi-folder workspace', () => {
     });
 
     it('26.3.2 should add folder dynamically', async () => {
-        // Arrange
         const logger = createMockLogger();
         const scanner = new WorkspaceScanner(logger, () => ({}));
-        await scanner.initialize(['/workspace1']);
+        const os = await import('node:os');
+        const fs = await import('node:fs/promises');
+        const path = await import('node:path');
 
-        // Act
-        await scanner.addFolder('/workspace2');
+        const rootA = path.join(os.tmpdir(), `ws-add-a-${Date.now()}`);
+        const rootB = path.join(os.tmpdir(), `ws-add-b-${Date.now()}`);
 
-        // Assert
-        const stats = scanner.getStats();
-        assert.equal(stats.rootCount, 2);
+        await fs.mkdir(rootA, { recursive: true });
+        await fs.mkdir(rootB, { recursive: true });
+        await fs.writeFile(path.join(rootA, 'a.pike'), 'int a;');
+        await fs.writeFile(path.join(rootB, 'b.pike'), 'int b;');
+
+        try {
+            await scanner.initialize([rootA]);
+
+            const beforeAdd = scanner.getAllFiles();
+            assert.equal(beforeAdd.length, 1);
+            assert.ok(beforeAdd.some(file => file.path.startsWith(`file://${rootA}`)));
+
+            await scanner.addFolder(rootB);
+
+            const afterAdd = scanner.getAllFiles();
+            assert.equal(afterAdd.length, 2);
+            assert.ok(afterAdd.some(file => file.path.startsWith(`file://${rootA}`)));
+            assert.ok(afterAdd.some(file => file.path.startsWith(`file://${rootB}`)));
+
+            const stats = scanner.getStats();
+            assert.equal(stats.rootCount, 2);
+            assert.equal(stats.fileCount, 2);
+        } finally {
+            await fs.rm(rootA, { recursive: true, force: true });
+            await fs.rm(rootB, { recursive: true, force: true });
+        }
     });
 
     it('26.3.3 should remove folder and its files', async () => {


### PR DESCRIPTION
## Summary
This keeps `WorkspaceScanner` consistent when workspace folders are added after initialization. Newly added roots now contribute their discovered Pike files immediately, so uncached workspace search paths can see the new folder without a full scanner reinitialize.

## Linked Issue

closes #802

## Root Cause
`WorkspaceScanner.addFolder()` updated `workspaceRoots` but discarded the `scanFolder()` result, so the scanner's live `files` map stayed stale after `workspace/didChangeWorkspaceFolders` additions. Features that depend on `getAllFiles()` and `getUncachedFiles()` could therefore miss files from the newly added root even though the server claimed the folder was added.

## Changes
- `packages/pike-lsp-server/src/services/workspace-scanner.ts`: merge `scanFolder()` results into the scanner's live `files` map during `addFolder()` so folder additions update searchable scanner state.
- `packages/pike-lsp-server/src/tests/services/workspace-scanner.test.ts`: replace the placeholder dynamic-folder test with a real temp-directory regression that proves files from both roots are visible after `addFolder()`.

## Verification
- `bun test packages/pike-lsp-server/src/tests/services/workspace-scanner.test.ts` (pass: 26 tests)
- `bun run typecheck` (pass: project graph dry-run reports `packages/pike-bridge` and `packages/pike-lsp-server` would build)
- pre-commit fast regression gate (pass: `pike-compile`, `bridge`, `server`)

## Notes for Reviewer
This is intentionally scoped to folder-add coherence only. File-watcher-driven scanner staleness is tracked separately in #800.