### PR TITLE
fix: group hover overload variants under main signature

### DIFF
--- a/packages/pike-lsp-server/src/features/navigation/hover.ts
+++ b/packages/pike-lsp-server/src/features/navigation/hover.ts
@@ -14,6 +14,22 @@ import { getWordRangeAtPosition } from '../utils/pike-identifier.js';
 import { Logger } from '@pike-lsp/core';
 import { getKeywordInfo } from './keywords.js';
 
+function collectSymbolsByName(symbols: PikeSymbol[], name: string): PikeSymbol[] {
+  const matches: PikeSymbol[] = [];
+
+  for (const symbol of symbols) {
+    if (symbol.name === name) {
+      matches.push(symbol);
+    }
+
+    if (symbol.children && symbol.children.length > 0) {
+      matches.push(...collectSymbolsByName(symbol.children, name));
+    }
+  }
+
+  return matches;
+}
+
 /**
  * Register hover handler.
  */
@@ -110,6 +126,28 @@ export function registerHoverHandler(
 
       if (!symbol) {
         return null;
+      }
+
+      if (symbol.kind === 'method') {
+        const overloadCandidates = collectSymbolsByName(cached.symbols, symbol.name)
+          .filter(s => s.kind === 'method');
+
+        if (overloadCandidates.length > 0) {
+          const mainSymbol = overloadCandidates.find(s => !(s.modifiers?.includes('variant') ?? false));
+          const variantSymbols = overloadCandidates.filter(s => s.modifiers?.includes('variant') ?? false);
+
+          if (mainSymbol) {
+            symbol = {
+              ...mainSymbol,
+              variants: variantSymbols,
+            } as PikeSymbol;
+          } else if (variantSymbols.length > 0) {
+            symbol = {
+              ...symbol,
+              variants: variantSymbols.filter(s => s !== symbol),
+            } as PikeSymbol;
+          }
+        }
       }
 
       // Build hover content

--- a/packages/pike-lsp-server/src/features/utils/hover-builder.ts
+++ b/packages/pike-lsp-server/src/features/utils/hover-builder.ts
@@ -359,6 +359,82 @@ function generatePikeDocsUrl(path: string): string {
     return `https://pike.lysator.liu.se/generated/manual/modref/ex/${urlPath}.html`;
 }
 
+function buildMethodSignature(symbol: PikeSymbol): string {
+    const symRecord = symbol as unknown as Record<string, unknown>;
+
+    if (symRecord['type'] && typeof symRecord['type'] === 'object') {
+        const typeRecord = symRecord['type'] as Record<string, unknown>;
+        if (typeRecord['kind'] === 'function' || typeRecord['kind'] === 'method') {
+            const returnType = typeRecord['returnType']
+                ? formatPikeType(typeRecord['returnType'])
+                : (typeRecord['returnType'] ?? 'void');
+
+            let argList = '';
+
+            if (symRecord['parameters'] && Array.isArray(symRecord['parameters'])) {
+                const params = symRecord['parameters'] as Array<{ name?: string; type?: string }>;
+                argList = params.map(p => {
+                    const type = p.type ?? 'mixed';
+                    const name = p.name ?? 'arg';
+                    return `${type} ${name}`;
+                }).join(', ');
+            } else {
+                const args = (typeRecord['argTypes'] ?? typeRecord['arguments']) as unknown[] | undefined;
+                if (args && args.length > 0) {
+                    argList = args.map((arg, i) => {
+                        if (typeof arg === 'object' && arg !== null) {
+                            const argObj = arg as Record<string, unknown>;
+                            const type = formatPikeType(argObj['type'] ?? arg);
+                            const name = (argObj['name'] as string) ?? `arg${i}`;
+                            return `${type} ${name}`;
+                        }
+                        return `${formatPikeType(arg)} arg${i}`;
+                    }).join(', ');
+                }
+            }
+
+            return `${returnType} ${symbol.name}(${argList})`;
+        }
+    }
+
+    if (symbol.type && symbol.type.kind === 'function') {
+        const funcType = symbol.type as PikeFunctionType;
+        const returnType = funcType.returnType ? formatPikeType(funcType.returnType) : 'void';
+
+        let argList = '';
+        const funcTypeRaw = symbol.type as unknown as Record<string, unknown>;
+        const args = (funcType.argTypes ?? funcTypeRaw['arguments']) as unknown[] | undefined;
+        if (args && args.length > 0) {
+            argList = args.map((arg, i) => {
+                if (typeof arg === 'object' && arg !== null) {
+                    const argObj = arg as Record<string, unknown>;
+                    const type = formatPikeType(argObj['type'] ?? arg);
+                    const name = (argObj['name'] as string) ?? `arg${i}`;
+                    return `${type} ${name}`;
+                }
+                return `${formatPikeType(arg)} arg${i}`;
+            }).join(', ');
+        }
+
+        return `${returnType} ${symbol.name}(${argList})`;
+    }
+
+    const returnType = formatPikeType(symRecord['returnType']);
+    const argNames = symRecord['argNames'] as string[] | undefined;
+    const argTypes = symRecord['argTypes'] as unknown[] | undefined;
+
+    let argList = '';
+    if (argTypes && argNames) {
+        argList = argTypes.map((t, i) => {
+            const type = formatPikeType(t);
+            const name = argNames[i] ?? `arg${i}`;
+            return `${type} ${name}`;
+        }).join(', ');
+    }
+
+    return `${returnType} ${symbol.name}(${argList})`;
+}
+
 /**
  * Build markdown content for hover.
  */
@@ -391,91 +467,20 @@ export function buildHoverContent(symbol: PikeSymbol, parentScope?: string): str
 
     // Build type signature using introspected type info if available
     if (symbol.kind === 'method') {
-        // Try introspected type first
-        const symRecord = symbol as unknown as Record<string, unknown>;
+        parts.push('```pike');
+        parts.push(buildMethodSignature(symbol));
+        parts.push('```');
 
-        // Check for test format: type: { kind: 'function', returnType: 'int' }, parameters: [...]
-        if (symRecord['type'] && typeof symRecord['type'] === 'object') {
-            const typeRecord = symRecord['type'] as Record<string, unknown>;
-            if (typeRecord['kind'] === 'function' || typeRecord['kind'] === 'method') {
-                const returnType = typeRecord['returnType']
-                    ? formatPikeType(typeRecord['returnType'])
-                    : (typeRecord['returnType'] ?? 'void');
-
-                let argList = '';
-
-                // Handle test format: parameters array
-                if (symRecord['parameters'] && Array.isArray(symRecord['parameters'])) {
-                    const params = symRecord['parameters'] as Array<{ name?: string; type?: string }>;
-                    argList = params.map(p => {
-                        const type = p.type ?? 'mixed';
-                        const name = p.name ?? 'arg';
-                        return `${type} ${name}`;
-                    }).join(', ');
-                }
-                // Handle introspection format: argTypes or arguments
-                else {
-                    const args = (typeRecord['argTypes'] ?? typeRecord['arguments']) as unknown[] | undefined;
-                    if (args && args.length > 0) {
-                        argList = args.map((arg, i) => {
-                            if (typeof arg === 'object' && arg !== null) {
-                                const argObj = arg as Record<string, unknown>;
-                                const type = formatPikeType(argObj['type'] ?? arg);
-                                const name = (argObj['name'] as string) ?? `arg${i}`;
-                                return `${type} ${name}`;
-                            }
-                            return `${formatPikeType(arg)} arg${i}`;
-                        }).join(', ');
-                    }
-                }
-
+        const variants = sym['variants'] as PikeSymbol[] | undefined;
+        if (variants && variants.length > 0) {
+            parts.push('');
+            parts.push('### Variants');
+            parts.push('');
+            for (const variant of variants) {
                 parts.push('```pike');
-                parts.push(`${returnType} ${symbol.name}(${argList})`);
+                parts.push(buildMethodSignature(variant));
                 parts.push('```');
             }
-        } else if (symbol.type && symbol.type.kind === 'function') {
-            const funcType = symbol.type as PikeFunctionType;
-            const returnType = funcType.returnType ? formatPikeType(funcType.returnType) : 'void';
-
-            let argList = '';
-            // Handle both 'argTypes' (from types.ts interface) and 'arguments' (from introspection)
-            const funcTypeRaw = symbol.type as unknown as Record<string, unknown>;
-            const args = (funcType.argTypes ?? funcTypeRaw['arguments']) as unknown[] | undefined;
-            if (args && args.length > 0) {
-                argList = args.map((arg, i) => {
-                    // Handle introspection format: {type: "string", name: "arg1"}
-                    // or argTypes format: PikeType object
-                    if (typeof arg === 'object' && arg !== null) {
-                        const argObj = arg as Record<string, unknown>;
-                        const type = formatPikeType(argObj['type'] ?? arg);
-                        const name = (argObj['name'] as string) ?? `arg${i}`;
-                        return `${type} ${name}`;
-                    }
-                    return `${formatPikeType(arg)} arg${i}`;
-                }).join(', ');
-            }
-
-            parts.push('```pike');
-            parts.push(`${returnType} ${symbol.name}(${argList})`);
-            parts.push('```');
-        } else {
-            // Fallback to old parse format
-            const returnType = formatPikeType(sym['returnType']);
-            const argNames = sym['argNames'] as string[] | undefined;
-            const argTypes = sym['argTypes'] as unknown[] | undefined;
-
-            let argList = '';
-            if (argTypes && argNames) {
-                argList = argTypes.map((t, i) => {
-                    const type = formatPikeType(t);
-                    const name = argNames[i] ?? `arg${i}`;
-                    return `${type} ${name}`;
-                }).join(', ');
-            }
-
-            parts.push('```pike');
-            parts.push(`${returnType} ${symbol.name}(${argList})`);
-            parts.push('```');
         }
     } else if (symbol.kind === 'variable' || symbol.kind === 'constant') {
         // Try introspected type first

--- a/packages/pike-lsp-server/src/tests/hover-variant-prioritization.test.ts
+++ b/packages/pike-lsp-server/src/tests/hover-variant-prioritization.test.ts
@@ -1,35 +1,10 @@
-/**
- * Hover Variant Prioritization Tests
- *
- * TDD tests for fixing hover to show main signature instead of variant.
- * Issue: Hover on functions shows "variant" signature instead of the main documented signature.
- *
- * Root Cause: Function variants are parsed as separate symbols; hover returns first match
- * without prioritizing main signature.
- *
- * Fix: Show main (non-variant) signature first at top, add "### Variants" section below.
- *
- * Run with: bun test src/tests/hover-variant-prioritization.test.ts
- */
-
 import { describe, it } from 'bun:test';
 import * as assert from 'node:assert/strict';
 import { buildHoverContent } from '../features/utils/hover-builder.js';
 import type { PikeSymbol } from '@pike-lsp/pike-bridge';
 
 describe('Hover - Variant Prioritization', () => {
-
-    /**
-     * Test: Main signature should be shown first, not variant
-     * GIVEN: A function with both main signature and variant
-     * WHEN: Hover content is built
-     * THEN: Main signature should appear at top, variants in separate section
-     */
-    it('should show main signature before variant signature', () => {
-        // This simulates Crypto.RSA->generate_key which has multiple signatures:
-        // - Main: generate_key(int(128..) bits, void|int|Gmp.mpz e)
-        // - Variant: generate_key(int bits, function:mixed rnd)
-
+    it('shows main signature with variants grouped below', () => {
         const mainSignature: PikeSymbol = {
             name: 'generate_key',
             kind: 'method',
@@ -58,41 +33,34 @@ describe('Hover - Variant Prioritization', () => {
             }
         };
 
-        // Build hover content for main signature
-        const mainHover = buildHoverContent(mainSignature, 'Crypto.RSA');
+        const hover = buildHoverContent(
+            {
+                ...mainSignature,
+                variants: [variantSignature]
+            } as PikeSymbol,
+            'Crypto.RSA'
+        );
 
-        assert.ok(mainHover, 'Should build hover content for main signature');
-
-        // Main signature should be shown first
-        const mainLines = mainHover!.split('\n');
-        const codeBlockStart = mainLines.findIndex(line => line.trim() === '```pike');
-
-        assert.ok(codeBlockStart >= 0, 'Should have code block');
-
-        // The signature should contain the type range
-        const signature = mainLines[codeBlockStart + 1];
-        assert.ok(signature, 'Should have signature line');
-
-        console.log('  Main signature hover:');
-        console.log(mainHover);
-
-        // Build hover content for variant
-        const variantHover = buildHoverContent(variantSignature, 'Crypto.RSA');
-
-        assert.ok(variantHover, 'Should build hover content for variant');
-
-        console.log('  Variant signature hover:');
-        console.log(variantHover);
-
-        // Variant should be marked
-        assert.ok(variantHover!.includes('variant') || variantSignature.modifiers?.includes('variant'),
-            'Variant should have variant modifier or be marked as such');
+        assert.ok(hover, 'Should build hover content');
+        assert.strictEqual(
+            hover,
+            [
+                '```pike',
+                'program generate_key(int(128..65536) arg0, mixed arg1)',
+                '```',
+                '',
+                '### Variants',
+                '',
+                '```pike',
+                'program generate_key(int arg0, function : mixed arg1)',
+                '```',
+                '',
+                '[Online Documentation](https://pike.lysator.liu.se/generated/manual/modref/ex/predef_3A_3A/Crypto/RSA/generate_key.html)'
+            ].join('\n')
+        );
     });
 
-    /**
-     * Test: Hover on regular function (no variants)
-     */
-    it('should show normal function signature correctly', () => {
+    it('shows normal function signature without variants section', () => {
         const symbol: PikeSymbol = {
             name: 'my_function',
             kind: 'method',
@@ -110,49 +78,14 @@ describe('Hover - Variant Prioritization', () => {
         const hover = buildHoverContent(symbol);
 
         assert.ok(hover, 'Should build hover content');
-
-        console.log('  Normal function hover:');
-        console.log(hover);
-
-        // Should contain the function name
-        assert.ok(hover!.includes('my_function'), 'Should include function name');
-
-        // Should contain code block
-        assert.ok(hover!.includes('```pike'), 'Should include code block');
-    });
-
-    /**
-     * Test: Variants should be grouped under parent symbol
-     * This is a placeholder for the future enhancement where we group variants
-     */
-    it('TODO: should group variants under main signature', () => {
-        // This will require modifications to Resolution.pike to group variants
-        // For now, this test documents the desired behavior
-
-        const mainSignature: PikeSymbol = {
-            name: 'generate_key',
-            kind: 'method',
-            modifiers: [],
-            type: {
-                kind: 'function',
-                returnType: { kind: 'program' },
-                argTypes: [
-                    { kind: 'int', min: '128', max: '65536' },
-                    { kind: 'mixed' }
-                ]
-            },
-            // Future: variants array
-            // variants: [variantSignature]
-        };
-
-        const hover = buildHoverContent(mainSignature, 'Crypto.RSA');
-
-        assert.ok(hover, 'Should build hover content');
-
-        // Future: should have "### Variants" section
-        // assert.ok(hover!.includes('### Variants'), 'Should have variants section');
-
-        console.log('  Current hover output:');
-        console.log(hover);
+        assert.strictEqual(
+            hover,
+            [
+                '```pike',
+                'int my_function(string arg0, int arg1)',
+                '```'
+            ].join('\n')
+        );
+        assert.ok(!hover!.includes('### Variants'), 'Should not add variants section when there are no variants');
     });
 });


### PR DESCRIPTION
## Summary
- Select the main non-variant method symbol for hover and attach same-name variant overloads from the cached symbol tree.
- Render overloads in hover markdown under a dedicated `### Variants` section while keeping the primary signature first.
- Replace TODO/shape-only hover variant tests with exact output assertions for grouped and non-grouped cases.

## Verification
- `bun test src/tests/hover-variant-prioritization.test.ts`
- `bun test src/tests/hover-builder.test.ts`
- `bunx tsc --build` (workspace build needed for hook/runtime resolution)

Closes #874