### PR TITLE
fix: resolve recursive type hierarchy chains

### DIFF
--- a/packages/pike-lsp-server/src/features/hierarchy.ts
+++ b/packages/pike-lsp-server/src/features/hierarchy.ts
@@ -854,48 +854,59 @@ export function registerHierarchyHandlers(
         return results; // Empty array = no hierarchy found
       }
 
-      // Search all documents for classes that inherit from this class
-      const entries = Array.from(documentCache.entries());
-      for (const [docUri, cached] of entries) {
-        for (const symbol of cached.symbols) {
+      const inheritanceIndex = new Map<
+        string,
+        Array<{ name: string; uri: string; line: number }>
+      >();
+
+      const addDirectSubtype = (parentName: string, subtype: { name: string; uri: string; line: number }) => {
+        const existing = inheritanceIndex.get(parentName) ?? [];
+        existing.push(subtype);
+        inheritanceIndex.set(parentName, existing);
+      };
+
+      const indexDocumentSymbols = (docUri: string, symbols: PikeSymbol[]) => {
+        for (const symbol of symbols) {
           if (symbol.kind !== 'inherit') {
             validateSymbolKind(symbol, 'subtypes traversal');
             continue;
           }
 
           const inheritedName = symbol.classname ?? symbol.name;
-          if (inheritedName !== className) continue;
+          if (!inheritedName) {
+            continue;
+          }
 
-          // Find the class that contains this inherit
           const inheritLine = symbol.position ? Math.max(0, (symbol.position.line ?? 1) - 1) : 0;
 
           // Find the class that declared this inherit (closest class at or before inherit line)
-          const containingClass = cached.symbols
-            .filter(
-              s => s.kind === 'class' && s.position && (s.position.line ?? 0) - 1 <= inheritLine
-            )
+          const containingClass = symbols
+            .filter(s => s.kind === 'class' && s.position && (s.position.line ?? 0) - 1 <= inheritLine)
             .sort((a, b) => (b.position?.line ?? 0) - (a.position?.line ?? 0))[0];
 
-          if (containingClass) {
-            const classLine = Math.max(0, (containingClass.position?.line ?? 1) - 1);
-            results.push({
-              name: containingClass.name,
-              kind: SymbolKind.Class,
-              uri: docUri,
-              range: {
-                start: { line: classLine, character: 0 },
-                end: { line: classLine, character: containingClass.name.length },
-              },
-              selectionRange: {
-                start: { line: classLine, character: 0 },
-                end: { line: classLine, character: containingClass.name.length },
-              },
-            });
+          if (!containingClass) {
+            continue;
           }
+
+          const containingClassName = containingClass.name;
+          if (!containingClassName) {
+            continue;
+          }
+
+          const classLine = Math.max(0, (containingClass.position?.line ?? 1) - 1);
+          addDirectSubtype(inheritedName, {
+            name: containingClassName,
+            uri: docUri,
+            line: classLine,
+          });
         }
+      };
+
+      const entries = Array.from(documentCache.entries());
+      for (const [docUri, cachedDoc] of entries) {
+        indexDocumentSymbols(docUri, cachedDoc.symbols);
       }
 
-      // Phase 6: Search workspace files not in cache
       if (services.workspaceScanner?.isReady()) {
         const cachedUris = new Set(documentCache.keys());
         const uncachedFiles = services.workspaceScanner.getUncachedFiles(cachedUris);
@@ -906,62 +917,47 @@ export function registerHierarchyHandlers(
             const content = await fs.readFile(filePath, 'utf-8');
             const parsed = await services.bridge?.bridge?.analyze(content, ['parse'], filePath);
             const parsedSymbols = parsed?.result?.parse?.symbols ?? [];
-
-            for (const symbol of parsedSymbols) {
-              if (symbol.kind !== 'inherit') {
-                continue;
-              }
-
-              const inheritedName = symbol.classname ?? symbol.name;
-              if (inheritedName !== className) {
-                continue;
-              }
-
-              const inheritLine = symbol.position ? Math.max(0, (symbol.position.line ?? 1) - 1) : 0;
-
-              const containingClass = parsedSymbols
-                .filter(
-                  s => s.kind === 'class' && s.position && (s.position.line ?? 0) - 1 <= inheritLine
-                )
-                .sort((a, b) => (b.position?.line ?? 0) - (a.position?.line ?? 0))[0];
-
-              if (!containingClass) {
-                continue;
-              }
-
-              const containingClassName = containingClass.name;
-              if (!containingClassName) {
-                continue;
-              }
-
-              const alreadyAdded = results.some(
-                r => r.uri === fileInfo.uri && r.name === containingClassName
-              );
-
-              if (alreadyAdded) {
-                continue;
-              }
-
-              const classLine = Math.max(0, (containingClass.position?.line ?? 1) - 1);
-              results.push({
-                name: containingClassName,
-                kind: SymbolKind.Class,
-                uri: fileInfo.uri,
-                range: {
-                  start: { line: classLine, character: 0 },
-                  end: { line: classLine, character: containingClassName.length },
-                },
-                selectionRange: {
-                  start: { line: classLine, character: 0 },
-                  end: { line: classLine, character: containingClassName.length },
-                },
-              });
-            }
+            indexDocumentSymbols(fileInfo.uri, parsedSymbols);
           } catch (err) {
             log.debug(`Failed to read uncached file: ${fileInfo.uri}`, {
               error: err instanceof Error ? err.message : String(err),
             });
           }
+        }
+      }
+
+      const seenParents = new Set<string>();
+      const seenResults = new Set<string>();
+      const queue = [className];
+
+      while (queue.length > 0) {
+        const parent = queue.shift()!;
+        if (seenParents.has(parent)) {
+          continue;
+        }
+        seenParents.add(parent);
+
+        const directSubtypes = inheritanceIndex.get(parent) ?? [];
+        for (const subtype of directSubtypes) {
+          const subtypeKey = `${subtype.uri}:${subtype.name}`;
+          if (!seenResults.has(subtypeKey)) {
+            seenResults.add(subtypeKey);
+            results.push({
+              name: subtype.name,
+              kind: SymbolKind.Class,
+              uri: subtype.uri,
+              range: {
+                start: { line: subtype.line, character: 0 },
+                end: { line: subtype.line, character: subtype.name.length },
+              },
+              selectionRange: {
+                start: { line: subtype.line, character: 0 },
+                end: { line: subtype.line, character: subtype.name.length },
+              },
+            });
+          }
+
+          queue.push(subtype.name);
         }
       }
 

--- a/packages/pike-lsp-server/src/tests/hierarchy/type-hierarchy-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/hierarchy/type-hierarchy-provider.test.ts
@@ -16,11 +16,21 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import {
     TypeHierarchyItem,
     Range,
     DiagnosticSeverity
 } from 'vscode-languageserver/node.js';
+import type { DocumentCacheEntry } from '../../core/types.js';
+import { registerHierarchyHandlers } from '../../features/hierarchy.js';
+import {
+    createMockConnection,
+    createMockDocuments,
+    createMockServices,
+    makeCacheEntry,
+    sym,
+} from '../helpers/mock-services.js';
 
 // Define TypeHierarchyDirection locally (not exported from vscode-languageserver in this version)
 const TypeHierarchyDirection = {
@@ -954,31 +964,126 @@ class MyClass {
      * Performance
      */
     describe('Performance', () => {
-        it('should build hierarchy quickly for small codebase', () => {
-            const code = `class Base { }
-class D1 { inherit Base; }
-class D2 { inherit Base; }`;
+        it('should recursively resolve supertypes in a deep inheritance chain', async () => {
+            const uri = 'file:///test/deep-chain.pike';
+            const classCount = 20;
+            const symbols: Array<ReturnType<typeof sym>> = [];
 
-            const start = Date.now();
-            // TODO: Build type hierarchy
-            const elapsed = Date.now() - start;
+            for (let level = 0; level < classCount; level++) {
+                const className = `Level${level}`;
+                const classLine = level * 2 + 1;
 
-            assert.ok(elapsed < 200, `Should build hierarchy in < 200ms, took ${elapsed}ms`);
+                symbols.push(sym(className, 'class', {
+                    position: { line: classLine, column: 0 },
+                }));
+
+                if (level > 0) {
+                    symbols.push(sym(`Level${level - 1}`, 'inherit', {
+                        classname: `Level${level - 1}`,
+                        position: { line: classLine + 1, column: 4 },
+                    }));
+                }
+            }
+
+            const code = Array.from({ length: classCount }, (_, level) => {
+                if (level === 0) {
+                    return `class Level0 { }`;
+                }
+                return `class Level${level} { inherit Level${level - 1}; }`;
+            }).join('\n');
+
+            const doc = TextDocument.create(uri, 'pike', 1, code);
+            const documents = createMockDocuments(new Map([[uri, doc]]));
+            const services = createMockServices({
+                cacheEntries: new Map<string, DocumentCacheEntry>([
+                    [uri, makeCacheEntry({ symbols })],
+                ]),
+            });
+            const connection = createMockConnection();
+            registerHierarchyHandlers(connection as any, services as any, documents as any);
+
+            const result = await connection.typeHierarchySupertypesHandler({
+                item: {
+                    name: 'Level19',
+                    kind: 5,
+                    uri,
+                    range: { start: { line: 38, character: 0 }, end: { line: 38, character: 7 } },
+                    selectionRange: { start: { line: 38, character: 0 }, end: { line: 38, character: 7 } },
+                    detail: 'class Level19',
+                },
+                direction: 'parents',
+            });
+
+            assert.ok(Array.isArray(result), 'Supertypes result should be an array');
+            assert.ok(result !== null, 'Supertypes result should not be null');
+            assert.strictEqual(
+                result.length,
+                classCount - 1,
+                'Deep chain should return all ancestors recursively'
+            );
+            assert.strictEqual(result[0]?.name, 'Level18', 'First supertype should be direct parent');
+            assert.strictEqual(result[result.length - 1]?.name, 'Level0', 'Last supertype should be root');
         });
 
-        it('should handle large number of classes', () => {
-            // Generate 100 classes
-            const lines: string[] = ['class Base { }'];
-            for (let i = 0; i < 100; i++) {
-                lines.push(`class Derived${i} { inherit Base; }`);
+        it('should recursively resolve subtypes in a deep inheritance chain', async () => {
+            const uri = 'file:///test/deep-chain-subtypes.pike';
+            const classCount = 20;
+            const symbols: Array<ReturnType<typeof sym>> = [];
+
+            for (let level = 0; level < classCount; level++) {
+                const className = `Level${level}`;
+                const classLine = level * 2 + 1;
+
+                symbols.push(sym(className, 'class', {
+                    position: { line: classLine, column: 0 },
+                }));
+
+                if (level > 0) {
+                    symbols.push(sym(`Level${level - 1}`, 'inherit', {
+                        classname: `Level${level - 1}`,
+                        position: { line: classLine + 1, column: 4 },
+                    }));
+                }
             }
-            const code = lines.join('\n');
 
-            const start = Date.now();
-            // TODO: Build hierarchy
-            const elapsed = Date.now() - start;
+            const code = Array.from({ length: classCount }, (_, level) => {
+                if (level === 0) {
+                    return `class Level0 { }`;
+                }
+                return `class Level${level} { inherit Level${level - 1}; }`;
+            }).join('\n');
 
-            assert.ok(elapsed < 500, `Should handle 100 classes in < 500ms, took ${elapsed}ms`);
+            const doc = TextDocument.create(uri, 'pike', 1, code);
+            const documents = createMockDocuments(new Map([[uri, doc]]));
+            const services = createMockServices({
+                cacheEntries: new Map<string, DocumentCacheEntry>([
+                    [uri, makeCacheEntry({ symbols })],
+                ]),
+            });
+            const connection = createMockConnection();
+            registerHierarchyHandlers(connection as any, services as any, documents as any);
+
+            const result = await connection.typeHierarchySubtypesHandler({
+                item: {
+                    name: 'Level0',
+                    kind: 5,
+                    uri,
+                    range: { start: { line: 0, character: 0 }, end: { line: 0, character: 6 } },
+                    selectionRange: { start: { line: 0, character: 0 }, end: { line: 0, character: 6 } },
+                    detail: 'class Level0',
+                },
+                direction: 'children',
+            });
+
+            assert.ok(Array.isArray(result), 'Subtypes result should be an array');
+            assert.ok(result !== null, 'Subtypes result should not be null');
+            assert.strictEqual(
+                result.length,
+                classCount - 1,
+                'Deep chain should return all descendants recursively'
+            );
+            assert.strictEqual(result[0]?.name, 'Level1', 'First subtype should be direct child');
+            assert.strictEqual(result[result.length - 1]?.name, 'Level19', 'Last subtype should be leaf');
         });
 
         it('should cache type hierarchy results', () => {


### PR DESCRIPTION
## Summary
- make `typeHierarchy/subtypes` recursively traverse inheritance descendants instead of returning only direct children
- keep subtype discovery across cached and uncached workspace files by indexing inherit symbols once, then traversing transitively
- replace TODO placeholder tests in `type-hierarchy-provider.test.ts` with concrete deep-chain supertypes/subtypes assertions that validate recursive behavior

## Verification
- bun test src/tests/hierarchy/type-hierarchy-provider.test.ts
- bun test src/tests/hierarchy/cross-file-hierarchy.test.ts
- bun test src/tests/hierarchy/workspace-inheritance.test.ts
- bun run typecheck
- bun run build

Closes #873