### PR TITLE
chore: bump version to alpha.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security** - Security vulnerability fixes
 - **Performance** - User-facing performance notes
 
+## [0.1.0-alpha.30] - 2026-03-17
+
+### Fixed
+
+- **Runtime settings propagation consistency** - initialization and config-change flows now sync mutable runtime settings through shared services state, and diagnostics consumes the same live settings source.
+- **Workspace-folder analyzer sync** - workspace folder add/remove events now propagate deltas into query-engine workspace state to keep analyzer roots aligned with scanner/index state.
+- **Interactive snapshot consistency and safe fallbacks** - navigation/completion queries now prefer fixed snapshots when available, and uncached workspace text-search fallbacks were removed for references/rename to avoid blind symbol-unsafe results.
+
+### Added
+
+- **Regression coverage for workspace/runtime consistency** - added tests for runtime workspace-folder delta forwarding and navigation snapshot selection behavior.
+
 ## [0.1.0-alpha.29] - 2026-03-16
 
 ### Fixed
@@ -28,16 +40,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Regression coverage for snapshot/edit correctness** - added bridge-level tests for ranged incremental edits, fixed snapshot pinning across later edits, and unknown fixed snapshot behavior.
 
-## [0.1.0-alpha.28] - 2026-03-15
-
-### Performance
-
-- **Bounded scheduler observability metrics** - Request scheduler queue-wait samples are now retained in a fixed-size rolling window to prevent unbounded memory growth during long editing sessions.
-- **Non-blocking workspace file discovery** - Workspace index file discovery now uses async directory and stat traversal, reducing event-loop blocking before parse/index phases.
-
-### Added
-
-- **Performance regression guards** - Added stress/regression coverage for scheduler sample bounding and synchronous workspace discovery prevention.
-
+[0.1.0-alpha.30]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.30
 [0.1.0-alpha.29]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.29
-[0.1.0-alpha.28]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.28

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pike-lsp",
-  "version": "0.1.0-alpha.29",
+  "version": "0.1.0-alpha.30",
   "private": true,
   "description": "Pike Language Server Protocol implementation and VSCode extension",
   "author": "Pike LSP Team",

--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-pike",
   "displayName": "Pike Language Support",
   "description": "Complete language support for Pike including IntelliSense, go-to-definition, find references, diagnostics, hover, signature help, code completion, semantic tokens, call hierarchy, and workspace symbols.",
-  "version": "0.1.0-alpha.29",
+  "version": "0.1.0-alpha.30",
   "publisher": "pike-lsp",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
## Summary
- Bump release version to `0.1.0-alpha.30` in root and VS Code extension package manifests.
- Update `CHANGELOG.md` with alpha.30 release notes while keeping only the latest release entries per repository policy.

## Verification
- `bun run typecheck`
- `cd packages/vscode-pike && bun run package`

Closes #822