### PR TITLE
feat: add inline snapshot testing infrastructure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Run LSP Server tests
         run: cd packages/pike-lsp-server && bun test
 
+      - name: Check inline snapshots
+        run: cd packages/pike-lsp-server && bun run test:snapshots:check
+
       - name: Run LSP smoke tests
         run: cd packages/pike-lsp-server && bun test ./src/tests/smoke.test.ts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,28 @@ describe('Your Feature', () => {
 - Tests must pass before merging
 - Pike stdlib files must continue to parse (100% compatibility)
 
+### Snapshot Tests
+
+Snapshot tests for LSP output use Bun inline snapshots in `packages/pike-lsp-server`.
+
+```bash
+# Check mode (CI)
+cd packages/pike-lsp-server
+bun run test:snapshots:check
+
+# Update mode (intentional output change)
+cd packages/pike-lsp-server
+bun run test:snapshots:update
+```
+
+Fixture marker DSL for snapshot inputs:
+
+- `$0` marks cursor position
+- `[|...|]` marks an unnamed range
+- `{|name: ... |}` marks a labeled range
+
+Use `parseSnapshotFixture()` from `src/tests/helpers/snapshot-fixture.ts` to parse markers.
+
 ### Version Testing
 
 - **Local development:** Use Pike 8.1116

--- a/packages/pike-lsp-server/package.json
+++ b/packages/pike-lsp-server/package.json
@@ -15,6 +15,8 @@
     "clean": "rm -rf dist",
     "watch": "tsc --watch",
     "test": "bun test",
+    "test:snapshots:check": "bun test src/tests/navigation/hover-provider.snapshot.test.ts src/tests/helpers/snapshot-fixture.test.ts",
+    "test:snapshots:update": "bun test --update-snapshots src/tests/navigation/hover-provider.snapshot.test.ts src/tests/helpers/snapshot-fixture.test.ts",
     "test:smoke": "bun test src/tests/",
     "test:source-trees": "PIKE_SOURCE_TREE_TEST=1 bun test src/tests/source-tree-e2e.test.ts",
     "typecheck": "tsc --noEmit",

--- a/packages/pike-lsp-server/src/tests/helpers/snapshot-fixture.test.ts
+++ b/packages/pike-lsp-server/src/tests/helpers/snapshot-fixture.test.ts
@@ -1,0 +1,20 @@
+import { parseSnapshotFixture } from './snapshot-fixture.js';
+
+const { describe, expect, it } = require('bun:test');
+
+describe('snapshot fixture marker parser', () => {
+  it('parses cursor and unnamed range markers', () => {
+    const fixture = parseSnapshotFixture('int [|counter|] = $01;');
+
+    expect(fixture.code).toBe('int counter = 1;');
+    expect(fixture.cursorOffset).toBe(14);
+    expect(fixture.ranges).toEqual([{ start: 4, end: 11 }]);
+  });
+
+  it('parses labeled ranges', () => {
+    const fixture = parseSnapshotFixture('mapping m = {|target: (["a": 1]) |};');
+
+    expect(fixture.code).toBe('mapping m =  (["a": 1]) ;');
+    expect(fixture.ranges).toEqual([{ start: 12, end: 24, label: 'target' }]);
+  });
+});

--- a/packages/pike-lsp-server/src/tests/helpers/snapshot-fixture.ts
+++ b/packages/pike-lsp-server/src/tests/helpers/snapshot-fixture.ts
@@ -1,0 +1,76 @@
+export interface FixtureRange {
+  start: number;
+  end: number;
+  label?: string;
+}
+
+export interface SnapshotFixture {
+  code: string;
+  cursorOffset: number | null;
+  ranges: FixtureRange[];
+}
+
+export function parseSnapshotFixture(input: string): SnapshotFixture {
+  let cursorOffset: number | null = null;
+  const ranges: FixtureRange[] = [];
+  let code = '';
+  let i = 0;
+
+  while (i < input.length) {
+    if (input.startsWith('$0', i)) {
+      cursorOffset = code.length;
+      i += 2;
+      continue;
+    }
+
+    if (input.startsWith('[|', i)) {
+      const start = code.length;
+      i += 2;
+      while (i < input.length && !input.startsWith('|]', i)) {
+        code += input[i]!;
+        i += 1;
+      }
+      if (!input.startsWith('|]', i)) {
+        throw new Error('Unterminated [|...|] range marker');
+      }
+      const end = code.length;
+      ranges.push({ start, end });
+      i += 2;
+      continue;
+    }
+
+    if (input.startsWith('{|', i)) {
+      i += 2;
+      const labelStart = i;
+      while (i < input.length && input[i] !== ':') {
+        i += 1;
+      }
+      if (i >= input.length || input[i] !== ':') {
+        throw new Error('Invalid {|label:...|} marker: missing label separator');
+      }
+      const label = input.slice(labelStart, i).trim();
+      i += 1;
+      const start = code.length;
+      while (i < input.length && !input.startsWith('|}', i)) {
+        code += input[i]!;
+        i += 1;
+      }
+      if (!input.startsWith('|}', i)) {
+        throw new Error('Unterminated {|label:...|} range marker');
+      }
+      const end = code.length;
+      ranges.push({ start, end, label });
+      i += 2;
+      continue;
+    }
+
+    code += input[i]!;
+    i += 1;
+  }
+
+  return {
+    code,
+    cursorOffset,
+    ranges,
+  };
+}

--- a/packages/pike-lsp-server/src/tests/navigation/hover-provider.snapshot.test.ts
+++ b/packages/pike-lsp-server/src/tests/navigation/hover-provider.snapshot.test.ts
@@ -1,0 +1,91 @@
+import type { PikeSymbol } from '@pike-lsp/pike-bridge';
+import { buildHoverContent } from '../../features/utils/hover-builder.js';
+import { parseSnapshotFixture } from '../helpers/snapshot-fixture.js';
+
+const { describe, expect, it } = require('bun:test');
+
+function createSymbol(overrides: Record<string, unknown>): PikeSymbol {
+  const base: Record<string, unknown> = {
+    name: 'symbol',
+    kind: 'variable',
+    modifiers: [],
+  };
+  return { ...base, ...overrides } as unknown as PikeSymbol;
+}
+
+function normalizeSnapshotValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  return value;
+}
+
+describe('hover provider inline snapshots', () => {
+  it('snapshots variable hover markdown', () => {
+    const fixture = parseSnapshotFixture('int [|counter|] = $00;');
+    const symbol = createSymbol({
+      name: fixture.code.slice(fixture.ranges[0]!.start, fixture.ranges[0]!.end),
+      kind: 'variable',
+      type: { kind: 'int', name: 'int' },
+      documentation: 'Current request count',
+    });
+
+    const hover = buildHoverContent(symbol);
+    expect(normalizeSnapshotValue(hover)).toMatchInlineSnapshot(`
+"\`\`\`pike
+int counter
+\`\`\`
+
+---
+
+Current request count"
+`);
+  });
+
+  it('snapshots function hover markdown with autodoc tags', () => {
+    const symbol = createSymbol({
+      name: 'sum',
+      kind: 'method',
+      type: { kind: 'function', returnType: 'int' },
+      parameters: [
+        { name: 'left', type: 'int' },
+        { name: 'right', type: 'int' },
+      ],
+      documentation:
+        'Adds two values\n@param left left operand\n@param right right operand\n@returns sum',
+    });
+
+    const hover = buildHoverContent(symbol);
+    expect(normalizeSnapshotValue(hover)).toMatchInlineSnapshot(`
+"\`\`\`pike
+int sum(int left, int right)
+\`\`\`
+
+---
+
+Adds two values
+@param left left operand
+@param right right operand
+@returns sum"
+`);
+  });
+
+  it('snapshots class hover markdown', () => {
+    const symbol = createSymbol({
+      name: 'HttpClient',
+      kind: 'class',
+      documentation: 'Simple HTTP client wrapper',
+    });
+
+    const hover = buildHoverContent(symbol);
+    expect(normalizeSnapshotValue(hover)).toMatchInlineSnapshot(`
+"\`\`\`pike
+class HttpClient
+\`\`\`
+
+---
+
+Simple HTTP client wrapper"
+`);
+  });
+});


### PR DESCRIPTION
## Summary
- add Bun inline snapshot test coverage for hover output and introduce fixture marker parsing (, , )
- add dedicated snapshot scripts for check/update flows in 
- document snapshot workflow and marker DSL in 

## Verification
- bun test v1.3.8 (b64edcb4)
- 
- 

Closes #829