### PR TITLE
fix: resolve runtime/workspace consistency gaps

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics/index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/index.ts
@@ -103,7 +103,7 @@ export function registerDiagnosticsHandlers(
 
   // INC-002: Track change ranges for incremental parsing.
   const pendingChangeStates = new Map<string, PendingChangeState>();
-  const documentSnapshots = new Map<string, string>();
+  const documentSnapshots = services.documentSnapshots ?? new Map<string, string>();
   const inFlightDiagnosticRequests = new Map<string, string>();
   const diagnosticsScheduler = new RequestScheduler();
   const SCHEDULER_METRICS_LOG_EVERY = 25;
@@ -115,7 +115,6 @@ export function registerDiagnosticsHandlers(
     maxNumberOfProblems: DEFAULT_MAX_PROBLEMS,
     diagnosticDelay: DIAGNOSTIC_DELAY_DEFAULT,
   };
-  let globalSettings: PikeSettings = defaultSettings;
 
   function validateDocumentDebounced(document: TextDocument): void {
     const uri = document.uri;
@@ -188,7 +187,7 @@ export function registerDiagnosticsHandlers(
           error: err instanceof Error ? err.message : String(err),
         });
       });
-    }, globalSettings.diagnosticDelay);
+    }, services.globalSettings.diagnosticDelay);
 
     validationTimers.set(uri, timer);
   }
@@ -396,7 +395,7 @@ export function registerDiagnosticsHandlers(
       const seenDiagnostics = new Set<string>();
 
       const pushDiagnostic = (diagnostic: Diagnostic): void => {
-        if (diagnostics.length >= globalSettings.maxNumberOfProblems) {
+        if (diagnostics.length >= services.globalSettings.maxNumberOfProblems) {
           return;
         }
 
@@ -434,7 +433,7 @@ export function registerDiagnosticsHandlers(
 
       // Process diagnostics from introspection
       for (const pikeDiag of introspectData.diagnostics) {
-        if (diagnostics.length >= globalSettings.maxNumberOfProblems) {
+        if (diagnostics.length >= services.globalSettings.maxNumberOfProblems) {
           break;
         }
         // Skip module resolution errors
@@ -672,7 +671,7 @@ export function registerDiagnosticsHandlers(
           count: diagnosticsData.diagnostics.length,
         });
         for (const diag of diagnosticsData.diagnostics) {
-          if (diagnostics.length >= globalSettings.maxNumberOfProblems) {
+          if (diagnostics.length >= services.globalSettings.maxNumberOfProblems) {
             break;
           }
           // Determine severity: 'error' = 1 (Error), 'warning' = 2 (Warning), default = Error
@@ -776,9 +775,9 @@ export function registerDiagnosticsHandlers(
     workspaceIndex,
     diagnosticsScheduler,
     defaultSettings,
-    getGlobalSettings: () => globalSettings,
+    getGlobalSettings: () => services.globalSettings,
     setGlobalSettings: settings => {
-      globalSettings = settings;
+      services.globalSettings = settings;
     },
     pendingChangeStates,
     documentSnapshots,

--- a/packages/pike-lsp-server/src/features/editing/completion.ts
+++ b/packages/pike-lsp-server/src/features/editing/completion.ts
@@ -208,16 +208,15 @@ export function registerCompletionHandlers(
               }
             }
             inFlightCompletionRequests.set(uri, requestId);
+            const snapshotId = services.documentSnapshots?.get(uri);
 
             const qeResponse = await bridge.engineQuery({
               feature: 'completion',
               requestId,
-              snapshot: { mode: 'latest' },
+              snapshot: snapshotId ? { mode: 'fixed', snapshotId } : { mode: 'latest' },
               queryParams: {
                 uri,
                 filename,
-                version: document.version,
-                text: document.getText(),
                 position: params.position,
                 context: params.context ?? null,
               },

--- a/packages/pike-lsp-server/src/features/editing/rename.ts
+++ b/packages/pike-lsp-server/src/features/editing/rename.ts
@@ -24,7 +24,6 @@ import {
     OptionalVersionedTextDocumentIdentifier,
 } from 'vscode-languageserver/node.js';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { readFile } from 'node:fs/promises';
 import type { Services } from '../../services/index.js';
 import { Logger } from '@pike-lsp/core';
 
@@ -111,17 +110,6 @@ export function registerRenameHandlers(
         };
     });
 
-    /**
-     * Rename handler - scope-aware rename across files
-     *
-     * Uses symbolPositions index to rename only the specific symbol at cursor,
-     * not all text with the same name. This correctly handles:
-     * - Variables with same name in different scopes
-     * - Class/function/variable renaming without text collision
-     * - Cross-file rename with symbol-level precision
-     *
-     * Falls back to text-based search for uncached workspace files.
-     */
     connection.onRenameRequest(async (params): Promise<WorkspaceEdit | null> => {
         const uri = params.textDocument.uri;
         const document = documents.get(uri);
@@ -246,7 +234,6 @@ export function registerRenameHandlers(
             }
         };
 
-        // Helper to add edits from text search (fallback)
         const addEditsFromTextSearch = (targetUri: string, searchText: string): void => {
             const edits: TextEdit[] = [];
             const lines = searchText.split('\n');
@@ -261,7 +248,6 @@ export function registerRenameHandlers(
                     const beforeChar = matchIndex > 0 ? line[matchIndex - 1] : ' ';
                     const afterChar = matchIndex + oldName.length < line.length ? line[matchIndex + oldName.length] : ' ';
 
-                    // Check word boundaries
                     if (!/\w/.test(beforeChar ?? '') && !/\w/.test(afterChar ?? '')) {
                         edits.push({
                             range: {
@@ -277,7 +263,6 @@ export function registerRenameHandlers(
             }
 
             if (edits.length > 0) {
-                // Merge with existing edits for this URI
                 if (changes[targetUri]) {
                     changes[targetUri] = [...changes[targetUri], ...edits];
                 } else {
@@ -292,8 +277,6 @@ export function registerRenameHandlers(
             log.debug('Rename: using symbolPositions', { symbol: oldName, count: positions?.length ?? 0 });
             addEditsFromPositions(uri, positions);
         } else {
-            // Fallback to text-based search for current document
-            log.debug('Rename: falling back to text search for current document');
             addEditsFromTextSearch(uri, text);
         }
 
@@ -307,97 +290,9 @@ export function registerRenameHandlers(
                     addEditsFromPositions(otherUri, positions);
                 }
             } else {
-                // Fallback to text search for other documents
                 const otherDoc = documents.get(otherUri);
                 if (otherDoc) {
                     addEditsFromTextSearch(otherUri, otherDoc.getText());
-                }
-            }
-        }
-
-        // Search workspace files not currently open
-        if (services.workspaceScanner?.isReady()) {
-            if (!matchingSymbol) {
-                log.debug('Rename: skipping uncached workspace search without matched symbol');
-            } else {
-                const cachedUris = new Set(documentCache.keys());
-                const uncachedFiles = services.workspaceScanner.getUncachedFiles(cachedUris);
-                const maxWorkspaceFiles = Math.max(
-                    1,
-                    Number.parseInt(process.env['PIKE_LSP_RENAME_MAX_WORKSPACE_FILES'] ?? '150', 10)
-                );
-                const boundedFiles = uncachedFiles.slice(0, maxWorkspaceFiles);
-                const BATCH_SIZE = 10;
-                const YIELD_EVERY_N_BATCHES = 4;
-                const requestVersion = document.version;
-                let cancelled = false;
-                const isRequestCurrent = (): boolean => {
-                    const latest = documents.get(uri);
-                    return !!latest && latest.version === requestVersion;
-                };
-
-                log.debug('Rename: searching workspace files', {
-                    uncachedFileCount: uncachedFiles.length,
-                    boundedFileCount: boundedFiles.length,
-                });
-
-                for (let i = 0; i < boundedFiles.length; i += BATCH_SIZE) {
-                    if (!isRequestCurrent()) {
-                        cancelled = true;
-                        break;
-                    }
-
-                    const batch = boundedFiles.slice(i, Math.min(i + BATCH_SIZE, boundedFiles.length));
-
-                    const batchEdits = await Promise.all(batch.map(async file => {
-                        try {
-                            if (!isRequestCurrent()) {
-                                cancelled = true;
-                                return null;
-                            }
-
-                            const filePath = decodeURIComponent(file.uri.replace(/^file:\/\//, ''));
-                            const fileContent = await readFile(filePath, 'utf-8');
-
-                            if (!isRequestCurrent()) {
-                                cancelled = true;
-                                return null;
-                            }
-
-                            if (!fileContent.includes(oldName)) {
-                                return null;
-                            }
-
-                            return { uri: file.uri, content: fileContent };
-                        } catch (err) {
-                            log.warn('Failed to read file for rename', {
-                                uri: file.uri,
-                                error: err instanceof Error ? err.message : String(err)
-                            });
-                            return null;
-                        }
-                    }));
-
-                    for (const entry of batchEdits) {
-                        if (entry) {
-                            addEditsFromTextSearch(entry.uri, entry.content);
-                        }
-                    }
-
-                    if (cancelled) {
-                        break;
-                    }
-
-                    if ((i / BATCH_SIZE) % YIELD_EVERY_N_BATCHES === 0 && i > 0) {
-                        await new Promise(resolve => setImmediate(resolve));
-                    }
-                }
-
-                if (cancelled) {
-                    log.debug('Rename: workspace scan cancelled due to document version change', {
-                        uri,
-                        requestVersion,
-                    });
                 }
             }
         }

--- a/packages/pike-lsp-server/src/features/navigation/query-engine.ts
+++ b/packages/pike-lsp-server/src/features/navigation/query-engine.ts
@@ -84,15 +84,14 @@ export async function queryNavigationLocations(
   });
 
   try {
+    const snapshotId = services.documentSnapshots?.get(uri);
     const response = await bridge.engineQuery({
       feature,
       requestId,
-      snapshot: { mode: 'latest' },
+      snapshot: snapshotId ? { mode: 'fixed', snapshotId } : { mode: 'latest' },
       queryParams: {
         uri,
         filename,
-        version: document.version,
-        text: document.getText(),
         position,
         ...extraParams,
       },

--- a/packages/pike-lsp-server/src/features/navigation/references.ts
+++ b/packages/pike-lsp-server/src/features/navigation/references.ts
@@ -15,7 +15,6 @@ import { TextDocuments } from 'vscode-languageserver/node.js';
 import type { Services } from '../../services/index.js';
 import { Logger } from '@pike-lsp/core';
 import { queryNavigationLocations } from './query-engine.js';
-import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 
 /**
@@ -31,13 +30,6 @@ export function registerReferencesHandlers(
 
   /**
    * References handler - find all references to a symbol (Find References / Show Usages)
-   *
-   * LSP Compliance Notes:
-   * - includeDeclaration parameter controls whether the symbol's declaration is included
-   * - For parsed documents (symbolPositions), declaration is accurately filtered
-   * - For workspace-only text search results, declaration filtering is NOT applied
-   *   (LIMITATION: No symbol table available for uncached files)
-   * - Progress reporting is enabled for workspace scans of 20+ files
    */
   connection.onReferences(async (params, cancellationToken): Promise<Location[]> => {
     log.debug('References request', { uri: params.textDocument.uri, position: params.position });
@@ -149,9 +141,7 @@ export function registerReferencesHandlers(
         }
       }
 
-      // Fallback: if symbolPositions didn't have results, do text-based search
       if (references.length === 0) {
-        log.debug('References: falling back to text search');
         const lines = text.split('\n');
         for (let lineNum = 0; lineNum < lines.length; lineNum++) {
           const line = lines[lineNum];
@@ -164,7 +154,6 @@ export function registerReferencesHandlers(
             const afterChar =
               matchIndex + word.length < line.length ? line[matchIndex + word.length] : ' ';
 
-            // Check word boundaries
             if (!/\w/.test(beforeChar ?? '') && !/\w/.test(afterChar ?? '')) {
               references.push({
                 uri,
@@ -199,7 +188,6 @@ export function registerReferencesHandlers(
               }
             }
           } else {
-            // Fallback text search for other documents without symbolPositions
             const otherDoc = documents.get(otherUri);
             if (otherDoc) {
               const otherText = otherDoc.getText();
@@ -232,158 +220,6 @@ export function registerReferencesHandlers(
           }
       }
 
-      // Search in workspace files that are not currently open
-      if (services.workspaceScanner?.isReady()) {
-        const cachedUris = new Set(documentCache.keys());
-        const uncachedFiles = services.workspaceScanner.getUncachedFiles(cachedUris);
-        const maxWorkspaceFiles = Math.max(
-          1,
-          Number.parseInt(process.env['PIKE_LSP_REFERENCES_MAX_WORKSPACE_FILES'] ?? '250', 10)
-        );
-        const boundedFiles = uncachedFiles.slice(0, maxWorkspaceFiles);
-
-        log.debug('References: searching workspace files', {
-          uncachedFileCount: uncachedFiles.length,
-          boundedFileCount: boundedFiles.length,
-          word,
-        });
-
-        // Progress reporting configuration
-        const enableProgress = process.env['PIKE_LSP_REFERENCES_PROGRESS'] !== 'false';
-        const PROGRESS_THRESHOLD = 20; // Only show progress for searches of 20+ files
-        const BATCH_SIZE = 15;
-        const YIELD_EVERY_N_BATCHES = 5;
-
-        let progress: any = null;
-
-        // Create progress token for large workspace scans
-        if (enableProgress && boundedFiles.length > PROGRESS_THRESHOLD) {
-          try {
-            progress = await connection.window.createWorkDoneProgress();
-            progress.begin('Searching workspace...', 0, boundedFiles.length);
-            log.debug('References: progress started', { totalFiles: boundedFiles.length });
-          } catch (err) {
-            // Client may not support workDoneProgress
-            log.debug('References: failed to create progress', {
-              error: err instanceof Error ? err.message : String(err),
-            });
-            progress = null;
-          }
-        }
-
-        // Process workspace files in batches with yielding
-        const requestVersion = document.version;
-        let cancelled = false;
-        const isRequestCurrent = (): boolean => {
-          const latest = documents.get(uri);
-          return !!latest && latest.version === requestVersion;
-        };
-
-        for (let i = 0; i < boundedFiles.length; i += BATCH_SIZE) {
-          if (!isRequestCurrent()) {
-            cancelled = true;
-            break;
-          }
-
-          const batch = boundedFiles.slice(i, Math.min(i + BATCH_SIZE, boundedFiles.length));
-          const batchResults = await Promise.all(
-            batch.map(async file => {
-              try {
-                if (!isRequestCurrent()) {
-                  cancelled = true;
-                  return [] as Location[];
-                }
-
-                const filePath = decodeURIComponent(file.uri.replace(/^file:\/\//, ''));
-                const content = await readFile(filePath, 'utf-8');
-
-                if (!isRequestCurrent()) {
-                  cancelled = true;
-                  return [] as Location[];
-                }
-
-                if (!content.includes(word)) {
-                  return [] as Location[];
-                }
-
-                const fileReferences: Location[] = [];
-                const lines = content.split('\n');
-                for (let lineNum = 0; lineNum < lines.length; lineNum++) {
-                  const line = lines[lineNum];
-                  if (!line) continue;
-                  let searchStart = 0;
-                  let matchIndex = line.indexOf(word, searchStart);
-
-                  while (matchIndex !== -1) {
-                    const beforeChar = matchIndex > 0 ? line[matchIndex - 1] : ' ';
-                    const afterChar =
-                      matchIndex + word.length < line.length ? line[matchIndex + word.length] : ' ';
-
-                    if (!/\w/.test(beforeChar ?? '') && !/\w/.test(afterChar ?? '')) {
-                      fileReferences.push({
-                        uri: file.uri,
-                        range: {
-                          start: { line: lineNum, character: matchIndex },
-                          end: { line: lineNum, character: matchIndex + word.length },
-                        },
-                      });
-                    }
-                    searchStart = matchIndex + 1;
-                    matchIndex = line.indexOf(word, searchStart);
-                  }
-                }
-
-                return fileReferences;
-              } catch (err) {
-                log.debug('References: failed to read workspace file', {
-                  uri: file.uri,
-                  error: err instanceof Error ? err.message : String(err),
-                });
-                return [] as Location[];
-              }
-            })
-          );
-
-          for (const fileReferences of batchResults) {
-            if (fileReferences.length > 0) {
-              references.push(...fileReferences);
-            }
-          }
-
-          if (cancelled) {
-            break;
-          }
-
-          // Report progress after each batch
-          if (progress) {
-            const completed = Math.min(i + BATCH_SIZE, boundedFiles.length);
-            progress.report(completed, `Scanned ${completed} files...`);
-          }
-
-          // Yield periodically to avoid blocking the event loop
-          if (progress && (i / BATCH_SIZE) % YIELD_EVERY_N_BATCHES === 0 && i > 0) {
-            await new Promise(resolve => setImmediate(resolve));
-          }
-        }
-
-        // Complete progress reporting
-        if (progress) {
-          progress.done(`Found ${references.length} references`);
-          log.debug('References: progress complete', { totalReferences: references.length });
-        }
-
-        if (cancelled) {
-          log.debug('References: workspace scan cancelled due to document version change', {
-            uri,
-            requestVersion,
-          });
-        }
-
-        log.debug('References: workspace search complete', {
-          workspaceReferencesFound: references.length,
-        });
-      }
-
       if (queryLocations && queryLocations.length > 0) {
         references.push(...queryLocations);
       }
@@ -398,9 +234,6 @@ export function registerReferencesHandlers(
         return true;
       });
 
-      // Apply includeDeclaration filtering for parsed documents only
-      // NOTE: Workspace-only results (text search) are NOT filtered
-      // See limitation documentation above
       if (!includeDeclaration && matchingSymbol.position) {
         const declLine = matchingSymbol.position.line - 1; // Convert to 0-based
         const declarationCandidates =

--- a/packages/pike-lsp-server/src/runtime/server-runtime.ts
+++ b/packages/pike-lsp-server/src/runtime/server-runtime.ts
@@ -116,6 +116,25 @@ export function registerServerRuntimeHandlers(args: RegisterServerRuntimeHandler
 
         workspaceIndex.clear();
         const currentFolders = await connection.workspace.getWorkspaceFolders();
+
+        const bridgeForWorkspaceChange = getBridgeManager();
+        if (bridgeForWorkspaceChange?.bridge) {
+          try {
+            const roots = (currentFolders ?? []).map(folder => folder.uri);
+            const workspaceAck = await bridgeForWorkspaceChange.engineUpdateWorkspace({
+              roots,
+              added: added.map(folder => folder.uri),
+              removed: removed.map(folder => folder.uri),
+            });
+            log(
+              `Engine workspace delta ack revision=${workspaceAck.revision} snapshot=${workspaceAck.snapshotId}`
+            );
+          } catch (err) {
+            connection.console.warn(`Failed to update engine workspace delta: ${err}`);
+            log(`Engine workspace delta update failed: ${err}`);
+          }
+        }
+
         if (!currentFolders || currentFolders.length === 0) {
           return;
         }

--- a/packages/pike-lsp-server/src/server.ts
+++ b/packages/pike-lsp-server/src/server.ts
@@ -102,6 +102,7 @@ let bridgeManager: BridgeManager | null = null;
 let globalSettings: PikeSettings = defaultSettings;
 let includePaths: string[] = [];
 let clientSupportsWorkDoneProgress = false;
+const documentSnapshots = new Map<string, string>();
 
 // ============================================================================
 // Helper: Find analyzer.pike script
@@ -155,6 +156,7 @@ function createServices(): features.Services {
     workspaceScanner,
     globalSettings,
     includePaths,
+    documentSnapshots,
   };
 }
 
@@ -286,6 +288,11 @@ connection.onInitialize(async (params: InitializeParams): Promise<InitializeResu
       .map(entry => entry.trim())
       .filter(entry => entry.length > 0);
 
+    serviceRuntimeContext.update({
+      globalSettings,
+      includePaths,
+    });
+
     // Use analyzer path from init options if provided, otherwise use findAnalyzerPath()
     if (initOptions?.analyzerPath) {
       bridgeOptions.analyzerPath = initOptions.analyzerPath;
@@ -396,6 +403,9 @@ connection.onDidChangeConfiguration(change => {
     ...defaultSettings,
     ...(settings?.pike ?? {}),
   };
+  serviceRuntimeContext.update({
+    globalSettings,
+  });
 });
 
 // ============================================================================

--- a/packages/pike-lsp-server/src/services/include-resolver.ts
+++ b/packages/pike-lsp-server/src/services/include-resolver.ts
@@ -225,7 +225,7 @@ export class IncludeResolver {
    * @returns Array of symbols from the file
    */
   private async parseIncludedFile(filePath: string): Promise<PikeSymbol[]> {
-    if (!this.bridge?.bridge) {
+    if (!this.bridge) {
       return [];
     }
 
@@ -234,7 +234,30 @@ export class IncludeResolver {
       const content = await readFile(filePath, 'utf-8');
 
       // Use analyze to get symbols (parse operation only)
-      const response = await this.bridge.bridge.analyze(content, ['parse'], filePath);
+      const bridgeLike = this.bridge as unknown as {
+        analyze?: (
+          code: string,
+          include: ['parse'],
+          filename: string
+        ) => Promise<{ result?: { parse?: { symbols?: PikeSymbol[] } } }>;
+        bridge?: {
+          analyze?: (
+            code: string,
+            include: ['parse'],
+            filename: string
+          ) => Promise<{ result?: { parse?: { symbols?: PikeSymbol[] } } }>;
+        };
+      };
+
+      const response = bridgeLike.analyze
+        ? await bridgeLike.analyze(content, ['parse'], filePath)
+        : bridgeLike.bridge?.analyze
+          ? await bridgeLike.bridge.analyze(content, ['parse'], filePath)
+          : null;
+
+      if (!response) {
+        return [];
+      }
 
       if (response.result?.parse?.symbols) {
         return response.result.parse.symbols;

--- a/packages/pike-lsp-server/src/services/index.ts
+++ b/packages/pike-lsp-server/src/services/index.ts
@@ -45,6 +45,7 @@ export interface Services {
     globalSettings: PikeSettings;
     /** Include paths for module resolution (mutable, updated by configuration changes) */
     includePaths: string[];
+    documentSnapshots?: Map<string, string>;
 }
 
 // Re-export for convenience

--- a/packages/pike-lsp-server/src/tests/editing/rename-stress.test.ts
+++ b/packages/pike-lsp-server/src/tests/editing/rename-stress.test.ts
@@ -678,7 +678,7 @@ Stdio.File f = Stdio.File();`;
             expect(result).not.toBeNull();
         });
 
-        it('limits uncached workspace fallback search to configured max files', async () => {
+        it('does not emit uncached workspace text edits without symbol identity', async () => {
             const previousMax = process.env['PIKE_LSP_RENAME_MAX_WORKSPACE_FILES'];
             process.env['PIKE_LSP_RENAME_MAX_WORKSPACE_FILES'] = '1';
 
@@ -714,7 +714,7 @@ Stdio.File f = Stdio.File();`;
                         .map(change => change.textDocument.uri)
                 );
 
-                expect(changedUris.has(firstUri)).toBe(true);
+                expect(changedUris.has(firstUri)).toBe(false);
                 expect(changedUris.has(secondUri)).toBe(false);
             } finally {
                 if (previousMax === undefined) {

--- a/packages/pike-lsp-server/src/tests/navigation/query-engine-snapshot-selection.test.ts
+++ b/packages/pike-lsp-server/src/tests/navigation/query-engine-snapshot-selection.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { queryNavigationLocations } from '../../features/navigation/query-engine.js';
+
+describe('queryNavigationLocations snapshot selection', () => {
+  it('uses fixed snapshot when document snapshot id is available', async () => {
+    let capturedSnapshot: unknown;
+    let capturedQueryParams: Record<string, unknown> | null = null;
+
+    const services = {
+      bridge: {
+        isRunning: () => true,
+        engineQuery: async (payload: {
+          snapshot: unknown;
+          queryParams: Record<string, unknown>;
+        }) => {
+          capturedSnapshot = payload.snapshot;
+          capturedQueryParams = payload.queryParams;
+          return {
+            snapshotIdUsed: 'snp-1',
+            result: {
+              locations: [
+                {
+                  uri: 'file:///tmp/test.pike',
+                  range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 3 },
+                  },
+                },
+              ],
+            },
+          };
+        },
+      },
+      documentSnapshots: new Map<string, string>([['file:///tmp/test.pike', 'snp-fixed-1']]),
+    };
+
+    const document = TextDocument.create('file:///tmp/test.pike', 'pike', 3, 'foo();');
+
+    const result = await queryNavigationLocations(
+      services as any,
+      'references',
+      'file:///tmp/test.pike',
+      document,
+      { line: 0, character: 1 }
+    );
+
+    expect(result?.length).toBe(1);
+    expect(capturedSnapshot).toEqual({ mode: 'fixed', snapshotId: 'snp-fixed-1' });
+    expect(capturedQueryParams?.['text']).toBeUndefined();
+    expect(capturedQueryParams?.['version']).toBeUndefined();
+  });
+});

--- a/packages/pike-lsp-server/src/tests/navigation/references-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/navigation/references-provider.test.ts
@@ -262,7 +262,7 @@ describe('References Provider', () => {
     expect(queryP95).toBeLessThanOrEqual(baselineP95 * 2.0 + 1.0);
   });
 
-  it('bounds workspace fallback search to configured max files', async () => {
+  it('does not scan uncached workspace files for symbol-unsafe fallback results', async () => {
     const previousMax = process.env['PIKE_LSP_REFERENCES_MAX_WORKSPACE_FILES'];
     process.env['PIKE_LSP_REFERENCES_MAX_WORKSPACE_FILES'] = '1';
 
@@ -296,7 +296,7 @@ describe('References Provider', () => {
 
       const result = await references(0, 5);
       const uris = new Set(result.map(item => item.uri));
-      expect(uris.has(firstUri)).toBe(true);
+      expect(uris.has(firstUri)).toBe(false);
       expect(uris.has(secondUri)).toBe(false);
     } finally {
       if (previousMax === undefined) {

--- a/packages/pike-lsp-server/src/tests/runtime/server-runtime-workspace-folders.test.ts
+++ b/packages/pike-lsp-server/src/tests/runtime/server-runtime-workspace-folders.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'bun:test';
+import { registerServerRuntimeHandlers } from '../../runtime/server-runtime.js';
+
+describe('server runtime workspace folder sync', () => {
+  it('forwards workspace folder deltas to engineUpdateWorkspace after initialization', async () => {
+    let initializedHandler: (() => Promise<void>) | null = null;
+    let workspaceFolderChangeHandler: ((event: any) => Promise<void>) | null = null;
+
+    const updateWorkspaceCalls: Array<{ roots: string[]; added: string[]; removed: string[] }> = [];
+
+    const bridgeManager = {
+      bridge: { isRunning: () => true },
+      checkPike: async () => false,
+      engineUpdateWorkspace: async (payload: {
+        roots: string[];
+        added: string[];
+        removed: string[];
+      }) => {
+        updateWorkspaceCalls.push(payload);
+        return { revision: 1, snapshotId: 'snp-1' };
+      },
+      stop: async () => undefined,
+    };
+
+    const connection = {
+      onInitialized: (handler: () => Promise<void>) => {
+        initializedHandler = handler;
+      },
+      onShutdown: () => undefined,
+      onExit: () => undefined,
+      onExecuteCommand: () => undefined,
+      client: {
+        register: async () => undefined,
+      },
+      workspace: {
+        onDidChangeWorkspaceFolders: (handler: (event: any) => Promise<void>) => {
+          workspaceFolderChangeHandler = handler;
+        },
+        getWorkspaceFolders: async () => [{ uri: 'file:///workspace/new', name: 'new' }],
+      },
+      window: {
+        createWorkDoneProgress: async () => null,
+      },
+      console: {
+        log: () => undefined,
+        warn: () => undefined,
+      },
+    };
+
+    const workspaceIndex = {
+      clear: () => undefined,
+      indexDirectory: async () => 0,
+      getStats: () => ({ documents: 0, symbols: 0, uniqueNames: 0 }),
+    };
+
+    const workspaceScanner = {
+      removeFolder: () => undefined,
+      addFolder: async () => undefined,
+      initialize: async () => undefined,
+      getStats: () => ({ fileCount: 0 }),
+    };
+
+    registerServerRuntimeHandlers({
+      connection: connection as any,
+      workspaceIndex: workspaceIndex as any,
+      workspaceScanner: workspaceScanner as any,
+      getBridgeManager: () => bridgeManager as any,
+      getGlobalSettings: () => ({ diagnosticDelay: 250 } as any),
+      getIncludePaths: () => [],
+      getClientSupportsWorkDoneProgress: () => false,
+      setStdlibIndex: () => undefined,
+      updateServices: () => undefined,
+      log: () => undefined,
+    });
+
+    expect(initializedHandler).not.toBeNull();
+    await initializedHandler!();
+
+    expect(workspaceFolderChangeHandler).not.toBeNull();
+    await workspaceFolderChangeHandler!({
+      added: [{ uri: 'file:///workspace/new', name: 'new' }],
+      removed: [{ uri: 'file:///workspace/old', name: 'old' }],
+    });
+
+    const deltaCall = updateWorkspaceCalls.find(call => call.removed.length === 1);
+    expect(deltaCall).toBeDefined();
+    expect(deltaCall?.roots).toEqual(['file:///workspace/new']);
+    expect(deltaCall?.added).toEqual(['file:///workspace/new']);
+    expect(deltaCall?.removed).toEqual(['file:///workspace/old']);
+  });
+});

--- a/packages/pike-lsp-server/src/workspace-index.ts
+++ b/packages/pike-lsp-server/src/workspace-index.ts
@@ -220,8 +220,9 @@ export class WorkspaceIndex {
         const filename = decodeURIComponent(uri.replace(/^file:\/\//, ''));
 
         try {
-            const result = await this.bridge.parse(content, filename);
-            const symbols = this.flattenSymbols(result.symbols);
+            const result = await this.bridge.analyze(content, ['parse'], filename);
+            const parsedSymbols = result.result?.parse?.symbols ?? [];
+            const symbols = this.flattenSymbols(parsedSymbols);
 
             // Remove old entries from lookup
             const existing = this.documents.get(uri);
@@ -629,7 +630,8 @@ export class WorkspaceIndex {
                 // Fallback to sequential parsing for this chunk
                 for (const fileData of chunkData) {
                     try {
-                        const parseResult = await this.bridge.parse(fileData.code, fileData.filename);
+                        const analyzeResult = await this.bridge.analyze(fileData.code, ['parse'], fileData.filename);
+                        const parsedSymbols = analyzeResult.result?.parse?.symbols ?? [];
                         const uri = `file://${fileData.filename}`;
 
                         // Remove old entries from lookup
@@ -639,7 +641,7 @@ export class WorkspaceIndex {
                         }
 
                         // Store indexed document with filesystem mtime
-                        const symbols = this.flattenSymbols(parseResult.symbols);
+                        const symbols = this.flattenSymbols(parsedSymbols);
                         this.documents.set(uri, {
                             uri,
                             symbols,


### PR DESCRIPTION
## Summary
- Sync runtime mutable settings into shared services state on initialize/config updates and make diagnostics read that shared source.
- Forward workspace-folder add/remove deltas to query-engine workspace state and align interactive query handlers with fixed snapshot IDs when available.
- Remove uncached-workspace text-search fallbacks for references/rename, route include/workspace parsing through unified analyze flow, and add regression tests.

## Verification
- bun run typecheck
- bun test packages/pike-lsp-server/src/tests/services/include-resolver.test.ts
- bun test packages/pike-lsp-server/src/tests/navigation/references-provider.test.ts packages/pike-lsp-server/src/tests/navigation/references-scope.test.ts packages/pike-lsp-server/src/tests/editing/rename-stress.test.ts packages/pike-lsp-server/src/tests/navigation/query-engine-snapshot-selection.test.ts packages/pike-lsp-server/src/tests/runtime/server-runtime-workspace-folders.test.ts
- scripts/test-agent.sh --fast
- bun run build

Closes #818
Closes #819
Closes #820
Closes #821
Closes #822