### PR TITLE
fix: sync workspace scanner on watched file changes

### DIFF
--- a/packages/pike-lsp-server/src/features/file-watcher.ts
+++ b/packages/pike-lsp-server/src/features/file-watcher.ts
@@ -81,7 +81,7 @@ export function registerFileWatcher(
   services: Services,
   documents: TextDocuments<TextDocument>
 ): void {
-  const { workspaceIndex, documentCache } = services;
+  const { workspaceIndex, documentCache, workspaceScanner } = services;
   const log = new Logger('FileWatcher');
 
   connection.onDidChangeWatchedFiles(async (params: DidChangeWatchedFilesParams) => {
@@ -116,7 +116,7 @@ export function registerFileWatcher(
         switch (type) {
           case LSPFileChangeType.Created: {
             connection.console.log(`[FILE_WATCHER] Created: ${uri}`);
-            await handleFileCreated(uri, filePath, documents, workspaceIndex);
+            await handleFileCreated(uri, filePath, documents, workspaceIndex, workspaceScanner);
             created++;
             processed++;
             break;
@@ -124,7 +124,14 @@ export function registerFileWatcher(
 
           case LSPFileChangeType.Changed: {
             connection.console.log(`[FILE_WATCHER] Changed: ${uri}`);
-            await handleFileChanged(uri, filePath, documents, workspaceIndex, documentCache);
+            await handleFileChanged(
+              uri,
+              filePath,
+              documents,
+              workspaceIndex,
+              documentCache,
+              workspaceScanner
+            );
             updated++;
             processed++;
             break;
@@ -132,7 +139,7 @@ export function registerFileWatcher(
 
           case LSPFileChangeType.Deleted: {
             connection.console.log(`[FILE_WATCHER] Deleted: ${uri}`);
-            handleFileDeleted(uri, workspaceIndex, documentCache);
+            handleFileDeleted(uri, workspaceIndex, documentCache, workspaceScanner);
             deleted++;
             processed++;
             break;
@@ -163,13 +170,15 @@ export function registerFileWatcher(
     uri: string,
     path: string,
     docs: TextDocuments<TextDocument>,
-    index: typeof workspaceIndex
+    index: typeof workspaceIndex,
+    scanner: typeof workspaceScanner
   ): Promise<void> {
     // Check if file is already open in editor
     const doc = docs.get(uri);
     if (doc) {
       // File is open, index from document content
       await index.indexDocument(uri, doc.getText(), doc.version);
+      scanner?.upsertFile?.(uri, Date.now());
       return;
     }
 
@@ -177,6 +186,8 @@ export function registerFileWatcher(
     try {
       const content = await fs.promises.readFile(path, 'utf-8');
       await index.indexDocument(uri, content, 0);
+      const stat = await fs.promises.stat(path);
+      scanner?.upsertFile?.(uri, stat.mtimeMs);
     } catch (err) {
       throw new Error(
         `Failed to read newly created file '${path}': ${err instanceof Error ? err.message : String(err)}. Check file permissions and ensure the path is accessible.`
@@ -192,7 +203,8 @@ export function registerFileWatcher(
     path: string,
     docs: TextDocuments<TextDocument>,
     index: typeof workspaceIndex,
-    cache: typeof documentCache
+    cache: typeof documentCache,
+    scanner: typeof workspaceScanner
   ): Promise<void> {
     // Check if file is open in editor
     const doc = docs.get(uri);
@@ -200,6 +212,8 @@ export function registerFileWatcher(
       // File is open in editor - didChange will handle indexing
       // No need to re-index here, it would create duplicate work
       connection.console.log(`[FILE_WATCHER] Skipping open file (didChange will handle): ${uri}`);
+      scanner?.upsertFile?.(uri, Date.now());
+      scanner?.invalidateFile?.(uri);
       return;
     }
 
@@ -207,13 +221,16 @@ export function registerFileWatcher(
     try {
       const content = await fs.promises.readFile(path, 'utf-8');
       await index.indexDocument(uri, content, 0);
+      const stat = await fs.promises.stat(path);
+      scanner?.upsertFile?.(uri, stat.mtimeMs);
+      scanner?.invalidateFile?.(uri);
 
       // Also clear any cached diagnostics for this file
       cache.delete(uri);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
         // File was deleted between change event and now
-        handleFileDeleted(uri, index, cache);
+        handleFileDeleted(uri, index, cache, scanner);
         return;
       }
       throw new Error(
@@ -228,13 +245,16 @@ export function registerFileWatcher(
   function handleFileDeleted(
     uri: string,
     index: typeof workspaceIndex,
-    cache: typeof documentCache
+    cache: typeof documentCache,
+    scanner: typeof workspaceScanner
   ): void {
     // Remove from workspace index
     index.removeDocument(uri);
 
     // Remove from document cache
     cache.delete(uri);
+
+    scanner?.removeFile?.(uri);
   }
 }
 

--- a/packages/pike-lsp-server/src/services/workspace-scanner.ts
+++ b/packages/pike-lsp-server/src/services/workspace-scanner.ts
@@ -252,6 +252,21 @@ export class WorkspaceScanner {
         }
     }
 
+    upsertFile(uri: string, lastModified: number): void {
+        const existing = this.files.get(uri);
+        if (existing) {
+            existing.lastModified = lastModified;
+            existing.path = uri;
+            return;
+        }
+
+        this.files.set(uri, {
+            uri,
+            path: uri,
+            lastModified,
+        });
+    }
+
     /**
      * Invalidate cached data for a file (e.g., on file change).
      */
@@ -261,6 +276,10 @@ export class WorkspaceScanner {
             file.symbols = undefined;
             file.symbolPositions = undefined;
         }
+    }
+
+    removeFile(uri: string): void {
+        this.files.delete(uri);
     }
 
     /**

--- a/packages/pike-lsp-server/src/tests/features/file-watcher.test.ts
+++ b/packages/pike-lsp-server/src/tests/features/file-watcher.test.ts
@@ -12,6 +12,7 @@ import { PikeBridge } from '@pike-lsp/pike-bridge';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { FileChangeType, registerFileWatcher } from '../../features/file-watcher.js';
 
 describe('File Watching (Issue #184)', () => {
   let bridge: PikeBridge | null = null;
@@ -160,6 +161,78 @@ class UpdatedClass {
         Changed: 2,
         Deleted: 3,
       });
+    });
+  });
+
+  describe('WorkspaceScanner synchronization', () => {
+    it('updates scanner state for watched unopened file create/change/delete events', async () => {
+      const uri = `file://${testFilePath}`;
+      fs.writeFileSync(testFilePath, 'int created = 1;');
+
+      const scannerEvents: Array<{ type: string; uri: string }> = [];
+      let watchedFilesHandler: ((params: { changes: Array<{ uri: string; type: number }> }) => Promise<void>) | null = null;
+
+      const connection = {
+        onDidChangeWatchedFiles(handler: typeof watchedFilesHandler) {
+          watchedFilesHandler = handler;
+        },
+        console: {
+          log() {},
+          warn() {},
+          error() {},
+        },
+      };
+
+      const services = {
+        workspaceIndex: {
+          async indexDocument() {},
+          removeDocument() {},
+        },
+        documentCache: {
+          delete() {},
+        },
+        workspaceScanner: {
+          upsertFile(targetUri: string) {
+            scannerEvents.push({ type: 'upsert', uri: targetUri });
+          },
+          invalidateFile(targetUri: string) {
+            scannerEvents.push({ type: 'invalidate', uri: targetUri });
+          },
+          removeFile(targetUri: string) {
+            scannerEvents.push({ type: 'remove', uri: targetUri });
+          },
+        },
+      };
+
+      const documents = {
+        get() {
+          return undefined;
+        },
+      };
+
+      registerFileWatcher(connection as any, services as any, documents as any);
+      expect(watchedFilesHandler).not.toBeNull();
+
+      await watchedFilesHandler!({
+        changes: [{ uri, type: FileChangeType.Created }],
+      });
+
+      fs.writeFileSync(testFilePath, 'int changed = 2;');
+      await watchedFilesHandler!({
+        changes: [{ uri, type: FileChangeType.Changed }],
+      });
+
+      fs.rmSync(testFilePath);
+      await watchedFilesHandler!({
+        changes: [{ uri, type: FileChangeType.Deleted }],
+      });
+
+      expect(scannerEvents).toEqual([
+        { type: 'upsert', uri },
+        { type: 'upsert', uri },
+        { type: 'invalidate', uri },
+        { type: 'remove', uri },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary
This keeps `WorkspaceScanner` aligned with watched Pike file create/change/delete events. Unopened workspace files now update scanner membership and invalidate scanner-cached metadata when the file watcher sees filesystem changes, so uncached workspace search paths stop drifting from on-disk state.

## Linked Issue

closes #800

## Root Cause
`registerFileWatcher()` updated `WorkspaceIndex` and `DocumentCache` but never updated `WorkspaceScanner`, even though references/rename/hierarchy fallback searches depend on the scanner for uncached workspace files. That let newly created or deleted files drift out of sync with the scanner's file set and stale lazy metadata survive changes.

## Changes
- `packages/pike-lsp-server/src/features/file-watcher.ts`: update watcher handlers to upsert, invalidate, and remove `WorkspaceScanner` entries alongside existing index/cache maintenance.
- `packages/pike-lsp-server/src/services/workspace-scanner.ts`: add focused `upsertFile()` and `removeFile()` helpers so watcher code can keep scanner state coherent without a full rescan.
- `packages/pike-lsp-server/src/tests/features/file-watcher.test.ts`: add regression coverage proving watched create/change/delete events propagate the expected scanner updates for unopened files.

## Verification
- `bun test packages/pike-lsp-server/src/tests/features/file-watcher.test.ts` (pass: 11 tests)
- `bun run typecheck` (pass: project graph dry-run reports `packages/pike-lsp-server` would build)
- `./scripts/test-agent.sh --fast` (pass: `pike-compile`, `bridge`, `server`)
- pre-commit fast regression gate (pass)

## Notes for Reviewer
The watcher now uses optional method calls (`workspaceScanner?.upsertFile?.(...)`) so older test/service mocks that provide a scanner object without the new helpers do not regress.