### PR TITLE
feat: semantic read/write document highlights

### DIFF
--- a/packages/pike-lsp-server/src/features/navigation/references.ts
+++ b/packages/pike-lsp-server/src/features/navigation/references.ts
@@ -368,6 +368,87 @@ export function registerReferencesHandlers(
         return null;
       }
 
+      const cached = documentCache.get(uri);
+
+      if (cached?.symbolPositions) {
+        const positions = cached.symbolPositions.get(word);
+        if (positions && positions.length > 0) {
+          const declarationLines = cached.symbols
+            .filter(symbol => symbol.name === word && symbol.position)
+            .map(symbol => Math.max(0, (symbol.position?.line ?? 1) - 1))
+            .sort((a, b) => a - b);
+
+          const cursorLine = params.position.line;
+          let activeDeclarationLine = declarationLines[0] ?? -1;
+          for (const line of declarationLines) {
+            if (line <= cursorLine) {
+              activeDeclarationLine = line;
+            }
+          }
+
+          let nextDeclarationLine = Number.POSITIVE_INFINITY;
+          if (activeDeclarationLine >= 0) {
+            for (const line of declarationLines) {
+              if (line > activeDeclarationLine) {
+                nextDeclarationLine = line;
+                break;
+              }
+            }
+          }
+
+          const escapeRegex = (value: string): string =>
+            value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          const escapedWord = escapeRegex(word);
+          const declarationRegex = new RegExp(
+            `\\b(?:int|string|float|mapping|array|object|mixed|multiset|program|function|void)\\s+${escapedWord}\\b`
+          );
+
+          const isWriteOccurrence = (line: string, character: number): boolean => {
+            const before = line.slice(0, character);
+            const after = line.slice(character + word.length);
+            if (declarationRegex.test(line)) {
+              return true;
+            }
+            if (/^\s*(\+\+|--|[+\-*/%&|^]?=)/.test(after)) {
+              return true;
+            }
+            if (/(\+\+|--)\s*$/.test(before)) {
+              return true;
+            }
+            return false;
+          };
+
+          const lines = text.split('\n');
+          const semanticHighlights: DocumentHighlight[] = [];
+
+          for (const pos of positions) {
+            if (
+              activeDeclarationLine >= 0 &&
+              (pos.line < activeDeclarationLine || pos.line >= nextDeclarationLine)
+            ) {
+              continue;
+            }
+
+            const line = lines[pos.line] ?? '';
+            const kind = isWriteOccurrence(line, pos.character)
+              ? DocumentHighlightKind.Write
+              : DocumentHighlightKind.Read;
+
+            semanticHighlights.push({
+              range: {
+                start: pos,
+                end: { line: pos.line, character: pos.character + word.length },
+              },
+              kind,
+            });
+          }
+
+          if (semanticHighlights.length > 0) {
+            return semanticHighlights;
+          }
+        }
+      }
+
       const highlights: DocumentHighlight[] = [];
       const lines = text.split('\n');
 

--- a/packages/pike-lsp-server/src/tests/navigation/references-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/navigation/references-provider.test.ts
@@ -11,7 +11,6 @@
  * - Edge cases: empty cache, short words, large files
  */
 
-import { describe, it, expect } from 'bun:test';
 import { DocumentHighlightKind } from 'vscode-languageserver/node.js';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import type { PikeSymbol } from '@pike-lsp/pike-bridge';
@@ -27,6 +26,8 @@ import {
   createMockWorkspaceScanner,
 } from '../helpers/mock-services.js';
 import type { DocumentCacheEntry } from '../../core/types.js';
+
+const { describe, it, expect } = require('bun:test');
 
 // =============================================================================
 // Setup helpers
@@ -1144,6 +1145,13 @@ describe('Document Highlight Provider', () => {
 count++;
 write(count);`;
 
+      const symbolPositions = new Map<string, { line: number; character: number }[]>();
+      symbolPositions.set('count', [
+        { line: 0, character: 4 },
+        { line: 1, character: 0 },
+        { line: 2, character: 6 },
+      ]);
+
       const { highlight } = setup({
         code,
         symbols: [
@@ -1154,6 +1162,7 @@ write(count);`;
             position: { file: 'test.pike', line: 1 },
           },
         ],
+        symbolPositions,
       });
 
       // Cursor on "count" at line 0, char 4
@@ -1161,10 +1170,9 @@ write(count);`;
       expect(result).not.toBeNull();
       expect(result!.length).toBe(3);
 
-      // All highlights should be DocumentHighlightKind.Text
-      for (const h of result!) {
-        expect(h.kind).toBe(DocumentHighlightKind.Text);
-      }
+      expect(result![0]!.kind).toBe(DocumentHighlightKind.Write);
+      expect(result![1]!.kind).toBe(DocumentHighlightKind.Write);
+      expect(result![2]!.kind).toBe(DocumentHighlightKind.Read);
     });
   });
 
@@ -1200,22 +1208,34 @@ x = 2;`;
   });
 
   describe('Scenario 7.3: Highlight symbol with different scopes', () => {
-    it('should highlight all text occurrences regardless of scope', async () => {
-      // The highlight handler uses text-based search, not scope-aware
+    it('should use semantic symbol positions to avoid cross-scope highlights', async () => {
       const code = `int xx = 1;
 void func() { int xx = 2; write(xx); }
 write(xx);`;
 
+      const symbolPositions = new Map<string, { line: number; character: number }[]>();
+      symbolPositions.set('xx', [
+        { line: 0, character: 4 },
+        { line: 2, character: 6 },
+      ]);
+
       const { highlight } = setup({
         code,
-        symbols: [],
+        symbols: [
+          {
+            name: 'xx',
+            kind: 'variable',
+            modifiers: [],
+            position: { file: 'test.pike', line: 1 },
+          },
+        ],
+        symbolPositions,
       });
 
       // Cursor on "xx" at line 0
       const result = await highlight(0, 5);
       expect(result).not.toBeNull();
-      // All 4 occurrences of "xx" are highlighted (no scope awareness)
-      expect(result!.length).toBe(4);
+      expect(result!.length).toBe(2);
     });
   });
 


### PR DESCRIPTION
## Summary
- switch document highlight resolution to prefer semantic symbol-position data
- classify highlight occurrences as read or write based on declaration and assignment/update contexts
- keep text-based matching as fallback when semantic data is unavailable
- update highlight provider tests for read/write and semantic-scope behavior

## Verification
- cd packages/pike-lsp-server && bun test src/tests/navigation/references-provider.test.ts src/tests/navigation/document-highlight-stress.test.ts
- cd packages/pike-lsp-server && bun run typecheck
- bun run build

Closes #833