### PR TITLE
test: add RequestScheduler regression tests for cancellation/coalescing/priority/rejection

### DIFF
--- a/packages/pike-lsp-server/src/tests/request-scheduler-regressions.test.ts
+++ b/packages/pike-lsp-server/src/tests/request-scheduler-regressions.test.ts
@@ -1,0 +1,136 @@
+import { describe, it } from 'bun:test';
+import assert from 'node:assert/strict';
+import { RequestScheduler, RequestSupersededError } from '../services/request-scheduler.js';
+
+describe('RequestScheduler regressions (#882)', () => {
+  it('cancels an in-flight keyed request when superseded and runs the replacement', async () => {
+    const scheduler = new RequestScheduler();
+    const releaseFirst: { fn?: () => void } = {};
+    const gate = new Promise<void>(resolve => {
+      releaseFirst.fn = resolve;
+    });
+
+    const first = scheduler.schedule({
+      requestClass: 'typing',
+      key: 'completion:file:///tmp/file.pike',
+      run: async checkpoint => {
+        await gate;
+        checkpoint();
+        return 'first';
+      },
+    });
+
+    const second = scheduler.schedule({
+      requestClass: 'typing',
+      key: 'completion:file:///tmp/file.pike',
+      run: async () => 'second',
+    });
+
+    const release = releaseFirst.fn;
+    if (!release) {
+      throw new Error('missing gate release function');
+    }
+    release();
+
+    let firstError: unknown;
+    try {
+      await first;
+      throw new Error('expected first request to be superseded');
+    } catch (error) {
+      firstError = error;
+    }
+
+    assert.equal(firstError instanceof RequestSupersededError, true);
+    assert.equal(
+      (firstError as Error).message,
+      'Cancelled during execution key=completion:file:///tmp/file.pike id=1'
+    );
+    assert.equal(await second, 'second');
+  });
+
+  it('coalesces repeated keyed requests and rejects superseded coalesced entry', async () => {
+    const scheduler = new RequestScheduler();
+    let runs = 0;
+
+    const first = scheduler.schedule({
+      requestClass: 'typing',
+      key: 'file:///tmp/coalesce.pike',
+      coalesceMs: 20,
+      run: async () => {
+        runs += 1;
+        return 'first';
+      },
+    });
+
+    const second = scheduler.schedule({
+      requestClass: 'typing',
+      key: 'file:///tmp/coalesce.pike',
+      coalesceMs: 20,
+      run: async () => {
+        runs += 1;
+        return 'second';
+      },
+    });
+
+    let firstError: unknown;
+    try {
+      await first;
+      throw new Error('expected first coalesced request to reject');
+    } catch (error) {
+      firstError = error;
+    }
+
+    assert.equal(firstError instanceof RequestSupersededError, true);
+    assert.equal((firstError as Error).message, 'Superseded request key=file:///tmp/coalesce.pike');
+    assert.equal(await second, 'second');
+    assert.equal(runs, 1);
+  });
+
+  it('prioritizes typing over background queued in grace window', async () => {
+    const scheduler = new RequestScheduler({ maxConcurrent: 1 });
+    const runOrder: string[] = [];
+
+    const background = scheduler.schedule({
+      requestClass: 'background',
+      run: async () => {
+        runOrder.push('background');
+      },
+    });
+
+    const typing = scheduler.schedule({
+      requestClass: 'typing',
+      run: async () => {
+        runOrder.push('typing');
+      },
+    });
+
+    await Promise.all([background, typing]);
+    assert.deepEqual(runOrder, ['typing', 'background']);
+  });
+
+  it('propagates run() promise rejection and records failure metrics', async () => {
+    const scheduler = new RequestScheduler();
+    const rejection = new Error('scheduler downstream rejection');
+
+    const request = scheduler.schedule({
+      requestClass: 'interactive',
+      run: async () => Promise.reject(rejection),
+    });
+
+    let seenError: unknown;
+    try {
+      await request;
+      throw new Error('expected scheduler to reject');
+    } catch (error) {
+      seenError = error;
+    }
+
+    assert.equal(seenError, rejection);
+    const metrics = scheduler.snapshotMetrics();
+    assert.equal(metrics.scheduled, 1);
+    assert.equal(metrics.started, 1);
+    assert.equal(metrics.completed, 0);
+    assert.equal(metrics.failed, 1);
+    assert.equal(metrics.canceled, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a dedicated `RequestScheduler` regression test file at `packages/pike-lsp-server/src/tests/request-scheduler-regressions.test.ts` for issue #882.
- Cover four critical behaviors with exact assertions: in-flight keyed cancellation on supersede, keyed coalescing behavior, typing-vs-background priority ordering, and promise rejection propagation with failure metrics.
- Keep scope strictly test-only (no scheduler behavior changes).

## Verification
- `bun test src/tests/request-scheduler-regressions.test.ts` ✅ (4 pass)
- `bun test src/tests/request-scheduler.test.ts src/tests/request-scheduler-regressions.test.ts` ✅ (16 pass)
- `bun run typecheck` (repo root) ✅
- `bun run build` (repo root) ✅
- Pre-commit hook fast regression: `pike-compile`, `bridge`, `server` all PASS ✅
- Pre-push checks PASS ✅
- `lsp_diagnostics` run on changed file (workspace has existing ambient module-resolution diagnostics for Bun/Node test imports; no code changes were made outside tests)

Closes #882