### PR TITLE
feat: add structural search and replace workflow

### DIFF
--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -130,6 +130,11 @@
         "category": "Pike LSP"
       },
       {
+        "command": "pike.lsp.structuralSearchReplace",
+        "title": "Structural Search and Replace",
+        "category": "Pike LSP"
+      },
+      {
         "command": "pike.lsp.runFile",
         "title": "Run Pike File",
         "category": "Pike LSP"

--- a/packages/vscode-pike/src/extension.ts
+++ b/packages/vscode-pike/src/extension.ts
@@ -25,10 +25,10 @@ import {
   window,
   OutputChannel,
   languages,
+  WorkspaceEdit,
   TextDocument as VSCodeTextDocument,
   TextDocumentChangeEvent,
   TextEdit,
-  WorkspaceEdit,
 } from 'vscode';
 import { computeFormattingWindow, isIndentationSensitiveChange } from './format-on-change';
 import { PIKE_LANGUAGE_IDS } from './constants';
@@ -40,6 +40,7 @@ import {
   State,
   TransportKind,
 } from 'vscode-languageclient/node';
+import { applyStructuralSearchReplace } from './structural-search-replace';
 
 function anonymizeSensitivePaths(value: string): string {
   const home = process.env['HOME'];
@@ -783,6 +784,66 @@ async function activateInternal(
   );
 
   runtime.track(showDiagnosticsDisposable);
+
+  const structuralSearchReplaceDisposable = commands.registerCommand(
+    'pike.lsp.structuralSearchReplace',
+    async () => {
+      if (runtime.isDisposed()) return;
+
+      const searchPattern = await window.showInputBox({
+        prompt: 'Structural search pattern (supports $name and $$args metavariables)',
+      });
+      if (!searchPattern) {
+        return;
+      }
+
+      const replacePattern = await window.showInputBox({
+        prompt: 'Replacement pattern',
+      });
+      if (replacePattern === undefined) {
+        return;
+      }
+
+      const files = await workspace.findFiles('**/*.{pike,pmod}');
+      const workspaceEdit = new WorkspaceEdit();
+      let totalMatches = 0;
+      let touchedFiles = 0;
+
+      for (const file of files) {
+        const doc = await workspace.openTextDocument(file);
+        const result = applyStructuralSearchReplace(doc.getText(), searchPattern, replacePattern);
+        if (result.matches.length === 0) {
+          continue;
+        }
+
+        touchedFiles += 1;
+        totalMatches += result.matches.length;
+        const fullRange = doc.validateRange(
+          new Range(doc.positionAt(0), doc.positionAt(doc.getText().length))
+        );
+        workspaceEdit.replace(file, fullRange, result.text);
+      }
+
+      if (totalMatches === 0) {
+        window.showInformationMessage('Pike SSR found no matches.');
+        return;
+      }
+
+      const choice = await window.showInformationMessage(
+        `Pike SSR found ${totalMatches} matches in ${touchedFiles} file(s). Apply changes?`,
+        'Apply',
+        'Cancel'
+      );
+      if (choice !== 'Apply') {
+        return;
+      }
+
+      await workspace.applyEdit(workspaceEdit);
+      window.showInformationMessage(`Pike SSR applied ${totalMatches} replacement(s).`);
+    }
+  );
+
+  runtime.track(structuralSearchReplaceDisposable);
 
   const showHealthDisposable = commands.registerCommand('pike.lsp.showHealth', async () => {
     if (runtime.isDisposed()) return;

--- a/packages/vscode-pike/src/structural-search-replace.ts
+++ b/packages/vscode-pike/src/structural-search-replace.ts
@@ -1,0 +1,118 @@
+export interface StructuralMatch {
+  start: number;
+  end: number;
+  groups: Record<string, string>;
+}
+
+export interface StructuralReplaceResult {
+  text: string;
+  matches: StructuralMatch[];
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isLikelyCodeMatch(text: string, startIndex: number): boolean {
+  const lineStart = text.lastIndexOf('\n', startIndex) + 1;
+  const lineEnd = text.indexOf('\n', startIndex) >= 0 ? text.indexOf('\n', startIndex) : text.length;
+  const line = text.slice(lineStart, lineEnd);
+  const inLineIndex = startIndex - lineStart;
+  const before = line.slice(0, inLineIndex);
+
+  const commentIndex = before.indexOf('//');
+  if (commentIndex >= 0) {
+    return false;
+  }
+
+  const quoteCount = (before.match(/"/g) ?? []).length;
+  if (quoteCount % 2 === 1) {
+    return false;
+  }
+
+  return true;
+}
+
+export function compileStructuralPattern(pattern: string): RegExp {
+  const parts: string[] = [];
+  let index = 0;
+
+  while (index < pattern.length) {
+    if (pattern.startsWith('$$', index)) {
+      index += 2;
+      let name = '';
+      while (index < pattern.length && /[A-Za-z0-9_]/.test(pattern[index] ?? '')) {
+        name += pattern[index];
+        index += 1;
+      }
+      if (!name) {
+        throw new Error('Invalid variadic metavariable in structural pattern');
+      }
+      parts.push(`(?<${name}>[\\s\\S]*?)`);
+      continue;
+    }
+
+    if (pattern[index] === '$') {
+      index += 1;
+      let name = '';
+      while (index < pattern.length && /[A-Za-z0-9_]/.test(pattern[index] ?? '')) {
+        name += pattern[index];
+        index += 1;
+      }
+      if (!name) {
+        throw new Error('Invalid metavariable in structural pattern');
+      }
+      parts.push(`(?<${name}>[\\s\\S]+?)`);
+      continue;
+    }
+
+    parts.push(escapeRegex(pattern[index]!));
+    index += 1;
+  }
+
+  return new RegExp(parts.join(''), 'gm');
+}
+
+function renderReplacement(template: string, groups: Record<string, string>): string {
+  return template.replace(/\$\$?([A-Za-z0-9_]+)/g, (_match, name) => groups[name] ?? '');
+}
+
+export function applyStructuralSearchReplace(
+  source: string,
+  searchPattern: string,
+  replacePattern: string
+): StructuralReplaceResult {
+  const regex = compileStructuralPattern(searchPattern);
+  const matches: StructuralMatch[] = [];
+  let updated = source;
+  let offset = 0;
+
+  for (const match of source.matchAll(regex)) {
+    const raw = match[0];
+    if (typeof raw !== 'string' || match.index === undefined) {
+      continue;
+    }
+
+    if (!isLikelyCodeMatch(source, match.index)) {
+      continue;
+    }
+
+    const groups = (match.groups ?? {}) as Record<string, string>;
+    const replacement = renderReplacement(replacePattern, groups);
+    const start = match.index;
+    const end = start + raw.length;
+
+    const shiftedStart = start + offset;
+    const shiftedEnd = end + offset;
+
+    updated = `${updated.slice(0, shiftedStart)}${replacement}${updated.slice(shiftedEnd)}`;
+    offset += replacement.length - raw.length;
+
+    matches.push({ start, end, groups });
+  }
+
+  return {
+    text: updated,
+    matches,
+  };
+}

--- a/packages/vscode-pike/src/test/extension-features.test.ts
+++ b/packages/vscode-pike/src/test/extension-features.test.ts
@@ -298,6 +298,19 @@ describe('Phase 7: VSCode Extension Features (Categories 31-34)', () => {
       expect(runTestCmd?.title).toBe('Run Pike Test');
       expect(runTestCmd?.category).toBe('Pike LSP');
     });
+
+    test('33.11 should register pike.lsp.structuralSearchReplace command', async () => {
+      const packageJsonPath = path.join(__dirname, '..', '..', 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
+      const ssrCmd = packageJson.contributes?.commands?.find(
+        (c: { command: string }) => c.command === 'pike.lsp.structuralSearchReplace'
+      );
+
+      expect(ssrCmd).toBeDefined();
+      expect(ssrCmd?.title).toBe('Structural Search and Replace');
+      expect(ssrCmd?.category).toBe('Pike LSP');
+    });
   });
 
   /**

--- a/packages/vscode-pike/src/test/structural-search-replace.test.ts
+++ b/packages/vscode-pike/src/test/structural-search-replace.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  applyStructuralSearchReplace,
+  compileStructuralPattern,
+} from '../structural-search-replace';
+
+describe('structural search and replace', () => {
+  test('compiles metavariable patterns into regex with named groups', () => {
+    const regex = compileStructuralPattern('write_to_log($msg, $level)');
+    const source = 'write_to_log(error_message, 3);';
+    const match = source.match(regex);
+
+    expect(match).toBeDefined();
+  });
+
+  test('replaces metavariables in structural rewrite', () => {
+    const source = 'write_to_log(error_message, 3);';
+    const result = applyStructuralSearchReplace(
+      source,
+      'write_to_log($msg, $level)',
+      'Logger.log($level, $msg)'
+    );
+
+    expect(result.matches.length).toBe(1);
+    expect(result.text).toContain('Logger.log(3, error_message)');
+  });
+
+  test('skips likely comment and string matches', () => {
+    const source = `// write_to_log(fake, 1)\nstring s = "write_to_log(fake, 1)";\nwrite_to_log(real, 2);`;
+    const result = applyStructuralSearchReplace(
+      source,
+      'write_to_log($msg, $level)',
+      'Logger.log($level, $msg)'
+    );
+
+    expect(result.matches.length).toBe(1);
+    expect(result.text).toContain('Logger.log(2, real)');
+    expect(result.text).toContain('// write_to_log(fake, 1)');
+    expect(result.text).toContain('"write_to_log(fake, 1)"');
+  });
+});


### PR DESCRIPTION
## Summary
- add a Pike structural search and replace engine with metavariable matching
- add a VSCode command to run structural replace across workspace Pike files with preview confirmation
- add command registration and structural replacement tests in vscode-pike

## Verification
- cd packages/vscode-pike && bun test src/test/structural-search-replace.test.ts src/test/extension-features.test.ts
- cd packages/vscode-pike && bun run typecheck
- bun run build

Closes #836