### PR TITLE
fix: targeted workspace-index cache invalidation on remove

### DIFF
--- a/packages/pike-lsp-server/src/tests/workspace-index-file-loading.test.ts
+++ b/packages/pike-lsp-server/src/tests/workspace-index-file-loading.test.ts
@@ -89,6 +89,60 @@ describe('WorkspaceIndex file loading', () => {
     }
   });
 
+  it('invalidates only affected search cache entries on removeDocument', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'workspace-index-cache-remove-'));
+    try {
+      const fileAlpha = join(dir, 'alpha.pike');
+      const fileBeta = join(dir, 'beta.pike');
+      await writeFile(fileAlpha, 'int alphaValue = 1;\n', 'utf-8');
+      await writeFile(fileBeta, 'int betaValue = 2;\n', 'utf-8');
+
+      const bridge = {
+        isRunning: () => true,
+        batchParse: async (files: Array<{ filename: string }>) => ({
+          results: files.map(file => ({
+            filename: file.filename,
+            symbols: [
+              {
+                name: file.filename.includes('alpha.pike') ? 'alphaValue' : 'betaValue',
+                kind: 'variable',
+                position: { line: 1 },
+              },
+            ],
+          })),
+        }),
+        parse: async (_code: string, filename: string) => ({
+          filename,
+          symbols: [{ name: 'fallback', kind: 'variable', position: { line: 1 } }],
+        }),
+      };
+
+      const index = new WorkspaceIndex(bridge as any);
+      await index.indexDirectory(dir, false);
+
+      index.searchSymbols('alpha');
+      index.searchSymbols('beta');
+      expect((index as any).searchCacheMisses).toBe(2);
+      expect((index as any).searchCacheHits).toBe(0);
+      expect((index as any).searchCache.size).toBe(2);
+
+      index.removeDocument(`file://${fileAlpha}`);
+      expect((index as any).searchCache.size).toBe(1);
+
+      const betaAfterRemoval = index.searchSymbols('beta');
+      expect((index as any).searchCacheHits).toBe(1);
+      expect((index as any).searchCacheMisses).toBe(2);
+      expect(betaAfterRemoval.length).toBe(1);
+      expect(betaAfterRemoval[0]?.location.uri).toBe(`file://${fileBeta}`);
+
+      const alphaAfterRemoval = index.searchSymbols('alpha');
+      expect((index as any).searchCacheMisses).toBe(3);
+      expect(alphaAfterRemoval.length).toBe(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('keeps container metadata without mutating source symbols', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'workspace-index-container-'));
     try {

--- a/packages/pike-lsp-server/src/workspace-index.ts
+++ b/packages/pike-lsp-server/src/workspace-index.ts
@@ -256,8 +256,7 @@ export class WorkspaceIndex {
     removeDocument(uri: string): void {
         this.removeFromLookup(uri);
         this.documents.delete(uri);
-        // PERF-430: Invalidate search cache when document is removed
-        this.searchCache.clear();
+        this.invalidateSearchCacheForUri(uri);
     }
 
     /**
@@ -811,6 +810,19 @@ export class WorkspaceIndex {
 
         // Clean up reverse index
         this.uriToSymbols.delete(uri);
+    }
+
+    private invalidateSearchCacheForUri(uri: string): void {
+        if (this.searchCache.size === 0) {
+            return;
+        }
+
+        for (const [cacheKey, cacheEntry] of this.searchCache) {
+            const referencesRemovedUri = cacheEntry.results.some(result => result.location.uri === uri);
+            if (referencesRemovedUri) {
+                this.searchCache.delete(cacheKey);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- update `WorkspaceIndex.removeDocument` to invalidate only cached workspace-symbol queries that reference the removed document URI instead of clearing the entire search cache
- add regression coverage in `workspace-index-file-loading.test.ts` proving unaffected cached queries persist while affected ones are invalidated and re-computed
- keep workspace symbol behavior intact by validating provider and stress suites after the change

## Verification
- `bun run build:tsc` (repo root)
- `bun test src/workspace-index.test.ts` (packages/pike-lsp-server)
- `bun test src/tests/workspace-index-file-loading.test.ts` (packages/pike-lsp-server)
- `bun test src/tests/symbols/workspace-symbol-provider.test.ts` (packages/pike-lsp-server)
- `bun test src/tests/symbols/workspace-symbol-stress.test.ts` (packages/pike-lsp-server)
- `bun run typecheck` (repo root)
- `bun run build` (repo root)

Closes #880