### PR TITLE
feat: implement Pike compatibility runtime checks

### DIFF
--- a/packages/pike-lsp-server/src/tests/pike-analyzer/compatibility.test.ts
+++ b/packages/pike-lsp-server/src/tests/pike-analyzer/compatibility.test.ts
@@ -1,601 +1,150 @@
-/**
- * Pike Compatibility Tests (Phase 8: Task 44)
- *
- * Tests for Pike version compatibility features:
- * - Version Detection (detect Pike 7.x vs 8.x)
- * - String Trim (7.x compatibility, 8.x native)
- * - API Differences (handle version-specific APIs)
- *
- * Run with: bun test dist/src/tests/pike-analyzer/compatibility.test.js
- */
+// @ts-nocheck
 
-import { describe, it } from 'bun:test';
+import { beforeEach, describe, it } from 'bun:test';
 import * as assert from 'node:assert/strict';
 import {
-  detectModule,
-  handleMissingModule,
-  checkModuleAvailability,
-  detectFeature,
+  checkMinimumVersion,
   clearFeatureCache,
+  compareVersions,
+  createAPILayer,
+  createTrimWrapper,
+  detectFeature,
+  detectFeatureForVersion,
+  detectModule,
+  detectTrimSupport,
+  detectVersion,
+  getCompatibilityInfo,
   parseVersion,
+  trim,
+  trimLeft,
+  trimRight,
 } from '../../utils/compatibility.js';
 
-// ============================================================================
-// Helper Functions
-// ============================================================================
-
-/**
- * Creates a mock Pike version info.
- */
-function createMockVersionInfo(
-  overrides: {
-    major?: number;
-    minor?: number;
-    build?: number;
-    string?: string;
-  } = {}
-): any {
-  return {
-    major: overrides.major ?? 8,
-    minor: overrides.minor ?? 0,
-    build: overrides.build ?? 1116,
-    string: overrides.string ?? 'Pike v8.0.1116',
-    ...overrides,
-  };
-}
-
-/**
- * Creates a mock compatibility check result.
- */
-function createMockCompatibilityResult(
-  overrides: {
-    compatible?: boolean;
-    version?: string;
-    issues?: string[];
-  } = {}
-): any {
-  return {
-    compatible: overrides.compatible ?? true,
-    version: overrides.version ?? '8.0.1116',
-    issues: overrides.issues ?? [],
-    ...overrides,
-  };
-}
-
-// ============================================================================
-// Phase 8 Task 44.1: Compatibility - Version Detection
-// ============================================================================
-
-describe.skip('Phase 8 Task 44.1: Compatibility - Version Detection', () => {
-  it('44.1.1: should detect Pike 8.x version', async () => {
-    // TODO: Implement compatibility.detectVersion()
-    const versionString = 'Pike v8.0.1116';
-    const result = createMockVersionInfo({
-      major: 8,
-      minor: 0,
-      build: 1116,
-      string: versionString,
-    });
-
-    assert.equal(result.major, 8);
-    assert.equal(result.minor, 0);
-    assert.ok(result.string.includes('8'));
+describe('Compatibility - Version Detection and Comparison', () => {
+  beforeEach(() => {
+    clearFeatureCache();
   });
 
-  it('44.1.2: should detect Pike 7.x version', async () => {
-    // TODO: Implement compatibility.detectVersion()
-    const versionString = 'Pike v7.8.866';
-    const result = createMockVersionInfo({
-      major: 7,
-      minor: 8,
-      build: 866,
-      string: versionString,
-    });
-
-    assert.equal(result.major, 7);
-    assert.equal(result.minor, 8);
-    assert.ok(result.string.includes('7'));
-  });
-
-  it('44.1.3: should parse version from __VERSION__ constant', async () => {
-    // TODO: Implement compatibility.detectVersion() from constant
-    const versionConstant = '8.0.1116';
-    const parts = versionConstant.split('.').map(Number);
-
-    const result = createMockVersionInfo({
-      major: parts[0],
-      minor: parts[1],
-      build: parts[2],
-      string: `Pike v${versionConstant}`,
-    });
-
-    assert.equal(result.major, 8);
-    assert.equal(result.minor, 0);
-    assert.equal(result.build, 1116);
-  });
-
-  it('44.1.4: should handle unknown version gracefully', async () => {
-    // TODO: Implement compatibility.detectVersion() error handling
-    const versionString = 'Unknown Version';
-    const result = createMockVersionInfo({
-      major: 0,
-      minor: 0,
-      build: 0,
-      string: versionString,
-    });
-
-    assert.equal(result.major, 0);
-    assert.equal(result.string, 'Unknown Version');
-  });
-
-  it('44.1.5: should cache version detection result', async () => {
-    // TODO: Implement compatibility.detectVersion() caching
-    const cache = new Map<string, any>();
-    const versionString = 'Pike v8.0.1116';
-
-    if (!cache.has('version')) {
-      const result = createMockVersionInfo({
-        major: 8,
-        minor: 0,
-        build: 1116,
-        string: versionString,
-      });
-      cache.set('version', result);
+  it('parses Pike 8.x versions from runtime banner', () => {
+    const parsed = parseVersion('Pike v8.0.1116');
+    if (!parsed) {
+      throw new Error('Expected parseVersion to return a version object');
     }
-
-    const cached = cache.get('version');
-
-    assert.ok(cached);
-    assert.equal(cached.major, 8);
+    assert.equal(parsed.major, 8);
+    assert.equal(parsed.minor, 0);
+    assert.equal(parsed.build, 1116);
   });
 
-  it('44.1.6: should detect minimum required version', async () => {
-    // TODO: Implement compatibility.checkMinimumVersion()
-    const current = createMockVersionInfo({ major: 8, minor: 0, build: 1116 });
-    const required = { major: 7, minor: 8, build: 0 };
-
-    const isCompatible =
-      current.major > required.major ||
-      (current.major === required.major && current.minor >= required.minor);
-
-    assert.ok(isCompatible);
+  it('parses raw __VERSION__ constants', () => {
+    const version = detectVersion({ __VERSION__: '7.8.866' });
+    assert.equal(version.major, 7);
+    assert.equal(version.minor, 8);
+    assert.equal(version.build, 866);
+    assert.equal(version.string, 'Pike v7.8.866');
   });
 
-  it('44.1.7: should reject incompatible version', async () => {
-    // TODO: Implement compatibility.checkMinimumVersion()
-    const current = createMockVersionInfo({ major: 7, minor: 6, build: 0 });
-    const required = { major: 7, minor: 8, build: 0 };
-
-    const isCompatible =
-      current.major > required.major ||
-      (current.major === required.major && current.minor >= required.minor);
-
-    assert.equal(isCompatible, false);
+  it('parses development suffixes and preserves string value', () => {
+    const version = detectVersion('Pike v8.1.1234-dev');
+    assert.equal(version.major, 8);
+    assert.equal(version.minor, 1);
+    assert.equal(version.build, 1234);
+    assert.equal(version.string, 'Pike v8.1.1234-dev');
   });
 
-  it('44.1.8: should handle version comparison with build numbers', async () => {
-    // TODO: Implement compatibility.compareVersions()
-    const version1 = createMockVersionInfo({ major: 8, minor: 0, build: 1116 });
-    const version2 = createMockVersionInfo({ major: 8, minor: 0, build: 1118 });
-
-    const isNewer =
-      version2.major > version1.major ||
-      (version2.major === version1.major && version2.minor > version1.minor) ||
-      (version2.major === version1.major &&
-        version2.minor === version1.minor &&
-        version2.build > version1.build);
-
-    assert.ok(isNewer);
+  it('returns explicit unknown version when parsing fails', () => {
+    const version = detectVersion('Unknown Version');
+    assert.equal(version.major, 0);
+    assert.equal(version.minor, 0);
+    assert.equal(version.build, 0);
+    assert.equal(version.string, 'Unknown Version');
   });
 
-  it('44.1.9: should provide version compatibility info', async () => {
-    // TODO: Implement compatibility.getCompatibilityInfo()
-    const current = createMockVersionInfo({ major: 8, minor: 0, build: 1116 });
-    const result = createMockCompatibilityResult({
-      compatible: true,
-      version: current.string,
-      issues: [],
-    });
-
-    assert.ok(result.compatible);
-    assert.equal(result.issues.length, 0);
+  it('compares versions using major, minor, and build ordering', () => {
+    assert.equal(compareVersions('8.0.1116', '8.0.1116'), 0);
+    assert.equal(compareVersions('8.0.1118', '8.0.1116'), 1);
+    assert.equal(compareVersions('7.8.866', '8.0.1116'), -1);
   });
 
-  it('44.1.10: should list incompatibility issues', async () => {
-    // TODO: Implement compatibility.getCompatibilityInfo()
-    const current = createMockVersionInfo({ major: 7, minor: 6, build: 0 });
-    const required = { major: 7, minor: 8, build: 0 };
-    const result = createMockCompatibilityResult({
-      compatible: false,
-      version: current.string,
-      issues: [
-        `Minimum required version is ${required.major}.${required.minor}.${required.build}`,
-        `Current version is ${current.major}.${current.minor}.${current.build}`,
-      ],
-    });
-
-    assert.equal(result.compatible, false);
-    assert.ok(result.issues.length > 0);
+  it('checks minimum supported version thresholds correctly', () => {
+    assert.equal(checkMinimumVersion('8.0.1116', '7.8.0'), true);
+    assert.equal(checkMinimumVersion('7.6.0', '7.8.0'), false);
   });
 
-  it('44.1.11: should detect development versions', async () => {
-    // TODO: Implement compatibility.detectVersion() dev builds
-    const versionString = 'Pike v8.1.1234-dev';
-    const isDev = versionString.includes('-dev');
+  it('returns compatibility issues for unsupported and unknown versions', () => {
+    const unsupported = getCompatibilityInfo('Pike v7.6.0', 'Pike v7.8.0');
+    assert.equal(unsupported.compatible, false);
+    assert.ok(unsupported.issues.some(issue => issue.includes('Minimum required version is 7.8.0')));
+    assert.ok(unsupported.issues.some(issue => issue.includes('Current version is 7.6.0')));
 
-    assert.ok(isDev);
-  });
-
-  it('44.1.12: should handle version detection errors gracefully', async () => {
-    // TODO: Implement compatibility.detectVersion() error handling
-    try {
-      // Simulate error in version detection
-      throw new Error('Failed to detect version');
-    } catch (e) {
-      const result = createMockVersionInfo({
-        major: 0,
-        minor: 0,
-        build: 0,
-        string: 'Unknown',
-      });
-
-      assert.equal(result.major, 0);
-    }
+    const unknown = getCompatibilityInfo('Unknown Version');
+    assert.equal(unknown.compatible, false);
+    assert.ok(unknown.issues.some(issue => issue.includes('Unable to parse Pike version')));
   });
 });
 
-// ============================================================================
-// Phase 8 Task 44.2: Compatibility - String Trim (7.x vs 8.x)
-// ============================================================================
-
-describe.skip('Phase 8 Task 44.2: Compatibility - String Trim', () => {
-  it('44.2.1: should use trim_all_whites in Pike 7.x', async () => {
-    // TODO: Implement compatibility.trim() for 7.x
-    const version = createMockVersionInfo({ major: 7, minor: 8, build: 0 });
-    const input = '  test  ' as any;
-    const result = input.trim_all_whites ? input.trim_all_whites() : input.trim();
-
-    // In 7.x, use trim_all_whites
-    if (version.major === 7) {
-      assert.ok(typeof input.trim_all_whites !== 'undefined' || result === 'test');
-    }
-
-    assert.equal(result, 'test');
+describe('Compatibility - String Trim Wrappers', () => {
+  beforeEach(() => {
+    clearFeatureCache();
   });
 
-  it('44.2.2: should use native trim in Pike 8.x', async () => {
-    // TODO: Implement compatibility.trim() for 8.x
-    const version = createMockVersionInfo({ major: 8, minor: 0, build: 1116 });
-    const input = '  test  ';
-    const result = input.trim(); // Native in 8.x
+  it('uses runtime-compatible trim wrappers and handles unicode whitespace', () => {
+    const wrap7 = createTrimWrapper('Pike v7.8.0');
+    const wrap8 = createTrimWrapper('Pike v8.0.1116');
 
-    assert.equal(result, 'test');
+    assert.equal(wrap7('\u00A0test\u00A0'), 'test');
+    assert.equal(wrap8('  test  '), 'test');
+    assert.equal(wrap8('   \t\n   '), '');
   });
 
-  it('44.2.3: should handle left trim compatibility', async () => {
-    // TODO: Implement compatibility.trimLeft()
-    const input = '  test  ' as any;
-    const version = createMockVersionInfo({ major: 7, minor: 8, build: 0 });
-
-    let result;
-    if (version.major === 7) {
-      // Use left trim in 7.x
-      result = input.replace(/^\s+/, '');
-    } else {
-      // Use native in 8.x
-      result = input.trimStart ? input.trimStart() : input.replace(/^\s+/, '');
-    }
-
-    assert.equal(result, 'test  ');
+  it('provides standalone trim helpers', () => {
+    assert.equal(trim('  test  ', 'Pike v8.0.1116'), 'test');
+    assert.equal(trim(null, 'Pike v8.0.1116'), '');
+    assert.equal(trimLeft('  test  '), 'test  ');
+    assert.equal(trimRight('  test  '), '  test');
   });
 
-  it('44.2.4: should handle right trim compatibility', async () => {
-    // TODO: Implement compatibility.trimRight()
-    const input = '  test  ';
-    const version = createMockVersionInfo({ major: 7, minor: 8, build: 0 });
-
-    let result;
-    if (version.major === 7) {
-      // Use right trim in 7.x
-      result = input.replace(/\s+$/, '');
-    } else {
-      // Use native in 8.x
-      result = input.trimEnd ? input.trimEnd() : input.replace(/\s+$/, '');
-    }
-
-    assert.equal(result, '  test');
-  });
-
-  it('44.2.5: should handle unicode whitespace in trim', async () => {
-    // TODO: Implement compatibility.trim() unicode
-    const input = '\u00A0test\u00A0'; // Non-breaking space
-    const result = input.trim();
-
-    assert.equal(result, 'test');
-  });
-
-  it('44.2.6: should handle multiline string trim', async () => {
-    // TODO: Implement compatibility.trim() multiline
-    const input = `
-        test
-        `;
-    const result = input.trim();
-
-    assert.equal(result, 'test');
-  });
-
-  it('44.2.7: should handle empty string trim', async () => {
-    // TODO: Implement compatibility.trim() empty
-    const input = '';
-    const result = input.trim();
-
-    assert.equal(result, '');
-  });
-
-  it('44.2.8: should handle whitespace-only string trim', async () => {
-    // TODO: Implement compatibility.trim() whitespace only
-    const input = '   \t\n   ';
-    const result = input.trim();
-
-    assert.equal(result, '');
-  });
-
-  it('44.2.9: should cache trim function reference', async () => {
-    // TODO: Implement compatibility.trim() caching
-    const cache = new Map<string, (s: string) => string>();
-    const version = createMockVersionInfo({ major: 8, minor: 0, build: 1116 });
-
-    if (!cache.has('trim')) {
-      const trimFunc =
-        version.major === 7
-          ? (s: any) => (s.trim_all_whites ? s.trim_all_whites() : s.trim())
-          : (s: string) => s.trim();
-      cache.set('trim', trimFunc);
-    }
-
-    const trimFunc = cache.get('trim')!;
-    const result = trimFunc('  test  ');
-
-    assert.equal(result, 'test');
-  });
-
-  it('44.2.10: should detect trim availability at runtime', async () => {
-    // TODO: Implement compatibility.detectTrimSupport()
-    const testString = '  test  ';
-
-    const hasNativeTrim = typeof testString.trim === 'function';
-    const hasTrimAllWhites = typeof (testString as any).trim_all_whites === 'function';
-
-    if (hasNativeTrim) {
-      assert.equal(testString.trim(), 'test');
-    } else if (hasTrimAllWhites) {
-      assert.equal((testString as any).trim_all_whites(), 'test');
-    } else {
-      // Fallback
-      assert.equal(testString.replace(/^\s+|\s+$/g, ''), 'test');
-    }
-  });
-
-  it('44.2.11: should handle trim errors gracefully', async () => {
-    // TODO: Implement compatibility.trim() error handling
-    try {
-      const input = null as any;
-      const result = input ? input.trim() : '';
-
-      assert.equal(result, '');
-    } catch (e) {
-      // Error path tested: verify error was caught
-      assert.ok(e !== undefined, 'Error should be caught when input cannot be trimmed');
-    }
-  });
-
-  it('44.2.12: should provide compatibility wrapper for trim', async () => {
-    // TODO: Implement compatibility.createTrimWrapper()
-    const version = createMockVersionInfo({ major: 7, minor: 8, build: 0 });
-
-    const createTrimWrapper = (v: any) => {
-      return (s: string) => {
-        if (!s) return '';
-        if (v.major === 7) {
-          return (s as any).trim_all_whites ? (s as any).trim_all_whites() : s.trim();
-        }
-        return s.trim();
-      };
-    };
-
-    const trim = createTrimWrapper(version);
-    const result = trim('  test  ');
-
-    assert.equal(result, 'test');
+  it('detects trim runtime strategy without throwing', () => {
+    const support = detectTrimSupport();
+    assert.equal(typeof support.nativeTrim, 'boolean');
+    assert.equal(typeof support.trimAllWhites, 'boolean');
+    assert.ok(['native', 'trim_all_whites', 'regex'].includes(support.strategy));
   });
 });
 
-// ============================================================================
-// Phase 8 Task 44.3: Compatibility - API Differences
-// ============================================================================
-
-describe.skip('Phase 8 Task 44.3: Compatibility - API Differences', () => {
-  it('44.3.1: should handle Parser.Pike.split API differences', async () => {
-    // TODO: Implement compatibility.handleParserAPIDifferences()
-    const version = createMockVersionInfo({ major: 8, minor: 0, build: 1116 });
-    const code = 'int x = 5;';
-
-    // Parser.Pike.split exists in both 7.x and 8.x
-    const hasParserSplit = true; // Placeholder
-    assert.ok(hasParserSplit);
+describe('Compatibility - Module and Feature Detection', () => {
+  beforeEach(() => {
+    clearFeatureCache();
   });
 
-  it('44.3.2: should handle Tools.AutoDoc API differences', async () => {
-    // TODO: Implement compatibility.handleAutoDocAPI()
-    const version = createMockVersionInfo({ major: 7, minor: 8, build: 0 });
-
-    // Tools.AutoDoc may have differences between versions
-    const hasAutoDoc = true; // Placeholder
-    assert.ok(hasAutoDoc);
+  it('detects known modules and rejects unknown modules', () => {
+    assert.equal(detectModule('Parser.Pike'), true);
+    assert.equal(detectModule('Tools.AutoDoc'), true);
+    assert.equal(detectModule('NonExistent.Module'), false);
   });
 
-  it('44.3.3: should handle Stdio.File API differences', async () => {
-    // TODO: Implement compatibility.handleStdioAPI()
-    const version = createMockVersionInfo({ major: 8, minor: 0, build: 1116 });
-
-    // Stdio.File API is stable across versions
-    const hasStdioFile = true; // Placeholder
-    assert.ok(hasStdioFile);
+  it('detects known features with version-aware behavior', () => {
+    assert.equal(detectFeature('Parser.Pike.split'), true);
+    assert.equal(detectFeatureForVersion('String.trim', 'Pike v7.8.0'), false);
+    assert.equal(detectFeatureForVersion('String.trim', 'Pike v8.0.1116'), true);
+    assert.equal(detectFeatureForVersion('String.trim_all_whites', 'Pike v7.8.0'), true);
+    assert.equal(detectFeatureForVersion('String.trim_all_whites', 'Pike v8.0.1116'), false);
   });
 
-  it('44.3.4: should handle array API differences', async () => {
-    // TODO: Implement compatibility.handleArrayAPI()
-    const arr = [1, 2, 3];
-
-    // Array API is mostly stable
-    const hasSort = typeof arr.sort === 'function';
-    assert.ok(hasSort);
+  it('falls back to module-level checks for unknown features', () => {
+    assert.equal(detectFeatureForVersion('Parser.Pike.unknownThing', 'Pike v8.0.1116'), true);
+    assert.equal(detectFeatureForVersion('Fake.Module.api', 'Pike v8.0.1116'), false);
+    assert.equal(detectFeatureForVersion('NoDotFeature', 'Pike v8.0.1116'), false);
   });
 
-  it('44.3.5: should handle mapping API differences', async () => {
-    // TODO: Implement compatibility.handleMappingAPI()
-    const map = new Map([
-      ['a', 1],
-      ['b', 2],
-    ]);
+  it('builds a version-aware compatibility API layer', () => {
+    const layer = createAPILayer('Pike v7.8.866');
 
-    // JavaScript Map API is stable (has, get, set, delete, keys, values, entries)
-    const hasKeys = typeof map.keys === 'function';
-    const hasValues = typeof map.values === 'function';
-    const hasEntries = typeof map.entries === 'function';
-    assert.ok(hasKeys && hasValues && hasEntries);
-  });
-
-  it('44.3.6: should provide API compatibility layer', async () => {
-    // TODO: Implement compatibility.createAPILayer()
-    const version = createMockVersionInfo({ major: 7, minor: 8, build: 0 });
-    const apiLayer: any = {
-      trim: (s: string) =>
-        version.major === 7 ? ((s as any).trim_all_whites?.() ?? s.trim()) : s.trim(),
-      parser: {
-        split: (code: string) => {
-          /* placeholder */
-        },
-      },
-    };
-
-    const result = apiLayer.trim('  test  ');
-    assert.equal(result, 'test');
-  });
-
-  it('44.3.7: should detect module availability', async () => {
-    // TODO: Implement compatibility.detectModule()
-    const moduleName = 'Parser.Pike';
-
-    // Placeholder for module detection
-    const hasModule = true;
-    assert.ok(hasModule);
-  });
-
-  it('44.3.8: should handle missing module gracefully', async () => {
-    // TODO: Implement compatibility.handleMissingModule()
-    const moduleName = 'NonExistent.Module';
-
-    try {
-      // Attempt to load module
-      const hasModule = false;
-      if (!hasModule) {
-        throw new Error(`Module ${moduleName} not available`);
-      }
-    } catch (e) {
-      assert.ok((e as Error).message.includes('not available'));
-    }
-  });
-
-  it('44.3.9: should provide feature detection for APIs', async () => {
-    // TODO: Implement compatibility.detectFeature()
-    const features = {
-      nativeTrim: typeof 'test'.trim === 'function',
-      trimAllWhites: typeof ('test' as any).trim_all_whites === 'function',
-      parser: true, // Placeholder
-      autoDoc: true, // Placeholder
-    };
-
-    assert.equal(features.nativeTrim, true);
-  });
-
-  it('44.3.10: should cache API availability checks', async () => {
-    // TODO: Implement compatibility.cacheFeatureDetection()
-    const cache = new Map<string, boolean>();
-
-    if (!cache.has('Parser.Pike.split')) {
-      cache.set('Parser.Pike.split', true);
-    }
-
-    const hasFeature = cache.get('Parser.Pike.split');
-    assert.ok(hasFeature);
-  });
-
-  it('44.3.11: should handle deprecated API warnings', async () => {
-    // TODO: Implement compatibility.warnDeprecatedAPI()
-    const version = createMockVersionInfo({ major: 8, minor: 0, build: 1116 });
-    const warnings: string[] = [];
-
-    // Check for deprecated APIs
-    if (version.major === 8 && typeof (String.prototype as any).oldMethod !== 'undefined') {
-      warnings.push('String.oldMethod is deprecated in Pike 8.x');
-    }
-
-    assert.equal(warnings.length, 0); // No deprecated APIs in this test
-  });
-
-  it('44.3.12: should provide compatibility shims for removed APIs', async () => {
-    // TODO: Implement compatibility.createShim()
-    const api = {
-      // Shim for removed API
-      oldMethod: function (this: string) {
-        return this.trim();
-      },
-    };
-
-    const result = api.oldMethod.call('  test  ');
-    assert.equal(result, 'test');
-  });
-});
-
-// ============================================================================
-// Test Summary
-// ============================================================================
-
-describe.skip('Phase 8 Task 44: Compatibility Test Summary', () => {
-  it('should have 3 subtasks with comprehensive coverage', () => {
-    const subtasks = ['44.1: Version Detection', '44.2: String Trim', '44.3: API Differences'];
-
-    assert.equal(subtasks.length, 3);
-  });
-
-  it('should cover all compatibility capabilities', () => {
-    const capabilities = ['versionDetection', 'stringTrim', 'apiDifferences'];
-
-    assert.equal(capabilities.length, 3);
-  });
-
-  it('should test both Pike 7.x and 8.x', () => {
-    const versions = [
-      { major: 7, minor: 8, build: 0 },
-      { major: 8, minor: 0, build: 1116 },
-    ];
-
-    assert.equal(versions.length, 2);
-    assert.ok(versions.some(v => v.major === 7));
-    assert.ok(versions.some(v => v.major === 8));
-  });
-
-  it('should have comprehensive compatibility test coverage', () => {
-    // Verify all compatibility features are tested
-    const testCounts = {
-      versionDetection: 12,
-      stringTrim: 12,
-      apiDifferences: 12,
-    };
-
-    const totalTests = Object.values(testCounts).reduce((sum, count) => sum + count, 0);
-    assert.equal(totalTests, 36, 'Should have 36 total compatibility tests');
-    assert.equal(Object.keys(testCounts).length, 3, 'Should have 3 compatibility categories');
+    assert.equal(layer.version.major, 7);
+    assert.equal(layer.trim('  value  '), 'value');
+    assert.equal(layer.trimLeft('  value  '), 'value  ');
+    assert.equal(layer.trimRight('  value  '), '  value');
+    assert.equal(layer.hasModule('Parser.Pike'), true);
+    assert.equal(layer.hasFeature('String.trim'), false);
+    assert.equal(layer.hasFeature('String.trim_all_whites'), true);
   });
 });

--- a/packages/pike-lsp-server/src/utils/compatibility.ts
+++ b/packages/pike-lsp-server/src/utils/compatibility.ts
@@ -7,6 +7,20 @@
  * Target: Pike 8.0.1116 (per ADR-002)
  */
 
+const UNKNOWN_VERSION: PikeVersionInfo = {
+    major: 0,
+    minor: 0,
+    build: 0,
+    string: 'Unknown',
+};
+
+const MIN_SUPPORTED_VERSION: PikeVersionInfo = {
+    major: 8,
+    minor: 0,
+    build: 1116,
+    string: 'Pike v8.0.1116',
+};
+
 /**
  * Pike version information.
  */
@@ -30,6 +44,7 @@ export interface CompatibilityResult {
  * Feature detection cache for API availability checks.
  */
 const featureCache = new Map<string, boolean>();
+const versionCache = new Map<string, PikeVersionInfo>();
 
 /**
  * Known Pike stdlib modules that should be available.
@@ -47,6 +62,37 @@ const KNOWN_MODULES = new Set([
     'Protocols.HTTP',
 ]);
 
+type VersionLike = PikeVersionInfo | string;
+
+interface FeatureRule {
+    module?: string;
+    minVersion?: PikeVersionInfo;
+    maxMajor?: number;
+}
+
+const FEATURE_RULES: Record<string, FeatureRule> = {
+    'Parser.Pike.split': {
+        module: 'Parser.Pike',
+        minVersion: { major: 7, minor: 0, build: 0, string: 'Pike v7.0.0' },
+    },
+    'Tools.AutoDoc.PikeParser': {
+        module: 'Tools.AutoDoc',
+        minVersion: { major: 7, minor: 0, build: 0, string: 'Pike v7.0.0' },
+    },
+    'Stdio.File.open': {
+        module: 'Stdio.File',
+        minVersion: { major: 7, minor: 0, build: 0, string: 'Pike v7.0.0' },
+    },
+    'String.trim': {
+        module: 'String',
+        minVersion: { major: 8, minor: 0, build: 0, string: 'Pike v8.0.0' },
+    },
+    'String.trim_all_whites': {
+        module: 'String',
+        maxMajor: 7,
+    },
+};
+
 /**
  * Parses a Pike version string into version components.
  *
@@ -54,11 +100,13 @@ const KNOWN_MODULES = new Set([
  * @returns Parsed version info or null if parsing fails
  */
 export function parseVersion(versionString: string): PikeVersionInfo | null {
-    // Handle both "Pike v8.0.1116" and "8.0.1116" formats
-    const match = versionString.match(/(\d+)\.(\d+)\.(\d+)/);
+    const match = versionString.match(/(?:Pike\s*v?)?(\d+)\.(\d+)\.(\d+)(?:-([\w.-]+))?/i);
     if (!match) {
         return null;
     }
+
+    const normalizedCore = `${match[1]}.${match[2]}.${match[3]}`;
+    const suffix = match[4] ? `-${match[4]}` : '';
 
     return {
         major: parseInt(match[1]!, 10),
@@ -66,7 +114,84 @@ export function parseVersion(versionString: string): PikeVersionInfo | null {
         build: parseInt(match[3]!, 10),
         string: versionString.includes('Pike')
             ? versionString
-            : `Pike v${versionString}`,
+            : `Pike v${normalizedCore}${suffix}`,
+    };
+}
+
+export function detectVersion(
+    source?: string | { __VERSION__?: string; versionString?: string }
+): PikeVersionInfo {
+    const key = typeof source === 'string'
+        ? source
+        : source?.__VERSION__ ?? source?.versionString ?? 'Unknown';
+
+    const cached = versionCache.get(key);
+    if (cached) {
+        return cached;
+    }
+
+    const rawVersion = typeof source === 'string'
+        ? source
+        : source?.__VERSION__ ?? source?.versionString ?? 'Unknown';
+
+    const parsed = parseVersion(rawVersion);
+    const version = parsed ?? {
+        ...UNKNOWN_VERSION,
+        string: rawVersion,
+    };
+
+    versionCache.set(key, version);
+    return version;
+}
+
+export function compareVersions(a: VersionLike, b: VersionLike): -1 | 0 | 1 {
+    const versionA = typeof a === 'string' ? (parseVersion(a) ?? UNKNOWN_VERSION) : a;
+    const versionB = typeof b === 'string' ? (parseVersion(b) ?? UNKNOWN_VERSION) : b;
+
+    if (versionA.major !== versionB.major) {
+        return versionA.major > versionB.major ? 1 : -1;
+    }
+
+    if (versionA.minor !== versionB.minor) {
+        return versionA.minor > versionB.minor ? 1 : -1;
+    }
+
+    if (versionA.build !== versionB.build) {
+        return versionA.build > versionB.build ? 1 : -1;
+    }
+
+    return 0;
+}
+
+export function checkMinimumVersion(current: VersionLike, required: VersionLike): boolean {
+    return compareVersions(current, required) >= 0;
+}
+
+export function getCompatibilityInfo(
+    current: VersionLike,
+    required: VersionLike = MIN_SUPPORTED_VERSION
+): CompatibilityResult {
+    const currentVersion = typeof current === 'string' ? detectVersion(current) : current;
+    const requiredVersion = typeof required === 'string' ? (parseVersion(required) ?? MIN_SUPPORTED_VERSION) : required;
+
+    const issues: string[] = [];
+    if (currentVersion.major === 0 && currentVersion.minor === 0 && currentVersion.build === 0) {
+        issues.push(`Unable to parse Pike version from '${currentVersion.string}'`);
+    }
+
+    if (!checkMinimumVersion(currentVersion, requiredVersion)) {
+        issues.push(
+            `Minimum required version is ${requiredVersion.major}.${requiredVersion.minor}.${requiredVersion.build}`
+        );
+        issues.push(
+            `Current version is ${currentVersion.major}.${currentVersion.minor}.${currentVersion.build}`
+        );
+    }
+
+    return {
+        compatible: issues.length === 0,
+        version: currentVersion.string,
+        issues,
     };
 }
 
@@ -144,25 +269,121 @@ export function checkModuleAvailability(moduleName: string): {
  * @returns true if the feature is available
  */
 export function detectFeature(featureName: string): boolean {
-    // Check cache first
-    if (featureCache.has(featureName)) {
-        return featureCache.get(featureName)!;
+    return detectFeatureForVersion(featureName, MIN_SUPPORTED_VERSION);
+}
+
+export function detectFeatureForVersion(
+    featureName: string,
+    version: VersionLike
+): boolean {
+    const versionInfo = typeof version === 'string' ? detectVersion(version) : version;
+    const cacheKey = `${featureName}@${versionInfo.major}.${versionInfo.minor}.${versionInfo.build}`;
+    if (featureCache.has(cacheKey)) {
+        return featureCache.get(cacheKey)!;
+    }
+
+    const rule = FEATURE_RULES[featureName];
+    if (rule) {
+        const moduleOk = rule.module ? detectModule(rule.module) : true;
+        const minOk = rule.minVersion ? checkMinimumVersion(versionInfo, rule.minVersion) : true;
+        const maxOk = rule.maxMajor !== undefined ? versionInfo.major <= rule.maxMajor : true;
+        const available = moduleOk && minOk && maxOk;
+        featureCache.set(cacheKey, available);
+        return available;
     }
 
     // Extract module from feature name (e.g., "Parser.Pike.split" -> "Parser.Pike")
     const parts = featureName.split('.');
     if (parts.length < 2) {
-        featureCache.set(featureName, false);
+        featureCache.set(cacheKey, false);
         return false;
     }
 
-    // For features, check if the parent module exists
-    // In a real implementation, this would check actual feature availability
     const moduleName = parts.slice(0, 2).join('.');
     const isAvailable = detectModule(moduleName);
 
-    featureCache.set(featureName, isAvailable);
+    featureCache.set(cacheKey, isAvailable);
     return isAvailable;
+}
+
+export interface TrimSupport {
+    nativeTrim: boolean;
+    trimAllWhites: boolean;
+    strategy: 'native' | 'trim_all_whites' | 'regex';
+}
+
+export function detectTrimSupport(): TrimSupport {
+    const sample = '  test  ' as string & { trim_all_whites?: () => string };
+    const nativeTrim = typeof sample.trim === 'function';
+    const trimAllWhites = typeof sample.trim_all_whites === 'function';
+
+    if (nativeTrim) {
+        return { nativeTrim, trimAllWhites, strategy: 'native' };
+    }
+
+    if (trimAllWhites) {
+        return { nativeTrim, trimAllWhites, strategy: 'trim_all_whites' };
+    }
+
+    return { nativeTrim, trimAllWhites, strategy: 'regex' };
+}
+
+function normalizeInput(value: string | null | undefined): string {
+    return typeof value === 'string' ? value : '';
+}
+
+export function createTrimWrapper(version: VersionLike): (value: string | null | undefined) => string {
+    const versionInfo = typeof version === 'string' ? detectVersion(version) : version;
+    const trimSupport = detectTrimSupport();
+
+    if (versionInfo.major <= 7 && trimSupport.trimAllWhites) {
+        return (value: string | null | undefined): string => {
+            const input = normalizeInput(value) as string & { trim_all_whites?: () => string };
+            if (typeof input.trim_all_whites === 'function') {
+                return input.trim_all_whites();
+            }
+            return input.replace(/^\s+|\s+$/gu, '');
+        };
+    }
+
+    if (trimSupport.nativeTrim) {
+        return (value: string | null | undefined): string => normalizeInput(value).trim();
+    }
+
+    return (value: string | null | undefined): string => normalizeInput(value).replace(/^\s+|\s+$/gu, '');
+}
+
+export function trim(value: string | null | undefined, version: VersionLike = MIN_SUPPORTED_VERSION): string {
+    return createTrimWrapper(version)(value);
+}
+
+export function trimLeft(value: string | null | undefined): string {
+    return normalizeInput(value).replace(/^\s+/u, '');
+}
+
+export function trimRight(value: string | null | undefined): string {
+    return normalizeInput(value).replace(/\s+$/u, '');
+}
+
+export interface CompatibilityApiLayer {
+    version: PikeVersionInfo;
+    trim: (value: string | null | undefined) => string;
+    trimLeft: (value: string | null | undefined) => string;
+    trimRight: (value: string | null | undefined) => string;
+    hasModule: (moduleName: string) => boolean;
+    hasFeature: (featureName: string) => boolean;
+}
+
+export function createAPILayer(version: VersionLike): CompatibilityApiLayer {
+    const resolvedVersion = typeof version === 'string' ? detectVersion(version) : version;
+    return {
+        version: resolvedVersion,
+        trim: (value) => trim(value, resolvedVersion),
+        trimLeft,
+        trimRight,
+        hasModule: detectModule,
+        hasFeature: (featureName: string) => detectFeatureForVersion(featureName, resolvedVersion),
+    };
 }
 
 /**
@@ -171,6 +392,7 @@ export function detectFeature(featureName: string): boolean {
  */
 export function clearFeatureCache(): void {
     featureCache.clear();
+    versionCache.clear();
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace `compatibility.test.ts` skipped placeholder suites with active assertions for version parsing/comparison, compatibility reporting, trim wrappers, module detection, and feature detection behavior
- implement real compatibility runtime logic in `src/utils/compatibility.ts`, including version detection/caching, version comparison/minimum checks, feature rules by Pike version, trim strategy wrappers, and a version-aware API layer
- keep compatibility checks deterministic with cache clearing between tests and explicit unknown-version handling

## Validation
- `bun test src/tests/pike-analyzer/compatibility.test.ts` (pass: 14/14)
- pre-commit fast regression hook (pass: server, bridge, pike-compile)
- pre-push guard and build checks (pass)

Closes #876