### PR TITLE
ci: parallelize vscode e2e by category matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,7 +268,7 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
-  vscode-e2e:
+  vscode-e2e-category:
     name: vscode-e2e (${{ matrix.category }})
     runs-on: ubuntu-24.04
     needs: [test, pike-test]
@@ -369,6 +369,21 @@ jobs:
           echo "- Grep: ${{ matrix.grep }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Check the 'Run VSCode E2E category suite' step above for results." >> $GITHUB_STEP_SUMMARY
+
+  vscode-e2e:
+    name: vscode-e2e
+    runs-on: ubuntu-24.04
+    needs: [vscode-e2e-category]
+    if: always()
+
+    steps:
+      - name: Validate matrix aggregate result
+        run: |
+          if [ "${{ needs.vscode-e2e-category.result }}" != "success" ]; then
+            echo "Required VSCode E2E categories failed."
+            exit 1
+          fi
+          echo "Required VSCode E2E categories passed."
 
   vscode-e2e-source-trees:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- split vscode-e2e into category-based matrix jobs: core-lsp, completion-navigation, reliability-workflows, performance
- run each category with its own grep selector so suites execute in parallel instead of one serialized block
- keep source-tree E2E job unchanged while improving speed and isolation for regular E2E coverage

## Verification
- lsp_diagnostics clean on .github/workflows/test.yml
- branch pushed and PR checks triggered

Closes #854

<!-- trigger format re-evaluation -->