### PR TITLE
fix: ignore comment-contained #" markers in folding multiline detection

### DIFF
--- a/packages/pike-lsp-server/src/features/advanced/folding.ts
+++ b/packages/pike-lsp-server/src/features/advanced/folding.ts
@@ -46,26 +46,6 @@ export function getFoldingRanges(document: TextDocument): FoldingRange[] {
             const line = lines[lineNum] ?? '';
             const trimmed = line.trim();
 
-            // Handle Pike multi-line strings: #" starts, "# ends
-            if (trimmed.includes('#"') && !inMultilineString) {
-                const startIndex = trimmed.indexOf('#"');
-                // Basic check to avoid matching inside regular strings
-                if (startIndex >= 0 && !trimmed.substring(0, startIndex).includes('"')) {
-                    inMultilineString = true;
-                    multilineStringStart = lineNum;
-                }
-            }
-            if (trimmed.includes('"#') && inMultilineString) {
-                if (multilineStringStart !== null && lineNum > multilineStringStart) {
-                    foldingRanges.push({
-                        startLine: multilineStringStart,
-                        endLine: lineNum,
-                    });
-                }
-                inMultilineString = false;
-                multilineStringStart = null;
-            }
-
             if (!inBlockComment && trimmed.startsWith('/*')) {
                 commentStart = lineNum;
                 inBlockComment = true;
@@ -95,6 +75,32 @@ export function getFoldingRanges(document: TextDocument): FoldingRange[] {
                     });
                 }
                 commentStart = null;
+            }
+
+            const lineCommentIndex = line.indexOf('//');
+            const inLineComment = lineCommentIndex >= 0 && lineCommentIndex <= line.search(/\S|$/);
+
+            if (!inBlockComment && !inLineComment) {
+                const multilineStartIndex = line.indexOf('#"');
+                if (multilineStartIndex >= 0 && !inMultilineString) {
+                    const prefix = line.slice(0, multilineStartIndex);
+                    if (!prefix.includes('"')) {
+                        inMultilineString = true;
+                        multilineStringStart = lineNum;
+                    }
+                }
+
+                const multilineEndIndex = line.indexOf('"#');
+                if (multilineEndIndex >= 0 && inMultilineString) {
+                    if (multilineStringStart !== null && lineNum > multilineStringStart) {
+                        foldingRanges.push({
+                            startLine: multilineStringStart,
+                            endLine: lineNum,
+                        });
+                    }
+                    inMultilineString = false;
+                    multilineStringStart = null;
+                }
             }
 
             for (let i = 0; i < line.length; i++) {

--- a/packages/pike-lsp-server/src/tests/advanced/folding-range-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/advanced/folding-range-provider.test.ts
@@ -283,6 +283,37 @@ multi-line comment */`;
             const isComment = code.startsWith('/*');
             assert.ok(isComment, 'Is multi-line comment');
         });
+
+        it('should not start multiline string folding for #" inside line comments', () => {
+            const code = `// #" not a multiline string start
+int x = 42;`;
+
+            const document = createDocument(code);
+            const ranges = getFoldingRanges(document);
+
+            assert.equal(ranges.length, 0, 'Should not create folding from comment-contained #"');
+        });
+
+        it('should not start multiline string folding for #" inside autodoc comments', () => {
+            const code = `//! #" not a multiline string start
+int x = 42;`;
+
+            const document = createDocument(code);
+            const ranges = getFoldingRanges(document);
+
+            assert.equal(ranges.length, 0, 'Should not create folding from //! comment #"');
+        });
+
+        it('should still fold valid Pike multiline strings outside comments', () => {
+            const code = `#"
+line1
+"#`;
+
+            const document = createDocument(code);
+            const ranges = getFoldingRanges(document);
+
+            assert.ok(ranges.some(r => r.startLine === 0 && r.endLine === 2), 'Should fold actual multiline string');
+        });
     });
 
     /**


### PR DESCRIPTION
## Summary
- reorder folding line-state handling so comment state is resolved before Pike #"..."# detection
- guard multiline string start/end detection when the current line is a comment context
- add regressions for // and //! comment-contained #" markers plus a positive multiline-string fold case

## Verification
- cd packages/pike-lsp-server && bun test src/tests/advanced/folding-range-provider.test.ts
- cd packages/pike-lsp-server && bun run typecheck
- bun run build

Closes #850