### PR TITLE
fix: ignore comment and string braces in folding range stack

### DIFF
--- a/packages/pike-lsp-server/src/features/advanced/folding.ts
+++ b/packages/pike-lsp-server/src/features/advanced/folding.ts
@@ -77,34 +77,78 @@ export function getFoldingRanges(document: TextDocument): FoldingRange[] {
                 commentStart = null;
             }
 
-            const lineCommentIndex = line.indexOf('//');
-            const inLineComment = lineCommentIndex >= 0 && lineCommentIndex <= line.search(/\S|$/);
-
-            if (!inBlockComment && !inLineComment) {
-                const multilineStartIndex = line.indexOf('#"');
-                if (multilineStartIndex >= 0 && !inMultilineString) {
-                    const prefix = line.slice(0, multilineStartIndex);
-                    if (!prefix.includes('"')) {
-                        inMultilineString = true;
-                        multilineStringStart = lineNum;
-                    }
-                }
-
-                const multilineEndIndex = line.indexOf('"#');
-                if (multilineEndIndex >= 0 && inMultilineString) {
-                    if (multilineStringStart !== null && lineNum > multilineStringStart) {
-                        foldingRanges.push({
-                            startLine: multilineStringStart,
-                            endLine: lineNum,
-                        });
-                    }
-                    inMultilineString = false;
-                    multilineStringStart = null;
-                }
-            }
+            let inString = false;
+            let stringQuote = '';
+            let escaped = false;
+            let inBraceBlockComment = inBlockComment;
 
             for (let i = 0; i < line.length; i++) {
-                const char = line[i];
+                const char = line[i] ?? '';
+                const next = i + 1 < line.length ? line[i + 1] ?? '' : '';
+
+                if (inBraceBlockComment) {
+                    if (char === '*' && next === '/') {
+                        inBraceBlockComment = false;
+                        i += 1;
+                    }
+                    continue;
+                }
+
+                if (inMultilineString) {
+                    if (char === '"' && next === '#') {
+                        if (multilineStringStart !== null && lineNum > multilineStringStart) {
+                            foldingRanges.push({
+                                startLine: multilineStringStart,
+                                endLine: lineNum,
+                            });
+                        }
+                        inMultilineString = false;
+                        multilineStringStart = null;
+                        i += 1;
+                    }
+                    continue;
+                }
+
+                if (inString) {
+                    if (escaped) {
+                        escaped = false;
+                        continue;
+                    }
+                    if (char === '\\') {
+                        escaped = true;
+                        continue;
+                    }
+                    if (char === stringQuote) {
+                        inString = false;
+                        stringQuote = '';
+                    }
+                    continue;
+                }
+
+                if (char === '/' && next === '*') {
+                    inBraceBlockComment = true;
+                    i += 1;
+                    continue;
+                }
+
+                if (char === '/' && next === '/') {
+                    break;
+                }
+
+                if (char === '#' && next === '"') {
+                    inMultilineString = true;
+                    multilineStringStart = lineNum;
+                    i += 1;
+                    continue;
+                }
+
+                if (char === '"' || char === '\'') {
+                    inString = true;
+                    stringQuote = char;
+                    escaped = false;
+                    continue;
+                }
+
                 if (char === '{') {
                     let kind: FoldingRangeKind | undefined;
                     if (trimmed.startsWith('class ') || trimmed.startsWith('inherit ')) {

--- a/packages/pike-lsp-server/src/tests/advanced/folding-range-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/advanced/folding-range-provider.test.ts
@@ -14,7 +14,7 @@
 import { describe, it, beforeAll } from 'bun:test';
 import assert from 'node:assert';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { FoldingRange } from 'vscode-languageserver/node.js';
+import { FoldingRange, FoldingRangeKind } from 'vscode-languageserver/node.js';
 import { ErrorCodes, ResponseError } from 'vscode-languageserver/node.js';
 import { getFoldingRanges } from '../../features/advanced/folding.js';
 
@@ -282,6 +282,34 @@ multi-line comment */`;
 
             const isComment = code.startsWith('/*');
             assert.ok(isComment, 'Is multi-line comment');
+        });
+
+        it('should ignore braces inside block comments when computing code folds', () => {
+            const code = `/*
+{ this brace pair is comment content }
+*/
+void run() {
+    int x = 1;
+}`;
+
+            const document = createDocument(code);
+            const ranges = getFoldingRanges(document);
+
+            const codeRangeCount = ranges.filter(r => r.kind !== FoldingRangeKind.Comment).length;
+            assert.equal(codeRangeCount, 1, 'Only the function body should produce a code fold');
+        });
+
+        it('should ignore braces inside string literals when computing code folds', () => {
+            const code = `void run() {
+    string s = "{ not a code block }";
+    int x = 1;
+}`;
+
+            const document = createDocument(code);
+            const ranges = getFoldingRanges(document);
+
+            const codeRangeCount = ranges.filter(r => r.kind !== FoldingRangeKind.Comment).length;
+            assert.equal(codeRangeCount, 1, 'String literal braces must not create extra folds');
         });
 
         it('should not start multiline string folding for #" inside line comments', () => {


### PR DESCRIPTION
## Summary
- make folding brace scanning context-aware for //, /* */, regular quoted strings, and Pike #"..."# multiline strings
- prevent comment/string braces from pushing or popping the structural brace stack
- add regressions proving braces in comments/strings do not create extra code folds

## Verification
- cd packages/pike-lsp-server && bun test src/tests/advanced/folding-range-provider.test.ts
- cd packages/pike-lsp-server && bun run typecheck
- bun run build

Closes #847