### PR TITLE
fix: configurable debug log path and warning on write failure

### DIFF
--- a/packages/pike-lsp-server/src/server.ts
+++ b/packages/pike-lsp-server/src/server.ts
@@ -12,6 +12,7 @@ import {
   ProposedFeatures,
   InitializeParams,
   InitializeResult,
+  MessageType,
   TextDocumentSyncKind,
   TextDocuments,
 } from 'vscode-languageserver/node.js';
@@ -40,6 +41,7 @@ import * as features from './features/index.js';
 import { registerServerRuntimeHandlers } from './runtime/server-runtime.js';
 import { ensureBridgeStartupOrThrow } from './runtime/bridge-startup.js';
 import { createServiceRuntimeContext } from './runtime/service-runtime-context.js';
+import { createLogger, resolveDebugLogFilePath } from './utils/debug-logger.js';
 
 // Semantic tokens legend (defined here for capabilities)
 const tokenTypes = [
@@ -168,14 +170,16 @@ function createServices(): features.Services {
 // Debug Logging
 // ============================================================================
 
-const logFile = '/tmp/pike-lsp-debug.log';
-const log = (msg: string) => {
-  try {
-    fsSync.appendFileSync(logFile, `[${new Date().toISOString()}] ${msg}\n`);
-  } catch {
-    // Silently ignore logging failures to prevent cascading errors
-  }
-};
+const logFile = resolveDebugLogFilePath();
+const log = createLogger(logFile, {
+  onWriteFailure: (failedLogFile, error) => {
+    const summary = toErrorSummary(error);
+    connection.sendNotification('window/logMessage', {
+      type: MessageType.Warning,
+      message: `Failed to write debug log to ${failedLogFile}: ${summary}`,
+    });
+  },
+});
 
 function toErrorSummary(err: unknown): string {
   if (err instanceof Error) {

--- a/packages/pike-lsp-server/src/tests/debug-logger.test.ts
+++ b/packages/pike-lsp-server/src/tests/debug-logger.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { createLogger, DEFAULT_LOG_FILE, resolveDebugLogFilePath } from '../utils/debug-logger.js';
+
+const testProcess = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
+
+function getEnv(name: string): string | undefined {
+  return testProcess?.env?.[name];
+}
+
+function setEnv(name: string, value: string): void {
+  if (!testProcess?.env) {
+    throw new Error('Test environment does not expose process.env');
+  }
+  testProcess.env[name] = value;
+}
+
+function unsetEnv(name: string): void {
+  if (!testProcess?.env) {
+    throw new Error('Test environment does not expose process.env');
+  }
+  delete testProcess.env[name];
+}
+
+describe('debug logger', () => {
+  const envVar = 'PIKE_LSP_LOG_FILE';
+  const previousValue = getEnv(envVar);
+
+  beforeEach(() => {
+    if (typeof previousValue === 'string') {
+      setEnv(envVar, previousValue);
+    } else {
+      unsetEnv(envVar);
+    }
+  });
+
+  afterEach(() => {
+    if (typeof previousValue === 'string') {
+      setEnv(envVar, previousValue);
+    } else {
+      unsetEnv(envVar);
+    }
+  });
+
+  it('uses PIKE_LSP_LOG_FILE when provided', () => {
+    setEnv(envVar, '/tmp/custom-debug-log.txt');
+    expect(resolveDebugLogFilePath()).toBe('/tmp/custom-debug-log.txt');
+  });
+
+  it('falls back to default log path when env var is unset or blank', () => {
+    unsetEnv(envVar);
+    expect(resolveDebugLogFilePath()).toBe(DEFAULT_LOG_FILE);
+
+    setEnv(envVar, '   ');
+    expect(resolveDebugLogFilePath()).toBe(DEFAULT_LOG_FILE);
+  });
+
+  it('uses resolved env log path when logger is created without explicit path', () => {
+    setEnv(envVar, '/tmp/debug-from-env.log');
+
+    const calls: Array<{ path: string; data: string }> = [];
+    const logger = createLogger(undefined, {
+      appendFileSync: (path, data) => {
+        calls.push({ path: String(path), data });
+      },
+    });
+
+    logger('hello');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.path).toBe('/tmp/debug-from-env.log');
+    expect(calls[0]?.data).toContain('hello');
+  });
+
+  it('invokes failure callback instead of throwing when append fails', () => {
+    const failures: Array<{ path: string; error: unknown }> = [];
+    const expectedError = new Error('EACCES: write failed');
+
+    const logger = createLogger('/missing/path/debug.log', {
+      appendFileSync: () => {
+        throw expectedError;
+      },
+      onWriteFailure: (path, error) => {
+        failures.push({ path, error });
+      },
+    });
+
+    expect(() => logger('test message')).not.toThrow();
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.path).toBe('/missing/path/debug.log');
+    expect(failures[0]?.error).toBe(expectedError);
+  });
+});

--- a/packages/pike-lsp-server/src/utils/debug-logger.ts
+++ b/packages/pike-lsp-server/src/utils/debug-logger.ts
@@ -6,20 +6,46 @@
 
 import * as fsSync from 'fs';
 
-const DEFAULT_LOG_FILE = '/tmp/pike-lsp-debug.log';
+export const DEFAULT_LOG_FILE = '/tmp/pike-lsp-debug.log';
+const LOG_FILE_ENV_VAR = 'PIKE_LSP_LOG_FILE';
+
+type AppendFileSync = (path: fsSync.PathOrFileDescriptor, data: string) => void;
+
+interface CreateLoggerOptions {
+  onWriteFailure?: (logFile: string, error: unknown) => void;
+  appendFileSync?: AppendFileSync;
+}
+
+function runtimeEnv(): Record<string, string | undefined> {
+  const runtimeProcess = (globalThis as { process?: { env?: Record<string, string | undefined> } })
+    .process;
+  return runtimeProcess?.env ?? {};
+}
+
+export function resolveDebugLogFilePath(env: Record<string, string | undefined> = runtimeEnv()): string {
+  const configuredPath = env[LOG_FILE_ENV_VAR]?.trim();
+  return configuredPath && configuredPath.length > 0 ? configuredPath : DEFAULT_LOG_FILE;
+}
 
 /**
  * Create a debug logger function.
  *
  * @param logFile - Optional custom log file path
+ * @param options - Logger behavior overrides
  * @returns Logger function
  */
-export function createLogger(logFile: string = DEFAULT_LOG_FILE): (msg: string) => void {
-    return (msg: string) => {
-        try {
-            fsSync.appendFileSync(logFile, `[${new Date().toISOString()}] ${msg}\n`);
-        } catch {
-            // Silently ignore logging failures to prevent cascading errors
-        }
-    };
+export function createLogger(
+  logFile: string = resolveDebugLogFilePath(),
+  options: CreateLoggerOptions = {}
+): (msg: string) => void {
+  const append = options.appendFileSync ?? fsSync.appendFileSync;
+  const onWriteFailure = options.onWriteFailure;
+
+  return (msg: string) => {
+    try {
+      append(logFile, `[${new Date().toISOString()}] ${msg}\n`);
+    } catch (error) {
+      onWriteFailure?.(logFile, error);
+    }
+  };
 }


### PR DESCRIPTION
## Summary
- Replace the inline server debug logger with the shared logger utility and resolve the log path from `PIKE_LSP_LOG_FILE` (default remains `/tmp/pike-lsp-debug.log`).
- Emit `window/logMessage` warnings (`MessageType.Warning`) when debug log writes fail, while keeping the server running.
- Add focused unit tests for env-based path resolution, default fallback behavior, and non-throwing write-failure callbacks.

## Validation
- `bun test src/tests/debug-logger.test.ts`
- `bun run build` (repo root)
- `bun run typecheck` (repo root)

Closes #884