### PR TITLE
fix: enforce priority and type labels on new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -7,22 +7,36 @@ assignees: ''
 ---
 
 ## Improvement Type
+
 - [ ] Performance - Speed, memory, or efficiency improvement
 - [ ] Code Quality - Refactoring, reducing complexity
 - [ ] Test Coverage - Adding or improving tests
 - [ ] Documentation - Improving docs or comments
 - [ ] User Experience - Better error messages, usability
 
+## Required Labels
+
+Add exactly one priority label and exactly one type label before submitting.
+
+Examples:
+
+- Priority: `P0-broken`, `P1-tests`, `P2-feature`, `P3-refactor`, or `P4-perf`
+- Type: `type:bug`, `type:feature`, `type:performance`, `type:test`, `type:tech-debt`, or `type:docs`
+
 ## Description
+
 <!-- What needs improvement and why -->
 
 ## Current Behavior
+
 <!-- Describe the current state -->
 
 ## Desired Behavior
+
 <!-- What should happen instead -->
 
 ## Acceptance Criteria
+
 - [ ] Code change implemented
 - [ ] Tests added/updated
 - [ ] TypeScript compiles: `bun run typecheck`

--- a/.github/ISSUE_TEMPLATE/safe.yml
+++ b/.github/ISSUE_TEMPLATE/safe.yml
@@ -7,26 +7,39 @@ assignees: ''
 ---
 
 ## Description
+
 <!-- Required: What needs to be done. Be specific — vague descriptions produce vague fixes. -->
 
+## Required Labels
+
+<!-- Required: Add exactly one priority label (`P0-broken`..`P4-perf`) and exactly one
+     type label (`type:bug`, `type:feature`, `type:performance`, `type:test`,
+     `type:tech-debt`, `type:docs`). Example: `P2-feature` + `type:feature` -->
+
 ## Problem
+
 <!-- Required: What is wrong or missing right now? Include error messages, logs, or
      observed behavior if applicable. -->
 
 ## Expected Behavior
+
 <!-- Required: What should happen after this is fixed? -->
 
 ## Suggested Approach
+
 <!-- Required: Concrete steps or pointers to relevant files/functions.
      If unsure, explain what you have investigated so far. -->
 
 ## Affected Files
+
 <!-- Required: List files or packages likely involved. Agents must read these before starting. -->
 
 ## Acceptance
+
 <!-- Required: How will we know this is fixed? What should pass or be observable? -->
 
 ## Environment
+
 - Pike binary: <!-- output of: pike --version -->
 - Bun version: <!-- output of: bun --version -->
 - $PIKE_SRC set: <!-- YES/NO -->

--- a/.github/workflows/enforce-issue-template.yml
+++ b/.github/workflows/enforce-issue-template.yml
@@ -18,12 +18,63 @@ jobs:
             const body = issue.body || '';
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const feedbackMarker = '<!-- issue-template-enforcement -->';
 
-            // Only enforce on safe issues
+            async function upsertFeedbackComment(message) {
+              const commentBody = `${feedbackMarker}\n${message}`;
+              const { data: comments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: issue.number,
+                per_page: 100
+              });
+
+              const existing = comments.find(comment => {
+                return comment.user?.type === 'Bot' && comment.body?.includes(feedbackMarker);
+              });
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body: commentBody
+                });
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: commentBody
+              });
+            }
+
             const labels = issue.labels.map(l => l.name);
-            if (!labels.includes('safe')) {
-              console.log(`Issue #${issue.number} not labeled safe, skipping`);
-              return;
+            const isSafeIssue = labels.includes('safe');
+
+            const allowedPriorityLabels = ['P0-broken', 'P1-tests', 'P2-feature', 'P3-refactor', 'P4-perf'];
+            const allowedTypeLabels = ['type:bug', 'type:feature', 'type:performance', 'type:test', 'type:tech-debt', 'type:docs'];
+
+            const priorityLabels = labels.filter(label => allowedPriorityLabels.includes(label));
+            const typeLabels = labels.filter(label => allowedTypeLabels.includes(label));
+            const missingClassification = [];
+
+            if (priorityLabels.length !== 1) {
+              missingClassification.push(
+                priorityLabels.length === 0
+                  ? 'Add exactly one priority label (`P0-broken`, `P1-tests`, `P2-feature`, `P3-refactor`, or `P4-perf`).'
+                  : `Keep exactly one priority label (currently ${priorityLabels.length}: ${priorityLabels.map(l => `\`${l}\``).join(', ')}).`
+              );
+            }
+
+            if (typeLabels.length !== 1) {
+              missingClassification.push(
+                typeLabels.length === 0
+                  ? 'Add exactly one type label (`type:bug`, `type:feature`, `type:performance`, `type:test`, `type:tech-debt`, or `type:docs`).'
+                  : `Keep exactly one type label (currently ${typeLabels.length}: ${typeLabels.map(l => `\`${l}\``).join(', ')}).`
+              );
             }
 
             const required = [
@@ -46,7 +97,10 @@ jobs:
               return !content.replace(/<!--[\s\S]*?-->/g, '').trim();
             });
 
-            if (missing.length > 0) {
+            const safeTemplateProblems = isSafeIssue && missing.length > 0;
+            const classificationProblems = missingClassification.length > 0;
+
+            if (safeTemplateProblems || classificationProblems) {
               try {
                 await github.rest.issues.addLabels({
                   owner, repo,
@@ -55,34 +109,52 @@ jobs:
                 });
               } catch (e) {}
 
-              await github.rest.issues.createComment({
-                owner, repo,
-                issue_number: issue.number,
-                body:
-                  `⚠️ This issue is missing required sections or has empty content:\n\n` +
+              const feedbackBlocks = [];
+
+              if (classificationProblems) {
+                feedbackBlocks.push(
+                  `### Required issue labels\n` +
+                  `Every new/edited issue must have exactly one priority label and one type label.\n\n` +
+                  missingClassification.map(problem => `- ${problem}`).join('\n') +
+                  `\n\nExamples:\n` +
+                  `- Priority: \`P0-broken\`, \`P1-tests\`, \`P2-feature\`, \`P3-refactor\`, \`P4-perf\`\n` +
+                  `- Type: \`type:bug\`, \`type:feature\`, \`type:performance\`, \`type:test\`, \`type:tech-debt\`, \`type:docs\``
+                );
+              }
+
+              if (safeTemplateProblems) {
+                feedbackBlocks.push(
+                  `### Required safe issue sections\n` +
+                  `This issue is labeled \`safe\`, so all safe template sections must be present with substantive content:\n\n` +
                   missing.map(s => `- \`${s}\``).join('\n') +
-                  `\n\nAll sections must have substantive content — not placeholders ` +
-                  `or HTML comments.\n\n` +
-                  `Agents will not pick up issues labeled \`needs-template\`. ` +
-                  `Update the issue body to remove this label.`
-              });
+                  `\n\nAll sections must include real content (not placeholders or HTML comments).`
+                );
+              }
+
+              await upsertFeedbackComment(
+                `⚠️ Issue template enforcement failed for #${issue.number}.\n\n` +
+                feedbackBlocks.join('\n\n') +
+                `\n\nThe \`needs-template\` label will be removed automatically after these items are fixed and the issue is edited.`
+              );
 
               core.setFailed(
-                `Issue #${issue.number} missing sections: ${missing.join(', ')}`
+                `Issue #${issue.number} failed template enforcement` +
+                (classificationProblems ? ` | classification issues: ${missingClassification.join(' ')}` : '') +
+                (safeTemplateProblems ? ` | missing safe sections: ${missing.join(', ')}` : '')
               );
               return;
             }
 
-            // All sections present — remove needs-template if exists
+            // Requirements satisfied — remove needs-template if exists
             try {
               await github.rest.issues.removeLabel({
                 owner, repo,
                 issue_number: issue.number,
                 name: 'needs-template'
               });
-              console.log(`Issue #${issue.number}: template OK, removed needs-template`);
+              console.log(`Issue #${issue.number}: issue requirements OK, removed needs-template`);
             } catch (e) {}
 
-            console.log(`Issue #${issue.number}: template format OK`);
+            console.log(`Issue #${issue.number}: issue requirements OK`);
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update issue templates to require one priority label (`P0-broken`..`P4-perf`) and one type label
- extend issue-template enforcement workflow to validate those exact label sets on issue open/edit
- preserve safe-template section validation and provide actionable non-spam feedback with comment upserts

## Verification
- bun run typecheck
- bun run build

Closes #855