### PR TITLE
fix: log cancellation bridge failures for completion/query engine

### DIFF
--- a/packages/pike-lsp-server/src/features/editing/completion.ts
+++ b/packages/pike-lsp-server/src/features/editing/completion.ts
@@ -179,7 +179,13 @@ export function registerCompletionHandlers(
       let cancelledByToken = false;
       const cancellationDisposable = cancellationToken?.onCancellationRequested(() => {
         cancelledByToken = true;
-        void bridge.engineCancelRequest({ requestId }).catch(() => undefined);
+        void bridge.engineCancelRequest({ requestId }).catch(error => {
+          logger.warn('Completion cancellation request failed', {
+            uri,
+            requestId,
+            error,
+          });
+        });
       });
       const clearInFlight = (): void => {
         if (inFlightCompletionRequests.get(uri) === requestId) {

--- a/packages/pike-lsp-server/src/features/navigation/query-engine.ts
+++ b/packages/pike-lsp-server/src/features/navigation/query-engine.ts
@@ -80,7 +80,14 @@ export async function queryNavigationLocations(
   let cancelled = false;
   const cancellationDisposable = cancellationToken?.onCancellationRequested(() => {
     cancelled = true;
-    void bridge.engineCancelRequest({ requestId }).catch(() => undefined);
+    void bridge.engineCancelRequest({ requestId }).catch(error => {
+      services.logger.warn('Navigation cancellation request failed', {
+        feature,
+        uri,
+        requestId,
+        error,
+      });
+    });
   });
 
   try {

--- a/packages/pike-lsp-server/src/tests/editing/completion-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/editing/completion-provider.test.ts
@@ -84,11 +84,11 @@ function createMockConnection(): MockConnection {
 
 /** Silent logger */
 const silentLogger = {
-  debug: () => {},
-  info: () => {},
-  warn: () => {},
-  error: () => {},
-  log: () => {},
+  debug: (..._args: unknown[]) => {},
+  info: (..._args: unknown[]) => {},
+  warn: (..._args: unknown[]) => {},
+  error: (..._args: unknown[]) => {},
+  log: (..._args: unknown[]) => {},
 };
 
 /** Build a minimal DocumentCacheEntry */
@@ -206,6 +206,7 @@ interface SetupOptions {
   noBridge?: boolean;
   bridge?: any;
   noCache?: boolean;
+  logger?: typeof silentLogger;
 }
 
 /**
@@ -240,7 +241,7 @@ function setup(opts: SetupOptions) {
     bridge: opts.noBridge
       ? null
       : (opts.bridge ?? createMockBridge(opts.bridgeContext, opts.queryItems)),
-    logger: silentLogger,
+    logger: opts.logger ?? silentLogger,
     documentCache,
     stdlibIndex: opts.stdlibModules ? createMockStdlibIndex(opts.stdlibModules) : null,
     includeResolver: opts.includeSymbols ? {} : null,
@@ -259,11 +260,21 @@ function setup(opts: SetupOptions) {
   registerCompletionHandlers(conn as any, services as any, documents as any);
 
   return {
-    complete: (line: number, character: number) =>
-      conn.completionHandler({
-        textDocument: { uri },
-        position: { line, character },
-      }),
+    complete: (
+      line: number,
+      character: number,
+      cancellationToken?: {
+        isCancellationRequested: boolean;
+        onCancellationRequested: (callback: () => void) => { dispose: () => void };
+      }
+    ) =>
+      (conn.completionHandler as any)(
+        {
+          textDocument: { uri },
+          position: { line, character },
+        },
+        cancellationToken
+      ),
     resolve: (item: CompletionItem) => conn.completionResolveHandler(item),
     uri,
   };
@@ -378,6 +389,68 @@ describe('Completion Provider', () => {
 
       await Promise.all([first, second]);
       expect(cancelled.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('logs warning when cancellation bridge call fails', async () => {
+      const cancellationError = new Error('cancel bridge failed');
+      const warnings: Array<{ message: string; payload: Record<string, unknown> }> = [];
+      const bridge = {
+        isRunning: () => true,
+        engineCancelRequest: async () => {
+          throw cancellationError;
+        },
+        engineQuery: async () => {
+          await new Promise(resolve => setTimeout(resolve, 10));
+          return { result: { result: { status: 'stub' } } };
+        },
+        getCompletionContext: async (): Promise<PikeCompletionContext> => ({
+          context: 'identifier',
+          objectName: '',
+          prefix: '',
+          operator: '',
+        }),
+      };
+      const logger = {
+        ...silentLogger,
+        warn: (...args: unknown[]) => {
+          const message = typeof args[0] === 'string' ? args[0] : String(args[0]);
+          const payload =
+            args[1] && typeof args[1] === 'object' && !Array.isArray(args[1])
+              ? (args[1] as Record<string, unknown>)
+              : {};
+          warnings.push({ message, payload: payload ?? {} });
+        },
+      };
+
+      const cancellationCallbacks: Array<() => void> = [];
+      const cancellationToken = {
+        isCancellationRequested: false,
+        onCancellationRequested: (callback: () => void) => {
+          cancellationCallbacks.push(callback);
+          return { dispose: () => undefined };
+        },
+      };
+
+      const { complete, uri } = setup({
+        code: 'int localVar = 1;',
+        bridge,
+        logger,
+      });
+
+      const completionPromise = complete(0, 3, cancellationToken);
+      cancellationToken.isCancellationRequested = true;
+      for (const callback of cancellationCallbacks) {
+        callback();
+      }
+
+      await completionPromise;
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(warnings.length).toBe(1);
+      expect(warnings[0]?.message).toBe('Completion cancellation request failed');
+      expect(warnings[0]?.payload['uri']).toBe(uri);
+      expect(String(warnings[0]?.payload['requestId']).startsWith(`completion:${uri}:1:`)).toBe(true);
+      expect(warnings[0]?.payload['error']).toBe(cancellationError);
     });
 
     it('keeps completion p95 non-regressing for query stub fallback path', async () => {

--- a/packages/pike-lsp-server/src/tests/navigation/query-engine-cancellation.test.ts
+++ b/packages/pike-lsp-server/src/tests/navigation/query-engine-cancellation.test.ts
@@ -62,19 +62,79 @@ describe('query-engine cancellation wiring', () => {
       true
     );
 
-    resolveQuery?.({
-      result: {
-        location: {
-          uri: document.uri,
-          range: {
-            start: { line: 0, character: 4 },
-            end: { line: 0, character: 9 },
+    const firstResolveQuery = resolveQuery;
+    if (typeof firstResolveQuery === 'function') {
+      firstResolveQuery({
+        result: {
+          location: {
+            uri: document.uri,
+            range: {
+              start: { line: 0, character: 4 },
+              end: { line: 0, character: 9 },
+            },
           },
         },
-      },
-    });
+      });
+    }
 
     const result = await queryPromise;
     expect(result).toBeUndefined();
+  });
+
+  it('logs warning when cancellation bridge call fails', async () => {
+    const document = TextDocument.create('file:///test.pike', 'pike', 1, 'int value = 1;');
+    const cancellationToken = new FakeCancellationToken();
+    const cancellationError = new Error('cancel bridge failed');
+    const warnings: Array<{ message: string; payload: Record<string, unknown> }> = [];
+
+    let resolveQuery: ((value: unknown) => void) | null = null;
+
+    const services = {
+      logger: {
+        warn: (message: string, payload?: Record<string, unknown>) => {
+          warnings.push({ message, payload: payload ?? {} });
+        },
+      },
+      bridge: {
+        isRunning: () => true,
+        engineQuery: async (_params: unknown) =>
+          await new Promise(resolve => {
+            resolveQuery = resolve;
+          }),
+        engineCancelRequest: async () => {
+          throw cancellationError;
+        },
+      },
+    };
+
+    const queryPromise = queryNavigationLocations(
+      services as any,
+      'references',
+      document.uri,
+      document,
+      { line: 0, character: 4 },
+      {},
+      cancellationToken as any
+    );
+
+    cancellationToken.cancel();
+
+    const secondResolveQuery = resolveQuery;
+    if (typeof secondResolveQuery === 'function') {
+      secondResolveQuery({ result: { result: { status: 'stub' } } });
+    }
+    const result = await queryPromise;
+    expect(result).toBeUndefined();
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]?.message).toBe('Navigation cancellation request failed');
+    expect(warnings[0]?.payload['feature']).toBe('references');
+    expect(warnings[0]?.payload['uri']).toBe(document.uri);
+    expect(String(warnings[0]?.payload['requestId']).startsWith(`references:${document.uri}:1:`)).toBe(
+      true
+    );
+    expect(warnings[0]?.payload['error']).toBe(cancellationError);
   });
 });


### PR DESCRIPTION
## Summary
- Log bridge cancellation failures as `warn` in both completion and navigation query-engine cancellation callbacks instead of swallowing them.
- Add regression tests that assert the exact warning messages, request-id prefixes, and propagated error object for both cancellation paths.
- Keep completion/query-engine behavior unchanged aside from visibility into cancellation bridge failures.

## Validation
- `bun test src/tests/navigation/query-engine-cancellation.test.ts src/tests/editing/completion-provider.test.ts`
- `bun run build`
- `bun run typecheck`

Closes #878