### PR TITLE
feat: add workspace indexing progress notifications

### DIFF
--- a/packages/pike-lsp-server/src/runtime/server-runtime.ts
+++ b/packages/pike-lsp-server/src/runtime/server-runtime.ts
@@ -43,6 +43,89 @@ export function registerServerRuntimeHandlers(args: RegisterServerRuntimeHandler
     log,
   } = args;
 
+  const createIndexingProgressReporter = async () => {
+    const progress = getClientSupportsWorkDoneProgress()
+      ? await connection.window.createWorkDoneProgress().catch(() => null)
+      : null;
+
+    if (progress) {
+      progress.begin('Pike LSP: Indexing workspace…', 0, 'Preparing workspace scan', false);
+      return {
+        report: (percentage: number, message: string) => {
+          const bounded = Math.max(0, Math.min(100, Math.floor(percentage)));
+          progress.report(bounded, message);
+        },
+        end: (message: string) => {
+          progress.report(100, message);
+          progress.done();
+        },
+      };
+    }
+
+    connection.window.showInformationMessage?.('Pike LSP: Indexing workspace…');
+    return {
+      report: (_percentage: number, _message: string) => undefined,
+      end: (message: string) => {
+        connection.window.showInformationMessage?.(`Pike LSP: ${message}`);
+      },
+    };
+  };
+
+  const indexWorkspaceFolders = async (
+    workspaceFolders: Array<{ uri: string; name: string }>
+  ): Promise<void> => {
+    connection.console.log(`Indexing ${workspaceFolders.length} workspace folder(s)...`);
+    setImmediate(async () => {
+      const reporter = await createIndexingProgressReporter();
+
+      const folderPaths: string[] = [];
+      for (let i = 0; i < workspaceFolders.length; i += 1) {
+        const folder = workspaceFolders[i]!;
+        try {
+          const folderStart = Math.floor((i / workspaceFolders.length) * 90);
+          const folderSpan = Math.max(1, Math.floor(90 / workspaceFolders.length));
+
+          reporter.report(folderStart, `Indexing ${folder.name}`);
+
+          const folderPath = decodeURIComponent(folder.uri.replace(/^file:\/\//, ''));
+          folderPaths.push(folderPath);
+
+          const indexed = await workspaceIndex.indexDirectory(folderPath, true, progress => {
+            const localProgress =
+              progress.total > 0 ? Math.floor((progress.current / progress.total) * folderSpan) : 0;
+            reporter.report(
+              Math.min(95, folderStart + localProgress),
+              `${folder.name}: ${progress.message}`
+            );
+          });
+          connection.console.log(`Indexed ${indexed} files from ${folder.name}`);
+        } catch (err) {
+          connection.console.warn(`Failed to index folder ${folder.name}: ${err}`);
+          log(`Indexing error for folder ${folder.name}: ${err}`);
+        }
+      }
+
+      const stats = workspaceIndex.getStats();
+      connection.console.log(
+        `Workspace indexing complete: ${stats.documents} files, ${stats.symbols} symbols`
+      );
+
+      try {
+        reporter.report(96, 'Building workspace scanner index');
+
+        await workspaceScanner.initialize(folderPaths);
+        const scannerStats = workspaceScanner.getStats();
+        connection.console.log(
+          `Workspace scanner initialized: ${scannerStats.fileCount} Pike files found`
+        );
+      } catch (err) {
+        connection.console.warn(`Failed to initialize workspace scanner: ${err}`);
+      } finally {
+        reporter.end('Indexing complete');
+      }
+    });
+  };
+
   connection.onInitialized(async () => {
     connection.console.log('Pike LSP Server initialized');
     connection.client.register(DidChangeConfigurationNotification.type, undefined);
@@ -139,14 +222,7 @@ export function registerServerRuntimeHandlers(args: RegisterServerRuntimeHandler
           return;
         }
 
-        for (const folder of currentFolders) {
-          try {
-            const folderPath = decodeURIComponent(folder.uri.replace(/^file:\/\//, ''));
-            await workspaceIndex.indexDirectory(folderPath, true);
-          } catch (err) {
-            connection.console.warn(`Failed to re-index folder ${folder.name}: ${err}`);
-          }
-        }
+        await indexWorkspaceFolders(currentFolders);
       });
     }
 
@@ -221,60 +297,7 @@ export function registerServerRuntimeHandlers(args: RegisterServerRuntimeHandler
       log(
         `Engine workspace ack revision=${workspaceAck.revision} snapshot=${workspaceAck.snapshotId}`
       );
-
-      connection.console.log(`Indexing ${workspaceFolders.length} workspace folder(s)...`);
-      setImmediate(async () => {
-        const progress = getClientSupportsWorkDoneProgress()
-          ? await connection.window.createWorkDoneProgress().catch(() => null)
-          : null;
-
-        if (progress) {
-          progress.begin('Pike: indexing workspace', 0, 'Scanning project folders', false);
-        }
-
-        const folderPaths: string[] = [];
-        for (let i = 0; i < workspaceFolders.length; i += 1) {
-          const folder = workspaceFolders[i]!;
-          try {
-            if (progress) {
-              const percentage = Math.floor((i / workspaceFolders.length) * 90);
-              progress.report(percentage, `Indexing ${folder.name}`);
-            }
-
-            const folderPath = decodeURIComponent(folder.uri.replace(/^file:\/\//, ''));
-            folderPaths.push(folderPath);
-            const indexed = await workspaceIndex.indexDirectory(folderPath, true);
-            connection.console.log(`Indexed ${indexed} files from ${folder.name}`);
-          } catch (err) {
-            connection.console.warn(`Failed to index folder ${folder.name}: ${err}`);
-            log(`Indexing error for folder ${folder.name}: ${err}`);
-          }
-        }
-
-        const stats = workspaceIndex.getStats();
-        connection.console.log(
-          `Workspace indexing complete: ${stats.documents} files, ${stats.symbols} symbols`
-        );
-
-        try {
-          if (progress) {
-            progress.report(95, 'Building workspace scanner index');
-          }
-
-          await workspaceScanner.initialize(folderPaths);
-          const scannerStats = workspaceScanner.getStats();
-          connection.console.log(
-            `Workspace scanner initialized: ${scannerStats.fileCount} Pike files found`
-          );
-        } catch (err) {
-          connection.console.warn(`Failed to initialize workspace scanner: ${err}`);
-        } finally {
-          if (progress) {
-            progress.report(100, 'Workspace ready');
-            progress.done();
-          }
-        }
-      });
+      await indexWorkspaceFolders(workspaceFolders);
     }
   });
 

--- a/packages/pike-lsp-server/src/tests/runtime/server-runtime-progress.test.ts
+++ b/packages/pike-lsp-server/src/tests/runtime/server-runtime-progress.test.ts
@@ -1,0 +1,178 @@
+import { registerServerRuntimeHandlers } from '../../runtime/server-runtime.js';
+
+const { describe, expect, it } = require('bun:test');
+
+describe('server runtime indexing progress', () => {
+  it('emits begin/report/end work-done progress when supported', async () => {
+    let initializedHandler: (() => Promise<void>) | null = null;
+    const progressEvents: Array<{ type: 'begin' | 'report' | 'done'; message?: string }> = [];
+
+    const connection = {
+      onInitialized: (handler: () => Promise<void>) => {
+        initializedHandler = handler;
+      },
+      onShutdown: () => undefined,
+      onExit: () => undefined,
+      onExecuteCommand: () => undefined,
+      client: {
+        register: async () => undefined,
+      },
+      workspace: {
+        onDidChangeWorkspaceFolders: () => undefined,
+        getWorkspaceFolders: async () => [{ uri: 'file:///workspace/a', name: 'a' }],
+      },
+      window: {
+        createWorkDoneProgress: async () => ({
+          begin: (_title: string, _percentage: number, message: string) => {
+            progressEvents.push({ type: 'begin', message });
+          },
+          report: (_percentage: number, message: string) => {
+            progressEvents.push({ type: 'report', message });
+          },
+          done: () => {
+            progressEvents.push({ type: 'done' });
+          },
+        }),
+      },
+      console: {
+        log: () => undefined,
+        warn: () => undefined,
+      },
+    };
+
+    const workspaceIndex = {
+      clear: () => undefined,
+      indexDirectory: async (
+        _path: string,
+        _recursive: boolean,
+        onProgress?: (progress: {
+          current: number;
+          total: number;
+          phase: 'discovering' | 'reading' | 'parsing' | 'indexing';
+          message: string;
+        }) => void
+      ) => {
+        onProgress?.({
+          current: 1,
+          total: 2,
+          phase: 'reading',
+          message: 'Reading files 1-1 of 2',
+        });
+        onProgress?.({
+          current: 2,
+          total: 2,
+          phase: 'indexing',
+          message: 'Indexed 2 of 2 changed files',
+        });
+        return 2;
+      },
+      getStats: () => ({ documents: 2, symbols: 4, uniqueNames: 4 }),
+    };
+
+    const workspaceScanner = {
+      removeFolder: () => undefined,
+      addFolder: async () => undefined,
+      initialize: async () => undefined,
+      getStats: () => ({ fileCount: 2 }),
+    };
+
+    const bridgeManager = {
+      bridge: { isRunning: () => true },
+      checkPike: async () => false,
+      engineUpdateWorkspace: async () => ({ revision: 1, snapshotId: 'snp-1' }),
+      stop: async () => undefined,
+    };
+
+    registerServerRuntimeHandlers({
+      connection: connection as any,
+      workspaceIndex: workspaceIndex as any,
+      workspaceScanner: workspaceScanner as any,
+      getBridgeManager: () => bridgeManager as any,
+      getGlobalSettings: () => ({ diagnosticDelay: 250 } as any),
+      getIncludePaths: () => [],
+      getClientSupportsWorkDoneProgress: () => true,
+      setStdlibIndex: () => undefined,
+      updateServices: () => undefined,
+      log: () => undefined,
+    });
+
+    expect(initializedHandler).not.toBeNull();
+    await initializedHandler!();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(progressEvents.some(e => e.type === 'begin')).toBeTrue();
+    expect(progressEvents.some(e => e.type === 'report' && e.message?.includes('Reading files'))).toBeTrue();
+    expect(progressEvents.some(e => e.type === 'done')).toBeTrue();
+  });
+
+  it('falls back to status messages when work-done progress is unsupported', async () => {
+    let initializedHandler: (() => Promise<void>) | null = null;
+    const messages: string[] = [];
+
+    const connection = {
+      onInitialized: (handler: () => Promise<void>) => {
+        initializedHandler = handler;
+      },
+      onShutdown: () => undefined,
+      onExit: () => undefined,
+      onExecuteCommand: () => undefined,
+      client: {
+        register: async () => undefined,
+      },
+      workspace: {
+        onDidChangeWorkspaceFolders: () => undefined,
+        getWorkspaceFolders: async () => [{ uri: 'file:///workspace/a', name: 'a' }],
+      },
+      window: {
+        createWorkDoneProgress: async () => null,
+        showInformationMessage: (message: string) => {
+          messages.push(message);
+        },
+      },
+      console: {
+        log: () => undefined,
+        warn: () => undefined,
+      },
+    };
+
+    const workspaceIndex = {
+      clear: () => undefined,
+      indexDirectory: async () => 1,
+      getStats: () => ({ documents: 1, symbols: 2, uniqueNames: 2 }),
+    };
+
+    const workspaceScanner = {
+      removeFolder: () => undefined,
+      addFolder: async () => undefined,
+      initialize: async () => undefined,
+      getStats: () => ({ fileCount: 1 }),
+    };
+
+    const bridgeManager = {
+      bridge: { isRunning: () => true },
+      checkPike: async () => false,
+      engineUpdateWorkspace: async () => ({ revision: 1, snapshotId: 'snp-1' }),
+      stop: async () => undefined,
+    };
+
+    registerServerRuntimeHandlers({
+      connection: connection as any,
+      workspaceIndex: workspaceIndex as any,
+      workspaceScanner: workspaceScanner as any,
+      getBridgeManager: () => bridgeManager as any,
+      getGlobalSettings: () => ({ diagnosticDelay: 250 } as any),
+      getIncludePaths: () => [],
+      getClientSupportsWorkDoneProgress: () => false,
+      setStdlibIndex: () => undefined,
+      updateServices: () => undefined,
+      log: () => undefined,
+    });
+
+    expect(initializedHandler).not.toBeNull();
+    await initializedHandler!();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(messages).toContain('Pike LSP: Indexing workspace…');
+    expect(messages).toContain('Pike LSP: Indexing complete');
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared indexing progress reporter in server runtime that emits progress begin/report/end during initial indexing and workspace-folder reindex operations
- pass workspace index phase updates through to progress reports for monotonically increasing status messages
- add runtime tests covering progress lifecycle and show-message fallback when work-done progress is unsupported

## Verification
- cd packages/pike-lsp-server && bun test src/tests/runtime/server-runtime-workspace-folders.test.ts src/tests/runtime/server-runtime-progress.test.ts
- cd packages/pike-lsp-server && bun run typecheck
- bun run build

Closes #830