### PR TITLE
fix: standardize document-links URI decoding

### DIFF
--- a/packages/pike-lsp-server/src/features/advanced/document-links.ts
+++ b/packages/pike-lsp-server/src/features/advanced/document-links.ts
@@ -15,6 +15,7 @@ import type { DocumentCache } from '../../services/document-cache.js';
 import { Logger } from '@pike-lsp/core';
 import * as path from 'path';
 import * as fsSync from 'fs';
+import { uriToFsPath } from '../../utils/uri-path.js';
 
 /**
  * Register document links handler.
@@ -197,8 +198,7 @@ function resolveIncludePath(
  * Get the directory path from a file URI
  */
 function getDocumentDirectory(uri: string): string {
-    // Decode URI-encoded characters (e.g., %20 -> space)
-    const filePath = decodeURIComponent(uri.replace(/^file:\/\/\/?/, ''));
+    const filePath = uriToFsPath(uri);
     const lastSlash = filePath.lastIndexOf('/');
     return lastSlash >= 0 ? filePath.substring(0, lastSlash) : filePath;
 }

--- a/packages/pike-lsp-server/src/tests/advanced/document-links-uri-decoding.test.js
+++ b/packages/pike-lsp-server/src/tests/advanced/document-links-uri-decoding.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'bun:test';
+import { uriToFsPath } from '../../utils/uri-path.js';
+
+describe('document links URI decoding regression', () => {
+  it('decodes encoded characters in file URI paths', () => {
+    expect(uriToFsPath('file:///workspace/my%20file.pike')).toBe('/workspace/my file.pike');
+  });
+
+  it('keeps double-leading slash shape after scheme removal', () => {
+    expect(uriToFsPath('file:////server/share/module.pike')).toBe('//server/share/module.pike');
+  });
+
+  it('preserves Windows-like drive URI shape', () => {
+    expect(uriToFsPath('file:///C:/workspace/module.pike')).toBe('/C:/workspace/module.pike');
+  });
+});

--- a/packages/pike-lsp-server/src/utils/uri-path.ts
+++ b/packages/pike-lsp-server/src/utils/uri-path.ts
@@ -1,0 +1,7 @@
+export function uriToFsPath(uri: string): string {
+  if (!uri.startsWith('file://')) {
+    return uri;
+  }
+
+  return decodeURIComponent(uri.replace(/^file:\/\//, ''));
+}


### PR DESCRIPTION
## Summary
- add a shared `uriToFsPath(uri: string)` helper in `packages/pike-lsp-server/src/utils/uri-path.ts` using the repo-consistent `^file:\/\/` scheme stripping and URI decoding
- update `packages/pike-lsp-server/src/features/advanced/document-links.ts` to use the shared helper instead of its one-off `^file:\/\/\/?` regex path handling
- add regression tests in `packages/pike-lsp-server/src/tests/advanced/document-links-uri-decoding.test.js` for encoded paths, edge leading slashes, and Windows-like `file:///C:/...` URIs

## Verification
- `bun test src/tests/advanced/document-links-uri-decoding.test.js`
- `bun test src/tests/advanced/document-links-provider.test.ts`
- `bun run typecheck` (in `packages/pike-lsp-server`)
- `bun run build` (workspace root)
- `lsp_diagnostics` on modified files (no diagnostics)

Closes #869