### PR TITLE
fix: validate workspace symbol line ranges

### DIFF
--- a/packages/pike-lsp-server/src/tests/symbols/workspace-symbol-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/symbols/workspace-symbol-provider.test.ts
@@ -14,7 +14,6 @@
  */
 
 import { describe, it, expect, beforeEach } from 'bun:test';
-import { SymbolKind } from 'vscode-languageserver/node.js';
 import { WorkspaceIndex } from '../../workspace-index.js';
 
 /**
@@ -25,7 +24,11 @@ class TestableWorkspaceIndex extends WorkspaceIndex {
     /**
      * Add a document with symbols directly (for testing without bridge)
      */
-    addTestDocument(uri: string, symbols: Array<{ name: string; kind: string; line: number; parentName?: string }>): void {
+    addTestDocument(
+        uri: string,
+        symbols: Array<{ name: string; kind: string; line: number; parentName?: string }>,
+        lineCount?: number
+    ): void {
         const docSymbols = symbols.map(s => ({
             name: s.name,
             kind: s.kind,
@@ -40,7 +43,8 @@ class TestableWorkspaceIndex extends WorkspaceIndex {
             uri,
             symbols: docSymbols,
             version: 1,
-            lastModified: Date.now()
+            lastModified: Date.now(),
+            lineCount,
         });
 
         // Add to lookup
@@ -52,7 +56,8 @@ class TestableWorkspaceIndex extends WorkspaceIndex {
                 name: symbol.name,
                 kind: symbol.kind,
                 uri,
-                line: symbol.line,
+                line: symbol.position.line,
+                maxLine: lineCount,
                 parentName: (symbol as { parentName?: string }).parentName
             };
             let entriesByUri = symbolLookup.get(nameLower);
@@ -259,6 +264,60 @@ describe('Workspace Symbol Provider', () => {
             expect(stats.documents).toBe(1);
             expect(stats.symbols).toBe(1);
         });
+
+        it('clamps out-of-range lines to document upper bound', () => {
+            index.addTestDocument(
+                'file:///test.pike',
+                [{ name: 'tooHigh', kind: 'method', line: 999 }],
+                12
+            );
+
+            const results = index.searchSymbols('tooHigh');
+
+            expect(results.length).toBe(1);
+            expect(results[0].location.range.start.line).toBe(11);
+            expect(results[0].location.range.end.line).toBe(11);
+        });
+
+        it('applies the same upper bound protection for empty-query results', () => {
+            index.addTestDocument(
+                'file:///test-empty-query.pike',
+                [{ name: 'emptyQuerySymbol', kind: 'method', line: 999 }],
+                3
+            );
+
+            const results = index.searchSymbols('');
+            const symbol = results.find(result => result.name === 'emptyQuerySymbol');
+
+            expect(symbol).toBeDefined();
+            expect(symbol!.location.range.start.line).toBe(2);
+            expect(symbol!.location.range.end.line).toBe(2);
+        });
+
+        it('normalizes non-finite and non-integer lines to a safe range', () => {
+            index.addTestDocument(
+                'file:///test-numbers.pike',
+                [
+                    { name: 'nanSymbol', kind: 'method', line: Number.NaN },
+                    { name: 'infinitySymbol', kind: 'method', line: Number.POSITIVE_INFINITY },
+                    { name: 'floatSymbol', kind: 'method', line: 2.5 }
+                ],
+                8
+            );
+
+            const nanResult = index.searchSymbols('nanSymbol');
+            const infinityResult = index.searchSymbols('infinitySymbol');
+            const floatResult = index.searchSymbols('floatSymbol');
+
+            expect(nanResult.length).toBe(1);
+            expect(nanResult[0].location.range.start.line).toBe(0);
+
+            expect(infinityResult.length).toBe(1);
+            expect(infinityResult[0].location.range.start.line).toBe(0);
+
+            expect(floatResult.length).toBe(1);
+            expect(floatResult[0].location.range.start.line).toBe(0);
+        });
     });
 
     /**
@@ -268,7 +327,7 @@ describe('Workspace Symbol Provider', () => {
         it('should search many symbols quickly', () => {
             // Add 1000 symbols
             for (let i = 0; i < 10; i++) {
-                const symbols = [];
+                const symbols: Array<{ name: string; kind: string; line: number }> = [];
                 for (let j = 0; j < 100; j++) {
                     symbols.push({ name: `symbol${i * 100 + j}`, kind: 'method', line: j + 1 });
                 }

--- a/packages/pike-lsp-server/src/workspace-index.ts
+++ b/packages/pike-lsp-server/src/workspace-index.ts
@@ -21,6 +21,7 @@ interface IndexedDocument {
     symbols: Array<FlattenedSymbolEntry | PikeSymbol>;
     version: number;
     lastModified: number;
+    lineCount?: number;
 }
 
 interface FlattenedSymbolEntry {
@@ -36,6 +37,7 @@ interface SymbolEntry {
     kind: string;
     uri: string;
     line: number;
+    maxLine?: number;
     parentName?: string;  // WS-001: Parent symbol name for containerName field
 }
 
@@ -208,6 +210,31 @@ export class WorkspaceIndex {
         return flat;
     }
 
+    private countLines(content: string): number {
+        if (content.length === 0) {
+            return 1;
+        }
+        return content.split('\n').length;
+    }
+
+    private normalizeLineToZeroBased(line: number | undefined, maxLineCount?: number): number {
+        if (typeof line !== 'number' || !Number.isFinite(line) || !Number.isInteger(line)) {
+            return 0;
+        }
+
+        let oneBasedLine = Math.max(1, line);
+        if (
+            typeof maxLineCount === 'number'
+            && Number.isFinite(maxLineCount)
+            && Number.isInteger(maxLineCount)
+            && maxLineCount > 0
+        ) {
+            oneBasedLine = Math.min(oneBasedLine, maxLineCount);
+        }
+
+        return oneBasedLine - 1;
+    }
+
     /**
      * Index a single document
      */
@@ -223,6 +250,7 @@ export class WorkspaceIndex {
             const result = await this.bridge.analyze(content, ['parse'], filename);
             const parsedSymbols = result.result?.parse?.symbols ?? [];
             const symbols = this.flattenSymbols(parsedSymbols);
+            const lineCount = this.countLines(content);
 
             // Remove old entries from lookup
             const existing = this.documents.get(uri);
@@ -236,10 +264,11 @@ export class WorkspaceIndex {
                 symbols,
                 version,
                 lastModified: Date.now(),
+                lineCount,
             });
 
             // Add to lookup
-            this.addToLookup(uri, symbols);
+            this.addToLookup(uri, symbols, lineCount);
 
             // PERF-430: Invalidate search cache when document changes
             this.searchCache.clear();
@@ -297,7 +326,7 @@ export class WorkspaceIndex {
                     const symbol = normalizedEntry.symbol;
                     // Skip symbols with null names
                     if (!symbol.name) continue;
-                    results.push(this.toSymbolInformation(symbol, uri, normalizedEntry.parentName));
+                    results.push(this.toSymbolInformation(symbol, uri, normalizedEntry.parentName, doc.lineCount));
                     if (results.length >= limit) {
                         return results;
                     }
@@ -352,8 +381,8 @@ export class WorkspaceIndex {
                     location: {
                         uri: entry.uri,
                         range: {
-                            start: { line: Math.max(0, entry.line - 1), character: 0 },
-                            end: { line: Math.max(0, entry.line - 1), character: entry.name.length },
+                            start: { line: this.normalizeLineToZeroBased(entry.line, entry.maxLine), character: 0 },
+                            end: { line: this.normalizeLineToZeroBased(entry.line, entry.maxLine), character: entry.name.length },
                         },
                     },
                 };
@@ -546,7 +575,7 @@ export class WorkspaceIndex {
             const chunkReadStart = performance.now();
 
             // PERF-008: Read only this chunk (lazy loading)
-            const chunkData: Array<{ code: string; filename: string; lastModified: number }> = [];
+            const chunkData: Array<{ code: string; filename: string; lastModified: number; lineCount: number }> = [];
             for (const fileInfo of chunk) {
                 try {
                     const content = await readFile(fileInfo.path, 'utf-8');
@@ -554,6 +583,7 @@ export class WorkspaceIndex {
                         code: content,
                         filename: fileInfo.path,
                         lastModified: fileInfo.lastModified,
+                        lineCount: this.countLines(content),
                     });
                 } catch {
                     // Skip files that can't be read
@@ -606,10 +636,11 @@ export class WorkspaceIndex {
                         symbols,
                         version: 1,
                         lastModified: fileInfo.lastModified,
+                        lineCount: fileInfo.lineCount,
                     });
 
                     // Add to lookup
-                    this.addToLookup(uri, symbols);
+                    this.addToLookup(uri, symbols, fileInfo.lineCount);
                     indexed++;
                 }
 
@@ -647,10 +678,11 @@ export class WorkspaceIndex {
                             symbols,
                             version: 1,
                             lastModified: fileData.lastModified,
+                            lineCount: fileData.lineCount,
                         });
 
                         // Add to lookup
-                        this.addToLookup(uri, symbols);
+                        this.addToLookup(uri, symbols, fileData.lineCount);
                         indexed++;
                     } catch {
                         // Skip files that fail to parse
@@ -723,7 +755,7 @@ export class WorkspaceIndex {
 
     // Private helpers
 
-    private addToLookup(uri: string, symbols: FlattenedSymbolEntry[]): void {
+    private addToLookup(uri: string, symbols: FlattenedSymbolEntry[], maxLineCount?: number): void {
         let symbolNames = this.uriToSymbols.get(uri);
         if (!symbolNames) {
             symbolNames = new Set<string>();
@@ -745,6 +777,9 @@ export class WorkspaceIndex {
                 uri,
                 line: symbol.position?.line ?? 1,
             };
+            if (typeof maxLineCount === 'number') {
+                entry.maxLine = maxLineCount;
+            }
             if (entryData.parentName !== undefined) {
                 entry.parentName = entryData.parentName;
             }
@@ -856,8 +891,13 @@ export class WorkspaceIndex {
         return files;
     }
 
-    private toSymbolInformation(symbol: PikeSymbol, uri: string, parentName?: string): SymbolInformation {
-        const line = Math.max(0, (symbol.position?.line ?? 1) - 1);
+    private toSymbolInformation(
+        symbol: PikeSymbol,
+        uri: string,
+        parentName?: string,
+        maxLineCount?: number
+    ): SymbolInformation {
+        const line = this.normalizeLineToZeroBased(symbol.position?.line, maxLineCount);
 
         const result: SymbolInformation = {
             name: symbol.name,


### PR DESCRIPTION
## Summary
- add workspace symbol line normalization that rejects non-finite/non-integer values and clamps to the document line upper bound when available
- thread document line counts through indexing so both indexed-query and empty-query symbol responses produce safe ranges
- add regression tests proving out-of-range and invalid line values cannot produce invalid LSP ranges

## Verification
- bun test src/tests/symbols/workspace-symbol-provider.test.ts
- pre-commit fast regression suite (bridge/server/pike-compile) passed during commit hook

Closes #879