### PR TITLE
fix: fail initialization when bridge startup fails

### DIFF
--- a/packages/pike-lsp-server/src/runtime/bridge-startup.ts
+++ b/packages/pike-lsp-server/src/runtime/bridge-startup.ts
@@ -1,0 +1,48 @@
+import { ErrorCodes, ResponseError } from 'vscode-languageserver/node.js';
+
+export interface BridgeStartupManager {
+  start: () => Promise<void>;
+}
+
+interface EnsureBridgeStartupArgs {
+  bridgeManager: BridgeStartupManager;
+  log: (message: string) => void;
+  reportConsoleError: (message: string) => void;
+  showErrorMessage?: (message: string) => void | Promise<unknown>;
+}
+
+function summarizeError(err: unknown): string {
+  if (err instanceof Error) {
+    return `${err.name}: ${err.message}`;
+  }
+  return String(err);
+}
+
+export async function ensureBridgeStartupOrThrow({
+  bridgeManager,
+  log,
+  reportConsoleError,
+  showErrorMessage,
+}: EnsureBridgeStartupArgs): Promise<void> {
+  try {
+    await bridgeManager.start();
+  } catch (err) {
+    const summary = summarizeError(err);
+    const userMessage =
+      'Pike LSP failed to start the Pike bridge during initialization. Check the configured Pike path and analyzer script.';
+    const detailedMessage = `${userMessage} (${summary})`;
+
+    reportConsoleError(detailedMessage);
+    log(`Bridge startup error during initialize: ${summary}`);
+
+    if (showErrorMessage) {
+      try {
+        await showErrorMessage(userMessage);
+      } catch (showError) {
+        log(`Failed to show bridge startup error message: ${summarizeError(showError)}`);
+      }
+    }
+
+    throw new ResponseError(ErrorCodes.InternalError, detailedMessage);
+  }
+}

--- a/packages/pike-lsp-server/src/runtime/server-runtime.ts
+++ b/packages/pike-lsp-server/src/runtime/server-runtime.ts
@@ -245,8 +245,10 @@ export function registerServerRuntimeHandlers(args: RegisterServerRuntimeHandler
           });
 
           if (!bridgeManager.bridge.isRunning()) {
-            log('Starting bridge after initialize handshake...');
-            await bridgeManager.bridge.start();
+            connection.console.warn(
+              'Pike bridge is not running after initialize handshake. Features may be degraded.'
+            );
+            log('Bridge reported not running after initialize handshake');
           }
 
           connection.console.log(

--- a/packages/pike-lsp-server/src/server.ts
+++ b/packages/pike-lsp-server/src/server.ts
@@ -38,6 +38,7 @@ import {
 import { PikeSettings, defaultSettings } from './core/types.js';
 import * as features from './features/index.js';
 import { registerServerRuntimeHandlers } from './runtime/server-runtime.js';
+import { ensureBridgeStartupOrThrow } from './runtime/bridge-startup.js';
 import { createServiceRuntimeContext } from './runtime/service-runtime-context.js';
 
 // Semantic tokens legend (defined here for capabilities)
@@ -321,6 +322,13 @@ connection.onInitialize(async (params: InitializeParams): Promise<InitializeResu
     workspaceIndex.setErrorCallback((message, uri) => {
       connection.console.warn(message + (uri ? ` (${uri})` : ''));
       log(`[WorkspaceIndex Error] ${message} (${uri})`);
+    });
+
+    await ensureBridgeStartupOrThrow({
+      bridgeManager,
+      log,
+      reportConsoleError: (message: string) => connection.console.error(message),
+      showErrorMessage: (message: string) => connection.window.showErrorMessage?.(message),
     });
 
     log('onInitialize completing');

--- a/packages/pike-lsp-server/src/tests/runtime/bridge-startup.test.ts
+++ b/packages/pike-lsp-server/src/tests/runtime/bridge-startup.test.ts
@@ -1,0 +1,72 @@
+import { ErrorCodes, ResponseError } from 'vscode-languageserver/node.js';
+import { ensureBridgeStartupOrThrow } from '../../runtime/bridge-startup.js';
+
+const { describe, expect, it } = require('bun:test');
+
+describe('bridge startup during initialize', () => {
+  it('starts bridge without reporting errors when startup succeeds', async () => {
+    const logs: string[] = [];
+    const consoleErrors: string[] = [];
+    const userMessages: string[] = [];
+
+    await ensureBridgeStartupOrThrow({
+      bridgeManager: {
+        start: async () => undefined,
+      },
+      log: message => {
+        logs.push(message);
+      },
+      reportConsoleError: message => {
+        consoleErrors.push(message);
+      },
+      showErrorMessage: message => {
+        userMessages.push(message);
+      },
+    });
+
+    expect(logs).toHaveLength(0);
+    expect(consoleErrors).toHaveLength(0);
+    expect(userMessages).toHaveLength(0);
+  });
+
+  it('throws ResponseError and emits user-facing message when startup fails', async () => {
+    const logs: string[] = [];
+    const consoleErrors: string[] = [];
+    const userMessages: string[] = [];
+
+    let caughtError: unknown;
+    try {
+      await ensureBridgeStartupOrThrow({
+        bridgeManager: {
+          start: async () => {
+            throw new Error('spawn ENOENT');
+          },
+        },
+        log: message => {
+          logs.push(message);
+        },
+        reportConsoleError: message => {
+          consoleErrors.push(message);
+        },
+        showErrorMessage: message => {
+          userMessages.push(message);
+        },
+      });
+    } catch (err) {
+      caughtError = err;
+    }
+
+    expect(caughtError).toBeInstanceOf(ResponseError);
+    const responseError = caughtError as ResponseError<unknown>;
+    expect(responseError.code).toBe(ErrorCodes.InternalError);
+    expect(responseError.message).toContain('failed to start the Pike bridge during initialization');
+    expect(responseError.message).toContain('spawn ENOENT');
+
+    expect(userMessages).toEqual([
+      'Pike LSP failed to start the Pike bridge during initialization. Check the configured Pike path and analyzer script.',
+    ]);
+    expect(consoleErrors).toHaveLength(1);
+    expect(consoleErrors[0]).toContain('spawn ENOENT');
+    expect(logs.some(message => message.includes('Bridge startup error during initialize'))).toBeTrue();
+  });
+});


### PR DESCRIPTION
## Summary
- Move Pike bridge startup into `onInitialize` and fail initialization explicitly when startup fails.
- Surface startup failures to users with `window/showErrorMessage` and return a JSON-RPC `ResponseError` instead of silently continuing.
- Add regression tests for bridge startup success/failure behavior and keep post-initialize runtime logic non-restarting.

## Root cause
Bridge startup happened in `onInitialized` and was wrapped in a `try/catch` that only logged warnings. This allowed `initialize` to succeed even when the bridge failed to start, leaving the server in a degraded state without an explicit initialization error.

## File-level rationale
- `packages/pike-lsp-server/src/runtime/bridge-startup.ts`: centralizes initialize-time bridge startup and explicit failure mapping (`ResponseError` + user-facing message).
- `packages/pike-lsp-server/src/server.ts`: invokes initialize-time bridge startup before returning capabilities.
- `packages/pike-lsp-server/src/runtime/server-runtime.ts`: removes deferred bridge start; only warns if bridge is unexpectedly not running after handshake.
- `packages/pike-lsp-server/src/tests/runtime/bridge-startup.test.ts`: regression tests for success and failure paths.

## Validation
- `bun test src/tests/runtime/bridge-startup.test.ts` ✅
- `bun test src/tests/runtime/server-runtime-progress.test.ts src/tests/runtime/server-runtime-workspace-folders.test.ts` ✅
- `bun test src/tests/runtime` ✅
- `bun run typecheck` (repo root) ✅
- `bun run build` (repo root) ✅
- `lsp_diagnostics` on modified files ✅ (no errors; one non-blocking hint in test file)

## Notes
- `packages/pike-lsp-server` local `bun run typecheck` reports existing workspace-reference TS6305 issues unrelated to this change.
- `packages/pike-lsp-server` local `bun run build` fails in prebuild due missing `scripts/build-roxen-data.ts` from package-local cwd; repository-root `bun run build` succeeds.

Closes #867