### PR TITLE
fix: await onDidClose workspace rehydration race

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics/lifecycle.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/lifecycle.ts
@@ -65,6 +65,14 @@ export function registerDiagnosticsLifecycleHandlers(
     log,
   } = args;
 
+  const workspaceRehydrateEpochs = new Map<string, number>();
+
+  const bumpWorkspaceRehydrateEpoch = (uri: string): number => {
+    const nextEpoch = (workspaceRehydrateEpochs.get(uri) ?? 0) + 1;
+    workspaceRehydrateEpochs.set(uri, nextEpoch);
+    return nextEpoch;
+  };
+
   const indexWorkspaceDocument = (document: TextDocument): void => {
     try {
       const indexResult = workspaceIndex.indexDocument?.(
@@ -87,17 +95,44 @@ export function registerDiagnosticsLifecycleHandlers(
     }
   };
 
-  const rehydrateWorkspaceDocumentFromDisk = (uri: string): void => {
+  const rehydrateWorkspaceDocumentFromDisk = async (uri: string, epoch: number): Promise<void> => {
     const filePath = decodeURIComponent(uri.replace(/^file:\/\//, ''));
-    readFile(filePath, 'utf-8')
-      .then(content => workspaceIndex.indexDocument(uri, content, 0))
-      .catch(err => {
+    try {
+      const content = await readFile(filePath, 'utf-8');
+      if (workspaceRehydrateEpochs.get(uri) !== epoch) {
+        return;
+      }
+
+      if (documents.get(uri)) {
+        return;
+      }
+
+      await workspaceIndex.indexDocument(uri, content, 0);
+
+      if (workspaceRehydrateEpochs.get(uri) !== epoch) {
+        const openDocument = documents.get(uri);
+        if (openDocument) {
+          await workspaceIndex.indexDocument(uri, openDocument.getText(), openDocument.version);
+        }
+      }
+    } catch (err) {
+      if (workspaceRehydrateEpochs.get(uri) !== epoch) {
+        return;
+      }
+
+      if (!documents.get(uri)) {
         workspaceIndex.removeDocument(uri);
-        log.debug('Workspace index rehydrate failed, removed entry', {
-          uri,
-          error: err instanceof Error ? err.message : String(err),
-        });
+      }
+
+      log.error('Workspace index rehydrate failed', {
+        uri,
+        error: err instanceof Error ? err.message : String(err),
       });
+    } finally {
+      if (workspaceRehydrateEpochs.get(uri) === epoch) {
+        workspaceRehydrateEpochs.delete(uri);
+      }
+    }
   };
 
   const invalidateIncludeCacheForUri = (uri: string): void => {
@@ -150,6 +185,7 @@ export function registerDiagnosticsLifecycleHandlers(
 
   documents.onDidOpen(event => {
     log.debug('Document opened', { uri: event.document.uri });
+    bumpWorkspaceRehydrateEpoch(event.document.uri);
     invalidateIncludeCacheForUri(event.document.uri);
     indexWorkspaceDocument(event.document);
 
@@ -184,6 +220,7 @@ export function registerDiagnosticsLifecycleHandlers(
   });
 
   documents.onDidChangeContent(change => {
+    bumpWorkspaceRehydrateEpoch(change.document.uri);
     invalidateIncludeCacheForUri(change.document.uri);
     indexWorkspaceDocument(change.document);
     validateDocumentDebounced(change.document);
@@ -236,6 +273,7 @@ export function registerDiagnosticsLifecycleHandlers(
   });
 
   documents.onDidSave(event => {
+    bumpWorkspaceRehydrateEpoch(event.document.uri);
     invalidateIncludeCacheForUri(event.document.uri);
     indexWorkspaceDocument(event.document);
 
@@ -252,7 +290,7 @@ export function registerDiagnosticsLifecycleHandlers(
     });
   });
 
-  documents.onDidClose(event => {
+  documents.onDidClose(async event => {
     invalidateIncludeCacheForUri(event.document.uri);
     services.bridge
       ?.engineCloseDocument({
@@ -274,7 +312,8 @@ export function registerDiagnosticsLifecycleHandlers(
     inFlightDiagnosticRequests.delete(event.document.uri);
 
     typeDatabase.removeProgram(event.document.uri);
-    rehydrateWorkspaceDocumentFromDisk(event.document.uri);
+    const rehydrateEpoch = bumpWorkspaceRehydrateEpoch(event.document.uri);
+    await rehydrateWorkspaceDocumentFromDisk(event.document.uri, rehydrateEpoch);
 
     const timer = validationTimers.get(event.document.uri);
     if (timer) {

--- a/packages/pike-lsp-server/src/tests/architecture-regressions.test.ts
+++ b/packages/pike-lsp-server/src/tests/architecture-regressions.test.ts
@@ -41,7 +41,7 @@ describe('Architecture regressions', () => {
 
   it('cleans validationVersions state on document close', async () => {
     const diagnosticsSource = await readServerFile('features/diagnostics/lifecycle.ts');
-    const didCloseIndex = diagnosticsSource.indexOf('documents.onDidClose(event => {');
+    const didCloseIndex = diagnosticsSource.indexOf('documents.onDidClose(async event => {');
     const cleanupIndex = diagnosticsSource.indexOf('validationVersions.delete(event.document.uri);');
 
     assert.equal(

--- a/packages/pike-lsp-server/src/tests/features/diagnostics/workspace-index-lifecycle.test.ts
+++ b/packages/pike-lsp-server/src/tests/features/diagnostics/workspace-index-lifecycle.test.ts
@@ -228,4 +228,180 @@ describe('Diagnostics lifecycle workspace index sync', () => {
     expect(invalidatedIncludePaths).toEqual([filePath, filePath]);
     rmSync(tempDir, { recursive: true, force: true });
   });
+
+  it('does not let close rehydrate overwrite a rapid reopen index update', async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'pike-lsp-ws-index-reopen-race-'));
+    const filePath = path.join(tempDir, 'reopen-race.pike');
+    writeFileSync(filePath, 'class DiskSnapshot {}\n', 'utf-8');
+
+    const uri = `file://${filePath}`;
+    const initialDoc = TextDocument.create(uri, 'pike', 1, 'class InitialLive {}\n');
+    const reopenedDoc = TextDocument.create(uri, 'pike', 2, 'class ReopenedLive {}\n');
+    const documents = createMockDocuments();
+    const indexedVersions: number[] = [];
+    const indexedContents: string[] = [];
+    const removedUris: string[] = [];
+    const errorLogs: string[] = [];
+
+    registerDiagnosticsLifecycleHandlers({
+      connection: {
+        onDidChangeConfiguration() {},
+        onDidChangeTextDocument() {},
+        sendDiagnostics() {},
+      } as any,
+      documents: documents as any,
+      services: {
+        bridge: null,
+        includeResolver: {
+          invalidate() {},
+        },
+      } as any,
+      documentCache: {
+        setPending() {},
+        delete() {},
+      } as any,
+      typeDatabase: {
+        removeProgram() {},
+      } as any,
+      workspaceIndex: {
+        async indexDocument(_callUri: string, content: string, version: number) {
+          indexedVersions.push(version);
+          indexedContents.push(content);
+          if (version === 0) {
+            await new Promise(resolve => setTimeout(resolve, 20));
+          }
+        },
+        removeDocument(callUri: string) {
+          removedUris.push(callUri);
+        },
+      } as any,
+      diagnosticsScheduler: {
+        schedule() {
+          return Promise.resolve();
+        },
+      } as any,
+      defaultSettings: {
+        pikePath: 'pike',
+        maxNumberOfProblems: 100,
+        diagnosticDelay: 0,
+      },
+      getGlobalSettings: () => ({
+        pikePath: 'pike',
+        maxNumberOfProblems: 100,
+        diagnosticDelay: 0,
+      }),
+      setGlobalSettings() {},
+      pendingChangeStates: new Map(),
+      documentSnapshots: new Map(),
+      inFlightDiagnosticRequests: new Map(),
+      validationTimers: new Map(),
+      validationVersions: new Map(),
+      validateDocument: async () => {},
+      validateDocumentDebounced: () => {},
+      log: {
+        debug() {},
+        error(message: string) {
+          errorLogs.push(message);
+        },
+      } as any,
+    });
+
+    documents.emitOpen(initialDoc);
+    documents.emitClose(initialDoc);
+    documents.emitOpen(reopenedDoc);
+
+    await new Promise(resolve => setTimeout(resolve, 60));
+
+    expect(indexedVersions.some(version => version === 0)).toBe(false);
+    expect(indexedVersions[indexedVersions.length - 1]).toBe(reopenedDoc.version);
+    expect(indexedContents[indexedContents.length - 1]).toBe(reopenedDoc.getText());
+    expect(removedUris).toEqual([]);
+    expect(errorLogs).toEqual([]);
+
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('does not remove index entry from stale close rehydrate failure after rapid re-add', async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'pike-lsp-ws-index-readd-race-'));
+    const filePath = path.join(tempDir, 'readd-race.pike');
+    writeFileSync(filePath, 'class Original {}\n', 'utf-8');
+
+    const uri = `file://${filePath}`;
+    const doc = TextDocument.create(uri, 'pike', 1, 'class Original {}\n');
+    const readdedDoc = TextDocument.create(uri, 'pike', 2, 'class Readded {}\n');
+    const documents = createMockDocuments();
+    const removedUris: string[] = [];
+    const errorLogs: string[] = [];
+
+    registerDiagnosticsLifecycleHandlers({
+      connection: {
+        onDidChangeConfiguration() {},
+        onDidChangeTextDocument() {},
+        sendDiagnostics() {},
+      } as any,
+      documents: documents as any,
+      services: {
+        bridge: null,
+        includeResolver: {
+          invalidate() {},
+        },
+      } as any,
+      documentCache: {
+        setPending() {},
+        delete() {},
+      } as any,
+      typeDatabase: {
+        removeProgram() {},
+      } as any,
+      workspaceIndex: {
+        async indexDocument() {},
+        removeDocument(callUri: string) {
+          removedUris.push(callUri);
+        },
+      } as any,
+      diagnosticsScheduler: {
+        schedule() {
+          return Promise.resolve();
+        },
+      } as any,
+      defaultSettings: {
+        pikePath: 'pike',
+        maxNumberOfProblems: 100,
+        diagnosticDelay: 0,
+      },
+      getGlobalSettings: () => ({
+        pikePath: 'pike',
+        maxNumberOfProblems: 100,
+        diagnosticDelay: 0,
+      }),
+      setGlobalSettings() {},
+      pendingChangeStates: new Map(),
+      documentSnapshots: new Map(),
+      inFlightDiagnosticRequests: new Map(),
+      validationTimers: new Map(),
+      validationVersions: new Map(),
+      validateDocument: async () => {},
+      validateDocumentDebounced: () => {},
+      log: {
+        debug() {},
+        error(message: string) {
+          errorLogs.push(message);
+        },
+      } as any,
+    });
+
+    documents.emitOpen(doc);
+    unlinkSync(filePath);
+    documents.emitClose(doc);
+
+    writeFileSync(filePath, 'class ReaddedOnDisk {}\n', 'utf-8');
+    documents.emitOpen(readdedDoc);
+
+    await new Promise(resolve => setTimeout(resolve, 30));
+
+    expect(removedUris).toEqual([]);
+    expect(errorLogs).toEqual([]);
+
+    rmSync(tempDir, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
## Summary
- replace close-time fire-and-forget workspace rehydration with an awaited, epoch-guarded flow in diagnostics lifecycle
- prevent stale close rehydrate completion from clobbering newer reopen/change/save indexing state and avoid stale remove-on-error paths
- add regression coverage for close→reopen and delete→close→re-add timing races, plus architecture assertion update for async close handler

## Validation
- bun test src/tests/features/diagnostics/workspace-index-lifecycle.test.ts
- bun test src/tests/architecture-regressions.test.ts
- bun test src/tests/query-engine-stale-diagnostics-race.test.ts
- bun run typecheck (packages/pike-lsp-server)
- bun run build (workspace root)

Closes #872