### PR TITLE
chore: bump version to alpha.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,29 +16,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security** - Security vulnerability fixes
 - **Performance** - User-facing performance notes
 
-## [0.1.0-alpha.30] - 2026-03-17
-
-### Fixed
-
-- **Runtime settings propagation consistency** - initialization and config-change flows now sync mutable runtime settings through shared services state, and diagnostics consumes the same live settings source.
-- **Workspace-folder analyzer sync** - workspace folder add/remove events now propagate deltas into query-engine workspace state to keep analyzer roots aligned with scanner/index state.
-- **Interactive snapshot consistency and safe fallbacks** - navigation/completion queries now prefer fixed snapshots when available, and uncached workspace text-search fallbacks were removed for references/rename to avoid blind symbol-unsafe results.
+## [0.1.0-alpha.32] - 2026-03-26
 
 ### Added
 
-- **Regression coverage for workspace/runtime consistency** - added tests for runtime workspace-folder delta forwarding and navigation snapshot selection behavior.
-
-## [0.1.0-alpha.29] - 2026-03-16
+- **Pull diagnostics and snapshot-driven editor tooling** - shipped pull-diagnostics handlers/capabilities, inline snapshot hover test infrastructure, runnable/test code lens commands, and workspace indexing progress reporting.
+- **Structural search and replace command** - added command surface and extension wiring for structural search/replace workflows.
 
 ### Fixed
 
-- **References completeness across files** - `textDocument/references` now merges query-engine and fallback sources, restores cross-file `.pike` scanning, and deduplicates merged locations to avoid missed usages.
-- **QE2 incremental document state** - `engine_change_document` now applies ordered range edits into stored document text instead of storing change metadata only.
-- **QE2 fixed snapshot resolution** - fixed-snapshot queries now validate snapshot existence and resolve against pinned snapshot state; unknown snapshot IDs return `SNAPSHOT_NOT_FOUND` payloads.
+- **Language correctness in edge syntax contexts** - fixed references, inlay hints, semantic tokens, and folding behavior to ignore comments and string literals in tricky multiline and inline cases.
+- **Formatting reliability and on-type behavior** - stabilized formatting context/on-type indentation behavior and added regression coverage around formatter depth handling.
+- **CI/E2E throughput and merge gating** - parallelized VS Code E2E by category matrix, kept flaky reliability slice non-blocking when needed, and restored required `vscode-e2e` status gating compatibility.
 
-### Added
+### Changed
 
-- **Regression coverage for snapshot/edit correctness** - added bridge-level tests for ranged incremental edits, fixed snapshot pinning across later edits, and unknown fixed snapshot behavior.
+- **Contributor testing policy** - tightened docs to require regression-focused tests for all feature and bug-fix PRs.
 
-[0.1.0-alpha.30]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.30
-[0.1.0-alpha.29]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.29
+## [0.1.0-alpha.31] - 2026-03-18
+
+### Fixed
+
+- **Live formatting stability** - replaced broken live formatting paths and stabilized Pike indentation behavior.
+
+[0.1.0-alpha.32]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.32
+[0.1.0-alpha.31]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.31

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pike-lsp",
-  "version": "0.1.0-alpha.30",
+  "version": "0.1.0-alpha.32",
   "private": true,
   "description": "Pike Language Server Protocol implementation and VSCode extension",
   "author": "Pike LSP Team",

--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-pike",
   "displayName": "Pike Language Support",
   "description": "Complete language support for Pike including IntelliSense, go-to-definition, find references, diagnostics, hover, signature help, code completion, semantic tokens, call hierarchy, and workspace symbols.",
-  "version": "0.1.0-alpha.30",
+  "version": "0.1.0-alpha.32",
   "publisher": "pike-lsp",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
## Summary
- bump root and VS Code extension versions to `0.1.0-alpha.32`
- refresh changelog to include alpha.32 notes and keep latest two releases
- prepare main for release tagging from `v0.1.0-alpha.31`

Closes #854