### PR TITLE
fix: skip semantic tokens inside multiline Pike strings

### DIFF
--- a/packages/pike-lsp-server/src/features/advanced/semantic-tokens.ts
+++ b/packages/pike-lsp-server/src/features/advanced/semantic-tokens.ts
@@ -142,42 +142,138 @@ export function registerSemanticTokensHandler(
     const text = document.getText();
     const lines = text.split('\n');
 
-    const isInsideComment = (line: string, charPos: number): boolean => {
-      const trimmed = line.trimStart();
-      if (PatternHelpers.isCommentLine(trimmed)) {
-        return true;
+    type IgnoredRange = { start: number; end: number };
+
+    const addIgnoredRange = (
+      ignoredRangesByLine: IgnoredRange[][],
+      lineNum: number,
+      start: number,
+      end: number
+    ): void => {
+      if (start >= end || lineNum < 0 || lineNum >= ignoredRangesByLine.length) {
+        return;
       }
-      const lineCommentPos = line.indexOf('//');
-      if (lineCommentPos >= 0 && lineCommentPos < charPos) {
-        return true;
+      ignoredRangesByLine[lineNum]!.push({ start, end });
+    };
+
+    const buildIgnoredRangesByLine = (sourceLines: string[]): IgnoredRange[][] => {
+      const ignoredRangesByLine: IgnoredRange[][] = sourceLines.map(() => []);
+      let inBlockComment = false;
+      let inString = false;
+      let inMultilineString = false;
+
+      for (let lineNum = 0; lineNum < sourceLines.length; lineNum++) {
+        const line = sourceLines[lineNum] ?? '';
+        let i = 0;
+
+        while (i < line.length) {
+          if (inBlockComment) {
+            const closeIndex = line.indexOf('*/', i);
+            if (closeIndex < 0) {
+              addIgnoredRange(ignoredRangesByLine, lineNum, i, line.length);
+              i = line.length;
+              continue;
+            }
+
+            const end = closeIndex + 2;
+            addIgnoredRange(ignoredRangesByLine, lineNum, i, end);
+            i = end;
+            inBlockComment = false;
+            continue;
+          }
+
+          if (inMultilineString) {
+            const closeIndex = line.indexOf('"#', i);
+            if (closeIndex < 0) {
+              addIgnoredRange(ignoredRangesByLine, lineNum, i, line.length);
+              i = line.length;
+              continue;
+            }
+
+            const end = closeIndex + 2;
+            addIgnoredRange(ignoredRangesByLine, lineNum, i, end);
+            i = end;
+            inMultilineString = false;
+            continue;
+          }
+
+          if (inString) {
+            const start = i;
+            let escaped = false;
+            while (i < line.length) {
+              const char = line[i];
+              if (escaped) {
+                escaped = false;
+                i++;
+                continue;
+              }
+
+              if (char === '\\') {
+                escaped = true;
+                i++;
+                continue;
+              }
+
+              if (char === '"') {
+                i++;
+                inString = false;
+                break;
+              }
+
+              i++;
+            }
+
+            addIgnoredRange(ignoredRangesByLine, lineNum, start, i);
+
+            if (inString && i >= line.length) {
+              inString = false;
+            }
+
+            continue;
+          }
+
+          if (line.startsWith('//', i)) {
+            addIgnoredRange(ignoredRangesByLine, lineNum, i, line.length);
+            break;
+          }
+
+          if (line.startsWith('/*', i)) {
+            inBlockComment = true;
+            continue;
+          }
+
+          if (line.startsWith('#"', i)) {
+            inMultilineString = true;
+            continue;
+          }
+
+          if (line[i] === '"') {
+            inString = true;
+            continue;
+          }
+
+          i++;
+        }
       }
-      const blockOpenPos = line.lastIndexOf('/*', charPos);
-      if (blockOpenPos >= 0) {
-        const blockClosePos = line.indexOf('*/', blockOpenPos);
-        if (blockClosePos < 0 || blockClosePos > charPos) {
+
+      return ignoredRangesByLine;
+    };
+
+    const ignoredRangesByLine = buildIgnoredRangesByLine(lines);
+
+    const isIgnoredPosition = (lineNum: number, charPos: number): boolean => {
+      const ranges = ignoredRangesByLine[lineNum];
+      if (!ranges || ranges.length === 0) {
+        return false;
+      }
+
+      for (const range of ranges) {
+        if (charPos >= range.start && charPos < range.end) {
           return true;
         }
       }
-      return false;
-    };
 
-    const isInsideString = (line: string, charPos: number): boolean => {
-      let inString = false;
-      let escaped = false;
-      for (let i = 0; i < charPos; i++) {
-        if (escaped) {
-          escaped = false;
-          continue;
-        }
-        if (line[i] === '\\') {
-          escaped = true;
-          continue;
-        }
-        if (line[i] === '"') {
-          inString = !inString;
-        }
-      }
-      return inString;
+      return false;
     };
 
     const declarationBit = 1 << tokenModifiers.indexOf('declaration');
@@ -262,7 +358,7 @@ export function registerSemanticTokensHandler(
         while (match !== null) {
           const matchIndex = match.index;
 
-          if (!(isInsideComment(line, matchIndex) || isInsideString(line, matchIndex))) {
+          if (!isIgnoredPosition(lineNum, matchIndex)) {
             const isDeclaration = symbol.position && symbol.position.line - 1 === lineNum;
             const modifiers = isDeclaration ? declModifiers : 0;
             builder.push(lineNum, matchIndex, symbol.name.length, tokenType, modifiers);
@@ -289,7 +385,7 @@ export function registerSemanticTokensHandler(
         while (match !== null) {
           const matchIndex = match.index;
 
-          if (!(isInsideComment(line, matchIndex) || isInsideString(line, matchIndex))) {
+          if (!isIgnoredPosition(lineNum, matchIndex)) {
             builder.push(lineNum, matchIndex, keyword.length, keywordTokenType, 0);
           }
 

--- a/packages/pike-lsp-server/src/tests/advanced/semantic-tokens-delta.test.ts
+++ b/packages/pike-lsp-server/src/tests/advanced/semantic-tokens-delta.test.ts
@@ -20,6 +20,50 @@ import {
 } from '../helpers/mock-services.js';
 import type { DocumentCacheEntry } from '../../core/types.js';
 
+const TOKEN_TYPE = {
+  variable: 8,
+};
+
+function decodeTokens(tokensData: number[]): Array<{
+  line: number;
+  startChar: number;
+  length: number;
+  tokenType: number;
+}> {
+  const decoded: Array<{
+    line: number;
+    startChar: number;
+    length: number;
+    tokenType: number;
+  }> = [];
+
+  let currentLine = 0;
+  let currentStartChar = 0;
+
+  for (let i = 0; i < tokensData.length; i += 5) {
+    const deltaLine = tokensData[i] ?? 0;
+    const deltaStart = tokensData[i + 1] ?? 0;
+    const length = tokensData[i + 2] ?? 0;
+    const tokenType = tokensData[i + 3] ?? 0;
+
+    if (deltaLine === 0) {
+      currentStartChar += deltaStart;
+    } else {
+      currentLine += deltaLine;
+      currentStartChar = deltaStart;
+    }
+
+    decoded.push({
+      line: currentLine,
+      startChar: currentStartChar,
+      length,
+      tokenType,
+    });
+  }
+
+  return decoded;
+}
+
 describe('Semantic Tokens Delta Handler', () => {
   describe('Handler Registration', () => {
     it('should register semanticTokens full handler', () => {
@@ -221,6 +265,46 @@ int main() { return x; }`;
 
       expect(second.resultId).toBe(first.resultId);
       expect(second.data).toEqual(first.data);
+    });
+
+    it('skips identifiers inside multiline #"..."# string bodies but keeps nearby code tokens', () => {
+      const uri = 'file:///multiline-string-filter.pike';
+      const code = `int target = 1;
+string template = #"
+target should stay plain text here
+target should also stay plain text here
+"#;
+if (target > 0) {
+    target--;
+}`;
+
+      const doc = TextDocument.create(uri, 'pike', 1, code);
+      const docsMap = new Map<string, TextDocument>();
+      docsMap.set(uri, doc);
+
+      const cacheEntry: DocumentCacheEntry = makeCacheEntry({
+        symbols: [sym('target', 'variable', { position: { line: 1, character: 4 } })],
+      });
+
+      const services = createMockServices({
+        cacheEntries: new Map([[uri, cacheEntry]]),
+      });
+      const documents = createMockDocuments(docsMap);
+      const conn = createMockConnection();
+
+      registerSemanticTokensHandler(conn as any, services as any, documents as any);
+
+      const result = conn.semanticTokensHandler({
+        textDocument: { uri },
+      });
+
+      const decoded = decodeTokens(result.data);
+      const targetTokens = decoded.filter(
+        token => token.tokenType === TOKEN_TYPE.variable && token.length === 'target'.length
+      );
+
+      expect(targetTokens.map(token => token.line).sort((a, b) => a - b)).toEqual([0, 5, 6]);
+      expect(targetTokens.some(token => token.line === 2 || token.line === 3)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- replace line-local semantic token filtering with document-level ignored-range scanning
- skip token emission inside Pike multiline strings (`#\"...\"#`) across lines
- add regression coverage to ensure multiline string body identifiers are not tokenized while surrounding code is

## Verification
- cd packages/pike-lsp-server && bun test src/tests/advanced/semantic-tokens-delta.test.ts src/tests/advanced/semantic-tokens-stress.test.ts
- cd packages/pike-lsp-server && bun run typecheck
- bun run typecheck
- bun run build

Closes #849