### PR TITLE
fix: clean validationVersions for closed-doc debounce

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics/index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/index.ts
@@ -254,10 +254,10 @@ export function registerDiagnosticsHandlers(
     // Set new timer
     const timer = setTimeout(() => {
       validationTimers.delete(uri);
-      validationVersions.delete(uri);
 
       const liveDocument = documents.get(uri);
       if (!liveDocument) {
+        validationVersions.delete(uri);
         pendingChangeStates.delete(uri);
         return;
       }
@@ -265,6 +265,7 @@ export function registerDiagnosticsHandlers(
       // INC-563: Check if this validation is stale (a newer version was scheduled)
       const currentVersion = liveDocument.version;
       if (currentVersion !== expectedVersion) {
+        validationVersions.delete(uri);
         // Clear pending change range since we're skipping
         pendingChangeStates.delete(uri);
         return;
@@ -278,6 +279,7 @@ export function registerDiagnosticsHandlers(
         : classifyChange(liveDocument, changeState?.range, cachedEntry);
 
       if (classification.canSkip) {
+        validationVersions.delete(uri);
         // Skip parsing entirely - just update cache metadata
         if (cachedEntry) {
           applySkippedValidationCacheUpdate(cachedEntry, currentVersion, classification);
@@ -298,6 +300,9 @@ export function registerDiagnosticsHandlers(
         },
       });
       documentCache.setPending(uri, promise);
+      promise.finally(() => {
+        validationVersions.delete(uri);
+      });
       promise.catch(err => {
         if (err instanceof RequestSupersededError) {
           return;

--- a/packages/pike-lsp-server/src/tests/advanced/configuration-handling.test.ts
+++ b/packages/pike-lsp-server/src/tests/advanced/configuration-handling.test.ts
@@ -81,6 +81,9 @@ function createMockDocuments(seedDocs: TextDocument[]) {
         closeHandler({ document });
       }
     },
+    dropWithoutClose(uri: string): void {
+      docs.delete(uri);
+    },
   };
 }
 
@@ -351,5 +354,74 @@ describe('Configuration Handling', () => {
     await waitFor(() => harness.getQueryCount() >= 1, 200);
     const published = harness.diagnosticsPublished.find(entry => entry.uri === uri);
     assert.ok(published, 'diagnostics should be published for changed document');
+  });
+
+  it('cleans version tracking when debounce runs after document disappears without close event', async () => {
+    type TrackedMapOperation = {
+      map: Map<unknown, unknown>;
+      op: 'set' | 'delete';
+      key: unknown;
+      value?: unknown;
+    };
+
+    const trackedOps: TrackedMapOperation[] = [];
+    const OriginalMap = globalThis.Map;
+
+    class TrackingMap<K, V> extends OriginalMap<K, V> {
+      override set(key: K, value: V): this {
+        trackedOps.push({ map: this as unknown as Map<unknown, unknown>, op: 'set', key, value });
+        return super.set(key, value);
+      }
+
+      override delete(key: K): boolean {
+        trackedOps.push({ map: this as unknown as Map<unknown, unknown>, op: 'delete', key });
+        return super.delete(key);
+      }
+    }
+
+    (globalThis as unknown as { Map: typeof Map }).Map = TrackingMap as unknown as typeof Map;
+
+    try {
+      const harness = createHarness([]);
+      const onConfig = harness.getConfigHandler();
+      onConfig({ settings: { pike: { diagnosticDelay: 0 } } });
+
+      const uri = 'file:///tmp/config-debounce-disappeared-doc.pike';
+      const changedDoc = TextDocument.create(uri, 'pike', 9, 'int orphaned = 1;\n');
+
+      harness.documentsLike.emitChange(changedDoc);
+      harness.documentsLike.dropWithoutClose(uri);
+
+      await sleep(20);
+
+      assert.equal(
+        harness.getQueryCount(),
+        0,
+        'Debounced validation should stop when live document is missing'
+      );
+
+      const mapsWithVersionSet = new Set(
+        trackedOps
+          .filter(op => op.op === 'set' && op.key === uri && typeof op.value === 'number')
+          .map(op => op.map)
+      );
+
+      assert.ok(
+        mapsWithVersionSet.size > 0,
+        'Expected debounce path to store validation version for changed URI'
+      );
+
+      const versionMapDeleteSeen = trackedOps.some(
+        op => op.op === 'delete' && op.key === uri && mapsWithVersionSet.has(op.map)
+      );
+
+      assert.equal(
+        versionMapDeleteSeen,
+        true,
+        'Debounce path must always clear validationVersions entry when document is no longer live'
+      );
+    } finally {
+      (globalThis as unknown as { Map: typeof Map }).Map = OriginalMap;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- make diagnostics debounce cleanup explicit for `validationVersions` across all early-return paths, including when the debounced callback sees no live document
- ensure scheduled debounce validation also clears `validationVersions` via `finally` after promise completion
- add regression coverage that simulates a debounced validation running after the document disappears without `onDidClose`, and asserts version-tracking cleanup behavior

## Verification
- `bun test src/tests/advanced/configuration-handling.test.ts`
- `bun test src/tests/query-engine-stale-diagnostics-race.test.ts`
- `bun run build` (packages/core)
- `bun run build` (packages/pike-bridge)
- `bun run typecheck` (packages/pike-lsp-server)
- `bunx tsc -p tsconfig.json` (packages/pike-lsp-server)

Closes #868