### PR TITLE
fix: log request scheduler async failures

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics/index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/index.ts
@@ -142,7 +142,7 @@ export function registerDiagnosticsHandlers(
   const documentSnapshots = services.documentSnapshots ?? new Map<string, string>();
   const inFlightDiagnosticRequests = new Map<string, string>();
   const pullDiagnosticResultIds = new Map<string, string>();
-  const diagnosticsScheduler = new RequestScheduler();
+  const diagnosticsScheduler = new RequestScheduler({ logger: log });
   const SCHEDULER_METRICS_LOG_EVERY = 25;
   let validationCompletions = 0;
 

--- a/packages/pike-lsp-server/src/features/editing/completion.ts
+++ b/packages/pike-lsp-server/src/features/editing/completion.ts
@@ -50,7 +50,7 @@ export function registerCompletionHandlers(
 ): void {
   // Note: stdlibIndex accessed via services.stdlibIndex for late binding (initialized after registration)
   const { logger, documentCache, moduleContext } = services;
-  const completionScheduler = new RequestScheduler();
+  const completionScheduler = new RequestScheduler({ logger });
   const COMPLETION_SCHEDULER_LOG_EVERY = 50;
   let completionRequestsObserved = 0;
 

--- a/packages/pike-lsp-server/src/services/request-scheduler.ts
+++ b/packages/pike-lsp-server/src/services/request-scheduler.ts
@@ -1,4 +1,10 @@
+import { Logger } from '@pike-lsp/core';
+
 export type RequestClass = 'typing' | 'interactive' | 'background';
+
+interface RequestSchedulerLogger {
+  error: (message: string, meta?: Record<string, unknown>) => void;
+}
 
 export interface RequestSchedulerMetrics {
   scheduled: number;
@@ -70,6 +76,7 @@ interface PendingTaskHandle {
 
 interface RequestSchedulerOptions {
   maxConcurrent?: number;
+  logger?: RequestSchedulerLogger;
 }
 
 export class RequestScheduler {
@@ -78,6 +85,7 @@ export class RequestScheduler {
   private dispatching = false;
   private activeWorkers = 0;
   private readonly maxConcurrent: number;
+  private readonly logger: RequestSchedulerLogger;
   private readonly activeByClass: Record<RequestClass, number> = {
     typing: 0,
     interactive: 0,
@@ -107,6 +115,7 @@ export class RequestScheduler {
   constructor(options: RequestSchedulerOptions = {}) {
     const configuredMax = Math.floor(options.maxConcurrent ?? 2);
     this.maxConcurrent = configuredMax > 0 ? configuredMax : 1;
+    this.logger = options.logger ?? new Logger('request-scheduler');
   }
 
   async schedule<T>(request: ScheduleRequest<T>): Promise<T> {
@@ -142,7 +151,9 @@ export class RequestScheduler {
             },
           });
         }
-        this.processQueue().catch(() => {});
+        this.processQueue().catch(error => {
+          this.logSchedulerError('schedule:processQueue', error);
+        });
       };
 
       const coalesceMs = request.coalesceMs ?? 0;
@@ -241,14 +252,18 @@ export class RequestScheduler {
         this.activeWorkers += 1;
         this.activeByClass[next.requestClass] += 1;
         this.runTask(next)
-          .catch(() => {})
+          .catch(error => {
+            this.logSchedulerError('runTask', error, { requestClass: next.requestClass, id: next.id });
+          })
           .finally(() => {
             this.activeWorkers -= 1;
             this.activeByClass[next.requestClass] = Math.max(
               0,
               this.activeByClass[next.requestClass] - 1
             );
-            this.processQueue().catch(() => {});
+            this.processQueue().catch(error => {
+              this.logSchedulerError('finally:processQueue', error);
+            });
           });
       }
     } finally {
@@ -256,8 +271,23 @@ export class RequestScheduler {
     }
 
     if (this.activeWorkers < this.maxConcurrent && this.hasQueuedTasks()) {
-      this.processQueue().catch(() => {});
+      this.processQueue().catch(error => {
+        this.logSchedulerError('tail:processQueue', error);
+      });
     }
+  }
+
+  private logSchedulerError(
+    location: string,
+    error: unknown,
+    extra: Record<string, unknown> = {}
+  ): void {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    this.logger.error('Request scheduler internal async error', {
+      location,
+      error: errorMessage,
+      ...extra,
+    });
   }
 
   private dequeueNextTask(): QueuedTask | undefined {

--- a/packages/pike-lsp-server/src/tests/request-scheduler-regressions.test.ts
+++ b/packages/pike-lsp-server/src/tests/request-scheduler-regressions.test.ts
@@ -133,4 +133,34 @@ describe('RequestScheduler regressions (#882)', () => {
     assert.equal(metrics.failed, 1);
     assert.equal(metrics.canceled, 0);
   });
+
+  it('logs processQueue scheduling failures instead of swallowing them silently (#871)', async () => {
+    const logged: Array<{ message: string; meta?: Record<string, unknown> }> = [];
+    const scheduler = new RequestScheduler({
+      logger: {
+        error: (message, meta) => {
+          logged.push({ message, meta });
+        },
+      },
+    });
+
+    const internal = scheduler as unknown as {
+      processQueue: () => Promise<void>;
+    };
+    internal.processQueue = async () => {
+      throw new Error('forced processQueue failure');
+    };
+
+    void scheduler.schedule({
+      requestClass: 'typing',
+      run: async () => 'ok',
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    assert.equal(logged.length, 1);
+    assert.equal(logged[0]?.message, 'Request scheduler internal async error');
+    assert.equal(logged[0]?.meta?.location, 'schedule:processQueue');
+    assert.equal(logged[0]?.meta?.error, 'forced processQueue failure');
+  });
 });


### PR DESCRIPTION
## Summary
- Replace silent RequestScheduler async catches with explicit error logging paths.
- Pass logger instances when creating completion and diagnostics schedulers so internal async failures are surfaced.
- Add a regression test that forces a processQueue failure and asserts the error is logged.

## Verification
- bun test src/tests/request-scheduler.test.ts
- bun test src/tests/request-scheduler-regressions.test.ts
- bun run typecheck
- bun run build:tsc

Closes #871