### PR TITLE
feat: add stale-analysis fallback for parse failures

### DIFF
--- a/packages/pike-lsp-server/src/core/types.ts
+++ b/packages/pike-lsp-server/src/core/types.ts
@@ -118,6 +118,10 @@ export interface DocumentCacheEntry {
     introspection?: import('@pike-lsp/pike-bridge').IntrospectionResult | undefined;
     /** Roxen-specific module information (Phase 3: Roxen LSP support) */
     roxenInfo?: import('../features/roxen/types.js').RoxenModuleInfo;
+    analysisState?: {
+        isStale: boolean;
+        parseFailed: boolean;
+    };
 }
 
 /**

--- a/packages/pike-lsp-server/src/features/diagnostics/index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/index.ts
@@ -65,6 +65,42 @@ export function applySkippedValidationCacheUpdate(
   cachedEntry.version = currentVersion;
 }
 
+export function buildStaleFallbackEntry(
+  existingEntry: DocumentCacheEntry | undefined,
+  version: number,
+  diagnostics: Diagnostic[],
+  contentHash: string,
+  lineHashes: number[]
+): DocumentCacheEntry {
+  if (existingEntry) {
+    return {
+      ...existingEntry,
+      version,
+      diagnostics,
+      contentHash,
+      lineHashes,
+      analysisState: {
+        isStale: true,
+        parseFailed: true,
+      },
+    };
+  }
+
+  return {
+    version,
+    symbols: [],
+    diagnostics,
+    symbolPositions: new Map(),
+    symbolNames: new Map(),
+    contentHash,
+    lineHashes,
+    analysisState: {
+      isStale: true,
+      parseFailed: true,
+    },
+  };
+}
+
 /**
  * Register diagnostics handlers with the LSP connection.
  *
@@ -593,6 +629,10 @@ export function registerDiagnosticsHandlers(
           lineHashes,
           // Store introspection for AutoDoc data including @deprecated tags
           introspection: introspectData.success ? introspectData : undefined,
+          analysisState: {
+            isStale: false,
+            parseFailed: false,
+          },
         };
         if (dependencies) {
           cacheEntry.dependencies = dependencies;
@@ -647,6 +687,10 @@ export function registerDiagnosticsHandlers(
           // INC-002: Store hashes for incremental change detection
           contentHash,
           lineHashes,
+          analysisState: {
+            isStale: false,
+            parseFailed: false,
+          },
         };
         if (dependencies) {
           cacheEntry.dependencies = dependencies;
@@ -662,6 +706,14 @@ export function registerDiagnosticsHandlers(
         });
       } else {
         log.debug('No parse result available for document', { uri });
+        const staleEntry = buildStaleFallbackEntry(
+          documentCache.get(uri),
+          version,
+          diagnostics,
+          contentHash,
+          lineHashes
+        );
+        documentCache.set(uri, staleEntry);
       }
 
       // Process diagnostics from unified analyze (includes syntax errors + uninitialized warnings)

--- a/packages/pike-lsp-server/src/tests/features/diagnostics/error-tolerant-analysis.test.ts
+++ b/packages/pike-lsp-server/src/tests/features/diagnostics/error-tolerant-analysis.test.ts
@@ -1,0 +1,42 @@
+import type { DocumentCacheEntry } from '../../../core/types.js';
+import { buildStaleFallbackEntry } from '../../../features/diagnostics/index.js';
+
+const { describe, expect, it } = require('bun:test');
+
+describe('error-tolerant analysis fallback', () => {
+  it('preserves last known symbols when parse fails', () => {
+    const existing: DocumentCacheEntry = {
+      version: 2,
+      symbols: [
+        {
+          name: 'stableSymbol',
+          kind: 'variable',
+          modifiers: [],
+        },
+      ],
+      diagnostics: [],
+      symbolPositions: new Map([['stableSymbol', [{ line: 0, character: 4 }]]]),
+      symbolNames: new Map(),
+      contentHash: 'prev',
+      lineHashes: [1, 2],
+    };
+
+    const next = buildStaleFallbackEntry(existing, 3, [], 'next', [3, 4]);
+
+    expect(next.version).toBe(3);
+    expect(next.symbols.map(symbol => symbol.name)).toEqual(['stableSymbol']);
+    expect(next.symbolPositions.get('stableSymbol')?.length).toBe(1);
+    expect(next.analysisState).toEqual({ isStale: true, parseFailed: true });
+    expect(next.contentHash).toBe('next');
+  });
+
+  it('creates predictable empty stale entry when no prior analysis exists', () => {
+    const next = buildStaleFallbackEntry(undefined, 1, [], 'fresh', [5]);
+
+    expect(next.version).toBe(1);
+    expect(next.symbols).toEqual([]);
+    expect(next.symbolPositions.size).toBe(0);
+    expect(next.symbolNames.size).toBe(0);
+    expect(next.analysisState).toEqual({ isStale: true, parseFailed: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit stale-analysis cache fallback entry construction for diagnostics parse failures
- preserve last known-good symbols and positions across parse failures while marking cache state as stale
- provide deterministic fallback entry shape for files that have never parsed successfully
- add diagnostics tests for stale-preservation and first-parse-failure behavior

## Verification
- cd packages/pike-lsp-server && bun test ./src/tests/features/diagnostics/error-tolerant-analysis.test.ts
- cd packages/pike-lsp-server && bun run typecheck
- bun run build

Closes #834