### PR TITLE
fix: implement pike analyzer LRU and compilation caches

### DIFF
--- a/packages/pike-lsp-server/src/services/compilation-cache.ts
+++ b/packages/pike-lsp-server/src/services/compilation-cache.ts
@@ -1,0 +1,276 @@
+import { LRUCache, type LRUCacheOptions, type LRUCacheStats } from './lru-cache.js';
+
+export interface CompilationCacheEntry<TResult> {
+    code: string;
+    result: TResult;
+    dependencies: string[];
+    timestamp: number;
+}
+
+export interface CompilationCacheOptions<TResult>
+    extends Omit<LRUCacheOptions<string, CompilationCacheEntry<TResult>>, 'sizeEstimator'> {
+    sizeEstimator?: (entry: CompilationCacheEntry<TResult>, uri: string) => number;
+    clock?: () => number;
+}
+
+export interface CompilationCacheStats extends LRUCacheStats {
+    trackedFiles: number;
+    trackedDependencyEdges: number;
+}
+
+interface SerializedCacheEntry<TResult> {
+    uri: string;
+    entry: CompilationCacheEntry<TResult>;
+}
+
+interface SerializedPayload<TResult> {
+    entries: SerializedCacheEntry<TResult>[];
+}
+
+export class CompilationCache<TResult> {
+    private readonly cache: LRUCache<string, CompilationCacheEntry<TResult>>;
+    private readonly dependenciesByFile = new Map<string, Set<string>>();
+    private readonly dependentsByFile = new Map<string, Set<string>>();
+    private readonly clock: () => number;
+
+    constructor(options: CompilationCacheOptions<TResult>) {
+        this.clock = options.clock ?? Date.now;
+        this.cache = new LRUCache<string, CompilationCacheEntry<TResult>>({
+            maxSize: options.maxSize,
+            sizeEstimator: (entry, uri) => {
+                const estimator = options.sizeEstimator;
+                if (estimator) {
+                    return estimator(entry, uri);
+                }
+                return defaultCompilationEntrySize(entry);
+            },
+        });
+    }
+
+    get size(): number {
+        return this.cache.entryCount;
+    }
+
+    store(
+        uri: string,
+        code: string,
+        result: TResult,
+        dependencies: readonly string[] = [],
+        timestamp = this.clock()
+    ): boolean {
+        const normalizedDependencies = [...new Set(dependencies)];
+        const entry: CompilationCacheEntry<TResult> = {
+            code,
+            result,
+            dependencies: normalizedDependencies,
+            timestamp,
+        };
+
+        const stored = this.cache.set(uri, entry);
+        if (!stored) {
+            this.removeDependencyEdges(uri);
+            return false;
+        }
+
+        this.updateDependencyEdges(uri, normalizedDependencies);
+        return true;
+    }
+
+    get(uri: string, code: string): CompilationCacheEntry<TResult> | undefined {
+        const entry = this.cache.get(uri);
+        if (!entry) {
+            return undefined;
+        }
+        if (entry.code !== code) {
+            return undefined;
+        }
+        return entry;
+    }
+
+    invalidate(uri: string, transitive = false): string[] {
+        if (!transitive) {
+            const removed = this.invalidateSingle(uri);
+            return removed ? [uri] : [];
+        }
+
+        const queue: string[] = [uri];
+        const visited = new Set<string>([uri]);
+        const invalidated: string[] = [];
+
+        while (queue.length > 0) {
+            const current = queue.shift();
+            if (!current) {
+                continue;
+            }
+
+            const dependents = this.dependentsByFile.get(current);
+            if (dependents) {
+                for (const dependent of dependents) {
+                    if (!visited.has(dependent)) {
+                        visited.add(dependent);
+                        queue.push(dependent);
+                    }
+                }
+            }
+
+            const removed = this.invalidateSingle(current);
+            if (removed) {
+                invalidated.push(current);
+            }
+        }
+
+        return invalidated;
+    }
+
+    evictOlderThan(maxAgeMs: number, now = this.clock()): string[] {
+        const evicted: string[] = [];
+        for (const [uri, entry] of this.cache.entries()) {
+            if (now - entry.timestamp > maxAgeMs) {
+                if (this.invalidateSingle(uri)) {
+                    evicted.push(uri);
+                }
+            }
+        }
+        return evicted;
+    }
+
+    clear(): void {
+        this.cache.clear();
+        this.dependenciesByFile.clear();
+        this.dependentsByFile.clear();
+    }
+
+    serialize(): string {
+        const payload: SerializedPayload<TResult> = {
+            entries: this.cache.entries().map(([uri, entry]) => ({ uri, entry })),
+        };
+        return JSON.stringify(payload);
+    }
+
+    getStats(): CompilationCacheStats {
+        let dependencyEdgeCount = 0;
+        for (const deps of this.dependenciesByFile.values()) {
+            dependencyEdgeCount += deps.size;
+        }
+
+        return {
+            ...this.cache.getStats(),
+            trackedFiles: this.dependenciesByFile.size,
+            trackedDependencyEdges: dependencyEdgeCount,
+        };
+    }
+
+    static deserialize<TResult>(
+        serialized: string,
+        options: CompilationCacheOptions<TResult>
+    ): CompilationCache<TResult> {
+        const cache = new CompilationCache<TResult>(options);
+
+        try {
+            const parsed = JSON.parse(serialized) as unknown;
+            if (!isSerializedPayload<TResult>(parsed)) {
+                return cache;
+            }
+
+            for (const record of parsed.entries) {
+                if (!isSerializedCacheEntry<TResult>(record)) {
+                    continue;
+                }
+
+                cache.store(
+                    record.uri,
+                    record.entry.code,
+                    record.entry.result,
+                    record.entry.dependencies,
+                    record.entry.timestamp
+                );
+            }
+        } catch {
+            return cache;
+        }
+
+        return cache;
+    }
+
+    private invalidateSingle(uri: string): boolean {
+        const removed = this.cache.delete(uri);
+        this.removeDependencyEdges(uri);
+        this.dependentsByFile.delete(uri);
+        return removed;
+    }
+
+    private updateDependencyEdges(uri: string, dependencies: string[]): void {
+        this.removeDependencyEdges(uri);
+
+        if (dependencies.length === 0) {
+            return;
+        }
+
+        this.dependenciesByFile.set(uri, new Set(dependencies));
+
+        for (const dependency of dependencies) {
+            const dependents = this.dependentsByFile.get(dependency) ?? new Set<string>();
+            dependents.add(uri);
+            this.dependentsByFile.set(dependency, dependents);
+        }
+    }
+
+    private removeDependencyEdges(uri: string): void {
+        const dependencies = this.dependenciesByFile.get(uri);
+        if (dependencies) {
+            for (const dependency of dependencies) {
+                const dependents = this.dependentsByFile.get(dependency);
+                if (!dependents) {
+                    continue;
+                }
+                dependents.delete(uri);
+                if (dependents.size === 0) {
+                    this.dependentsByFile.delete(dependency);
+                }
+            }
+            this.dependenciesByFile.delete(uri);
+        }
+    }
+}
+
+function defaultCompilationEntrySize<TResult>(entry: CompilationCacheEntry<TResult>): number {
+    void entry;
+    return 1;
+}
+
+function isSerializedPayload<TResult>(value: unknown): value is SerializedPayload<TResult> {
+    if (!isRecord(value)) {
+        return false;
+    }
+    return Array.isArray(value['entries']);
+}
+
+function isSerializedCacheEntry<TResult>(value: unknown): value is SerializedCacheEntry<TResult> {
+    if (!isRecord(value)) {
+        return false;
+    }
+
+    if (typeof value['uri'] !== 'string') {
+        return false;
+    }
+
+    return isCompilationEntry<TResult>(value['entry']);
+}
+
+function isCompilationEntry<TResult>(value: unknown): value is CompilationCacheEntry<TResult> {
+    if (!isRecord(value)) {
+        return false;
+    }
+
+    return (
+        typeof value['code'] === 'string' &&
+        Array.isArray(value['dependencies']) &&
+        value['dependencies'].every(item => typeof item === 'string') &&
+        typeof value['timestamp'] === 'number' &&
+        'result' in value
+    );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}

--- a/packages/pike-lsp-server/src/services/index.ts
+++ b/packages/pike-lsp-server/src/services/index.ts
@@ -56,3 +56,10 @@ export { BridgeManager, type HealthStatus } from './bridge-manager.js';
 export { WorkspaceScanner } from './workspace-scanner.js';
 export { ModuleContext } from './module-context.js';
 export { FormattingService } from './formatting-service.js';
+export { LRUCache, type LRUCacheOptions, type LRUCacheStats } from './lru-cache.js';
+export {
+    CompilationCache,
+    type CompilationCacheEntry,
+    type CompilationCacheOptions,
+    type CompilationCacheStats,
+} from './compilation-cache.js';

--- a/packages/pike-lsp-server/src/services/lru-cache.ts
+++ b/packages/pike-lsp-server/src/services/lru-cache.ts
@@ -1,0 +1,167 @@
+export interface LRUCacheStats {
+    hits: number;
+    misses: number;
+    evictions: number;
+    size: number;
+    maxSize: number;
+}
+
+export interface LRUCacheOptions<TKey, TValue> {
+    maxSize: number;
+    sizeEstimator?: (value: TValue, key: TKey) => number;
+}
+
+interface CacheEntry<TValue> {
+    value: TValue;
+    size: number;
+}
+
+const DEFAULT_ENTRY_SIZE = 1;
+
+export class LRUCache<TKey, TValue> {
+    private readonly maxSize: number;
+    private readonly sizeEstimator: (value: TValue, key: TKey) => number;
+    private readonly cache = new Map<TKey, CacheEntry<TValue>>();
+    private currentSize = 0;
+    private hits = 0;
+    private misses = 0;
+    private evictions = 0;
+
+    constructor(options: LRUCacheOptions<TKey, TValue>) {
+        if (!Number.isFinite(options.maxSize) || options.maxSize < 0) {
+            throw new Error(`maxSize must be a non-negative finite number, got ${String(options.maxSize)}`);
+        }
+
+        this.maxSize = Math.floor(options.maxSize);
+        this.sizeEstimator = options.sizeEstimator ?? (() => DEFAULT_ENTRY_SIZE);
+    }
+
+    get size(): number {
+        return this.currentSize;
+    }
+
+    get entryCount(): number {
+        return this.cache.size;
+    }
+
+    has(key: TKey): boolean {
+        return this.cache.has(key);
+    }
+
+    get(key: TKey): TValue | undefined {
+        const entry = this.cache.get(key);
+        if (!entry) {
+            this.misses += 1;
+            return undefined;
+        }
+
+        this.hits += 1;
+        this.cache.delete(key);
+        this.cache.set(key, entry);
+        return entry.value;
+    }
+
+    peek(key: TKey): TValue | undefined {
+        return this.cache.get(key)?.value;
+    }
+
+    set(key: TKey, value: TValue): boolean {
+        const entrySize = this.normalizeSize(this.sizeEstimator(value, key));
+        const previous = this.cache.get(key);
+
+        if (entrySize > this.maxSize) {
+            if (previous) {
+                this.delete(key);
+            }
+            return false;
+        }
+
+        if (previous) {
+            this.currentSize -= previous.size;
+            this.cache.delete(key);
+        }
+
+        while (this.currentSize + entrySize > this.maxSize && this.cache.size > 0) {
+            this.evictOldest();
+        }
+
+        if (this.currentSize + entrySize > this.maxSize) {
+            return false;
+        }
+
+        this.cache.set(key, { value, size: entrySize });
+        this.currentSize += entrySize;
+        return true;
+    }
+
+    delete(key: TKey): boolean {
+        const entry = this.cache.get(key);
+        if (!entry) {
+            return false;
+        }
+
+        this.currentSize -= entry.size;
+        this.cache.delete(key);
+        return true;
+    }
+
+    evict(count = 1): TKey[] {
+        const keys: TKey[] = [];
+        const evictionCount = Math.max(0, Math.floor(count));
+        for (let i = 0; i < evictionCount; i += 1) {
+            const key = this.evictOldest();
+            if (key === undefined) {
+                break;
+            }
+            keys.push(key);
+        }
+        return keys;
+    }
+
+    clear(): void {
+        this.cache.clear();
+        this.currentSize = 0;
+    }
+
+    entries(): Array<[TKey, TValue]> {
+        return Array.from(this.cache.entries(), ([key, entry]) => [key, entry.value]);
+    }
+
+    getStats(): LRUCacheStats {
+        return {
+            hits: this.hits,
+            misses: this.misses,
+            evictions: this.evictions,
+            size: this.currentSize,
+            maxSize: this.maxSize,
+        };
+    }
+
+    getHitRate(): number {
+        const total = this.hits + this.misses;
+        if (total === 0) {
+            return 0;
+        }
+        return this.hits / total;
+    }
+
+    private evictOldest(): TKey | undefined {
+        const oldest = this.cache.entries().next();
+        if (oldest.done) {
+            return undefined;
+        }
+
+        const [key, entry] = oldest.value;
+        this.cache.delete(key);
+        this.currentSize -= entry.size;
+        this.evictions += 1;
+        return key;
+    }
+
+    private normalizeSize(size: number): number {
+        if (!Number.isFinite(size) || size <= 0) {
+            return DEFAULT_ENTRY_SIZE;
+        }
+        return Math.ceil(size);
+    }
+}

--- a/packages/pike-lsp-server/src/tests/pike-analyzer/caching.test.ts
+++ b/packages/pike-lsp-server/src/tests/pike-analyzer/caching.test.ts
@@ -1,619 +1,222 @@
-/**
- * Pike Caching Tests (Phase 8: Task 43)
- *
- * Tests for Pike caching mechanisms:
- * - LRU Cache (hit, miss, eviction, statistics)
- * - Compilation Cache (store, hit/miss, invalidation, transitive invalidation)
- *
- * Run with: bun test dist/src/tests/pike-analyzer/caching.test.js
- */
-
-/**
- * PLACEHOLDER TESTS
- *
- * This file contains placeholder tests for Pike caching methods that are not yet implemented.
- * These tests document the expected behavior for:
- * - LRUCache.get() / set() / clear() - basic cache operations
- * - LRUCache.getStats() / getHitRate() - cache statistics
- * - LRUCache eviction and access ordering
- * - CompilationCache.store() / get() / invalidate() / transitiveInvalidate()
- * - CompilationCache serialization/deserialization and time eviction
- *
- * These tests will be implemented once the Pike analyzer supports the corresponding caching methods.
- */
-
 import { describe, it } from 'bun:test';
 import * as assert from 'node:assert/strict';
+import { LRUCache } from '../../services/lru-cache.js';
+import { CompilationCache } from '../../services/compilation-cache.js';
 
-// ============================================================================
-// Helper Functions
-// ============================================================================
-
-/**
- * Creates a mock LRU cache entry.
- */
-function createMockLRUEntry<T>(value: T, size: number = 1): { value: T; size: number } {
-  return { value, size };
+interface AnalysisResult {
+    symbols: string[];
+    diagnostics: Array<{ message: string; severity: 'error' | 'warning' }>;
 }
 
-/**
- * Creates a mock cache statistics object.
- */
-function createMockStats(
-  overrides: {
-    hits?: number;
-    misses?: number;
-    evictions?: number;
-    size?: number;
-    maxSize?: number;
-  } = {}
-): any {
-  return {
-    hits: overrides.hits ?? 0,
-    misses: overrides.misses ?? 0,
-    evictions: overrides.evictions ?? 0,
-    size: overrides.size ?? 0,
-    maxSize: overrides.maxSize ?? 100,
-    ...overrides,
-  };
+function createResult(symbols: string[], diagnostics: AnalysisResult['diagnostics'] = []): AnalysisResult {
+    return { symbols, diagnostics };
 }
 
-/**
- * Creates a mock compilation cache entry.
- */
-function createMockCompilationEntry(
-  overrides: {
-    code?: string;
-    result?: any;
-    dependencies?: string[];
-    timestamp?: number;
-  } = {}
-): any {
-  return {
-    code: overrides.code ?? 'int x;',
-    result: overrides.result ?? { symbols: [] },
-    dependencies: overrides.dependencies ?? [],
-    timestamp: overrides.timestamp ?? Date.now(),
-    ...overrides,
-  };
-}
+describe('LRUCache', () => {
+    it('tracks cache hits and misses through get()', () => {
+        const cache = new LRUCache<string, string>({ maxSize: 3 });
 
-// ============================================================================
-// Phase 8 Task 43.1: Caching - LRU Cache
-// ============================================================================
+        cache.set('a', 'alpha');
 
-describe.skip('Phase 8 Task 43.1: Caching - LRU Cache', () => {
-  it('43.1.1: should have cache hit on subsequent access', () => {
-    // TODO: Implement LRUCache.get()
-    const cache = new Map<string, any>();
-    const key = 'test-key';
-    const value = createMockLRUEntry({ data: 'test-data' }, 10);
+        assert.equal(cache.get('a'), 'alpha', 'existing key should be a hit');
+        assert.equal(cache.get('missing'), undefined, 'missing key should be a miss');
 
-    // First access - miss
-    cache.set(key, value);
-    const stats = createMockStats({ misses: 1, size: 10 });
-
-    // Second access - hit
-    const result = cache.get(key);
-    stats.hits += 1;
-
-    assert.ok(result);
-    assert.equal(stats.hits, 1);
-    assert.equal(stats.misses, 1);
-  });
-
-  it('43.1.2: should have cache miss on first access', () => {
-    // TODO: Implement LRUCache.get()
-    const cache = new Map<string, any>();
-    const key = 'nonexistent-key';
-
-    const result = cache.get(key);
-    const stats = createMockStats({ misses: 1 });
-
-    assert.equal(result, undefined);
-    assert.equal(stats.misses, 1);
-  });
-
-  it('43.1.3: should evict least recently used entry when full', () => {
-    // TODO: Implement LRUCache.evict()
-    const maxSize = 100;
-    const cache = new Map<string, { value: any; size: number }>();
-    const stats = createMockStats({ maxSize, size: 0 });
-
-    // Fill cache
-    cache.set('key1', createMockLRUEntry('data1', 40));
-    stats.size = 40;
-    cache.set('key2', createMockLRUEntry('data2', 40));
-    stats.size = 80;
-
-    // Add entry that exceeds capacity
-    cache.set('key3', createMockLRUEntry('data3', 30));
-
-    // Should evict key1 (LRU)
-    cache.delete('key1');
-    stats.size = 80 - 40 + 30; // 70
-    stats.evictions += 1;
-
-    assert.equal(stats.size, 70);
-    assert.equal(stats.evictions, 1);
-    assert.ok(!cache.has('key1'));
-    assert.ok(cache.has('key2'));
-    assert.ok(cache.has('key3'));
-  });
-
-  it('43.1.4: should track cache statistics accurately', () => {
-    // TODO: Implement LRUCache.getStats()
-    const cache = new Map<string, any>();
-    const stats = createMockStats({ maxSize: 100, size: 0 });
-
-    // Add entries
-    cache.set('a', createMockLRUEntry('data-a', 20));
-    stats.size = 20;
-    cache.set('b', createMockLRUEntry('data-b', 30));
-    stats.size = 50;
-
-    // Hits
-    cache.get('a');
-    stats.hits += 1;
-    cache.get('b');
-    stats.hits += 1;
-
-    // Misses
-    cache.get('nonexistent');
-    stats.misses += 1;
-
-    // Evictions
-    cache.set('c', createMockLRUEntry('data-c', 60));
-    cache.delete('a'); // Evict LRU
-    stats.evictions += 1;
-    stats.size = 50 - 20 + 60; // 90
-
-    assert.equal(stats.hits, 2);
-    assert.equal(stats.misses, 1);
-    assert.equal(stats.evictions, 1);
-    assert.equal(stats.size, 90);
-  });
-
-  it('43.1.5: should update LRU order on access', () => {
-    // TODO: Implement LRUCache access ordering
-    const cache = new Map<string, any>();
-    const accessOrder: string[] = [];
-
-    // Add entries
-    cache.set('key1', createMockLRUEntry('data1', 10));
-    accessOrder.push('key1');
-    cache.set('key2', createMockLRUEntry('data2', 10));
-    accessOrder.push('key2');
-    cache.set('key3', createMockLRUEntry('data3', 10));
-    accessOrder.push('key3');
-
-    // Access key1 (should become most recent)
-    cache.get('key1');
-    accessOrder.splice(accessOrder.indexOf('key1'), 1);
-    accessOrder.push('key1');
-
-    assert.equal(accessOrder[accessOrder.length - 1], 'key1');
-  });
-
-  it('43.1.6: should handle large entries correctly', () => {
-    // TODO: Implement LRUCache size calculation
-    const maxSize = 100;
-    const cache = new Map<string, any>();
-    const stats = createMockStats({ maxSize, size: 0 });
-
-    // Entry larger than max size
-    const largeEntry = createMockLRUEntry('large-data', 150);
-
-    // Should not add entry if it exceeds max size
-    if (largeEntry.size > maxSize) {
-      stats.misses += 1;
-    }
-
-    assert.equal(stats.size, 0);
-    assert.equal(cache.size, 0);
-  });
-
-  it('43.1.7: should clear all cache entries', () => {
-    // TODO: Implement LRUCache.clear()
-    const cache = new Map<string, any>();
-    const stats = createMockStats({ size: 0 });
-
-    // Fill cache
-    cache.set('key1', createMockLRUEntry('data1', 10));
-    stats.size = 10;
-    cache.set('key2', createMockLRUEntry('data2', 20));
-    stats.size = 30;
-
-    // Clear
-    cache.clear();
-    stats.size = 0;
-
-    assert.equal(cache.size, 0);
-    assert.equal(stats.size, 0);
-  });
-
-  it('43.1.8: should handle concurrent access safely', () => {
-    // TODO: Implement LRUCache thread safety
-    const cache = new Map<string, any>();
-    const stats = createMockStats({ size: 0 });
-
-    // Simulate concurrent access
-    const operations = [
-      () => cache.set('key1', createMockLRUEntry('data1', 10)),
-      () => cache.get('key1'),
-      () => cache.set('key2', createMockLRUEntry('data2', 10)),
-      () => cache.get('key2'),
-    ];
-
-    operations.forEach(op => {
-      op();
+        const stats = cache.getStats();
+        assert.equal(stats.hits, 1);
+        assert.equal(stats.misses, 1);
+        assert.equal(cache.getHitRate(), 0.5);
     });
-    stats.size = 20;
 
-    assert.equal(cache.size, 2);
-    assert.equal(stats.size, 20);
-  });
+    it('evicts least-recently-used entry when max size is exceeded', () => {
+        const cache = new LRUCache<string, string>({ maxSize: 2 });
 
-  it('43.1.9: should calculate entry size correctly', () => {
-    // TODO: Implement LRUCache size calculation
-    const entry1 = createMockLRUEntry({ data: 'test' }, 10);
-    const entry2 = createMockLRUEntry({ data: [1, 2, 3] }, 20);
+        cache.set('a', 'alpha');
+        cache.set('b', 'bravo');
+        cache.get('a');
+        cache.set('c', 'charlie');
 
-    const totalSize = entry1.size + entry2.size;
+        assert.equal(cache.get('b'), undefined, 'entry b should be evicted as least recently used');
+        assert.equal(cache.get('a'), 'alpha');
+        assert.equal(cache.get('c'), 'charlie');
+        assert.equal(cache.getStats().evictions, 1);
+    });
 
-    assert.equal(totalSize, 30);
-  });
+    it('uses configured size estimator and rejects oversize entries', () => {
+        const cache = new LRUCache<string, string>({
+            maxSize: 4,
+            sizeEstimator: value => value.length,
+        });
 
-  it('43.1.10: should handle cache with zero max size', () => {
-    // TODO: Implement LRUCache with zero capacity
-    const maxSize = 0;
-    const cache = new Map<string, any>();
-    const stats = createMockStats({ maxSize, size: 0 });
+        const stored = cache.set('oversize', '12345');
 
-    // Try to add entry
-    const entry = createMockLRUEntry('data', 10);
-    if (maxSize === 0 || entry.size > maxSize) {
-      stats.misses += 1;
-    }
+        assert.equal(stored, false, 'entry larger than max size should not be stored');
+        assert.equal(cache.entryCount, 0);
+        assert.equal(cache.size, 0);
+    });
 
-    assert.equal(cache.size, 0);
-    assert.equal(stats.size, 0);
-  });
+    it('updates existing entry and recalculates total size', () => {
+        const cache = new LRUCache<string, string>({
+            maxSize: 10,
+            sizeEstimator: value => value.length,
+        });
 
-  it('43.1.11: should update existing entry', () => {
-    // TODO: Implement LRUCache.set() update
-    const cache = new Map<string, any>();
-    const key = 'test-key';
+        cache.set('item', 'ab');
+        cache.set('item', 'abcdef');
 
-    cache.set(key, createMockLRUEntry('old-data', 10));
-    cache.set(key, createMockLRUEntry('new-data', 15));
+        assert.equal(cache.get('item'), 'abcdef');
+        assert.equal(cache.size, 6);
+        assert.equal(cache.entryCount, 1);
+    });
 
-    const result = cache.get(key);
+    it('clear() removes all entries and keeps stats readable', () => {
+        const cache = new LRUCache<string, number>({ maxSize: 5 });
 
-    assert.equal(result.value, 'new-data');
-  });
+        cache.set('a', 1);
+        cache.set('b', 2);
+        cache.get('a');
+        cache.clear();
 
-  it('43.1.12: should provide hit rate calculation', () => {
-    // TODO: Implement LRUCache.getHitRate()
-    const stats = createMockStats({ hits: 80, misses: 20 });
+        assert.equal(cache.entryCount, 0);
+        assert.equal(cache.size, 0);
 
-    const hitRate = stats.hits / (stats.hits + stats.misses);
+        const stats = cache.getStats();
+        assert.equal(stats.hits, 1, 'clear should not erase collected telemetry');
+        assert.equal(stats.size, 0);
+    });
 
-    assert.equal(hitRate, 0.8);
-  });
+    it('maintains integrity during interleaved async access', async () => {
+        const cache = new LRUCache<string, string>({ maxSize: 3 });
+
+        await Promise.all([
+            Promise.resolve().then(() => {
+                cache.set('a', 'alpha');
+            }),
+            Promise.resolve().then(() => {
+                cache.set('b', 'bravo');
+            }),
+            Promise.resolve().then(() => {
+                cache.set('c', 'charlie');
+                cache.get('a');
+            }),
+            Promise.resolve().then(() => {
+                cache.set('d', 'delta');
+            }),
+        ]);
+
+        assert.ok(cache.entryCount <= 3, 'cache should never exceed configured max size');
+        assert.equal(cache.get('d'), 'delta', 'latest write should be retained');
+    });
 });
 
-// ============================================================================
-// Phase 8 Task 43.2: Caching - Compilation Cache
-// ============================================================================
+describe('CompilationCache', () => {
+    it('stores and returns entry when code is unchanged', () => {
+        const cache = new CompilationCache<AnalysisResult>({ maxSize: 100 });
+        const uri = 'file:///main.pike';
+        const code = 'int x = 1;';
 
-describe.skip('Phase 8 Task 43.2: Caching - Compilation Cache', () => {
-  it('43.2.1: should store compilation result', async () => {
-    // TODO: Implement CompilationCache.store()
-    const code = 'int x = 5;';
-    const uri = 'file:///test.pike';
-    const cache = new Map<string, any>();
+        const stored = cache.store(uri, code, createResult(['x']));
+        const cached = cache.get(uri, code);
 
-    const entry = createMockCompilationEntry({
-      code,
-      result: { symbols: [{ name: 'x', kind: 'variable' }] },
-      dependencies: [],
+        assert.equal(stored, true);
+        assert.ok(cached, 'entry should be available immediately after store');
+        assert.deepEqual(cached?.result.symbols, ['x']);
     });
 
-    cache.set(uri, entry);
+    it('returns cache miss when code changes', () => {
+        const cache = new CompilationCache<AnalysisResult>({ maxSize: 100 });
+        const uri = 'file:///main.pike';
 
-    assert.ok(cache.has(uri));
-    assert.equal(cache.get(uri).code, code);
-  });
+        cache.store(uri, 'int x = 1;', createResult(['x']));
+        const cached = cache.get(uri, 'int x = 2;');
 
-  it('43.2.2: should have cache hit when code unchanged', async () => {
-    // TODO: Implement CompilationCache.get() valid
-    const code = 'int x = 5;';
-    const uri = 'file:///test.pike';
-    const cache = new Map<string, any>();
-
-    // Store
-    const entry = createMockCompilationEntry({
-      code,
-      result: { symbols: [] },
-    });
-    cache.set(uri, entry);
-
-    // Retrieve - hit
-    const cached = cache.get(uri);
-    const isHit = cached && cached.code === code;
-
-    assert.ok(isHit);
-    assert.equal(cached.code, code);
-  });
-
-  it('43.2.3: should have cache miss when code changed', async () => {
-    // TODO: Implement CompilationCache.get() invalid
-    const oldCode = 'int x = 5;';
-    const newCode = 'int x = 10;';
-    const uri = 'file:///test.pike';
-    const cache = new Map<string, any>();
-
-    // Store old version
-    cache.set(uri, createMockCompilationEntry({ code: oldCode }));
-
-    // Try to retrieve with new code - miss
-    const cached = cache.get(uri);
-    const isMiss = !cached || cached.code !== newCode;
-
-    assert.ok(isMiss);
-  });
-
-  it('43.2.4: should invalidate entry when dependency changes', async () => {
-    // TODO: Implement CompilationCache.invalidate()
-    const mainCode = 'int x = 5;';
-    const depUri = 'file:///dep.pike';
-    const mainUri = 'file:///main.pike';
-    const cache = new Map<string, any>();
-
-    // Store with dependency
-    cache.set(
-      mainUri,
-      createMockCompilationEntry({
-        code: mainCode,
-        dependencies: [depUri],
-      })
-    );
-
-    // Invalidate dependency
-    cache.delete(depUri);
-    const mainEntry = cache.get(mainUri);
-    if (mainEntry) {
-      mainEntry.invalidated = true;
-    }
-
-    assert.equal(mainEntry.invalidated, true);
-  });
-
-  it('43.2.5: should handle transitive invalidation', async () => {
-    // TODO: Implement CompilationCache.transitiveInvalidate()
-    const cache = new Map<string, any>();
-
-    // A depends on B, B depends on C
-    cache.set(
-      'file:///a.pike',
-      createMockCompilationEntry({
-        dependencies: ['file:///b.pike'],
-      })
-    );
-    cache.set(
-      'file:///b.pike',
-      createMockCompilationEntry({
-        dependencies: ['file:///c.pike'],
-      })
-    );
-    cache.set(
-      'file:///c.pike',
-      createMockCompilationEntry({
-        dependencies: [],
-      })
-    );
-
-    // Invalidate C
-    cache.delete('file:///c.pike');
-
-    // B should be invalidated
-    const bEntry = cache.get('file:///b.pike');
-    if (bEntry) bEntry.invalidated = true;
-
-    // A should be invalidated
-    const aEntry = cache.get('file:///a.pike');
-    if (aEntry) aEntry.invalidated = true;
-
-    assert.equal(bEntry.invalidated, true);
-    assert.equal(aEntry.invalidated, true);
-  });
-
-  it('43.2.6: should cache compilation errors', async () => {
-    // TODO: Implement CompilationCache.store() with errors
-    const code = 'int x = ';
-    const uri = 'file:///test.pike';
-    const cache = new Map<string, any>();
-
-    const entry = createMockCompilationEntry({
-      code,
-      result: {
-        symbols: [],
-        diagnostics: [{ message: 'Syntax error', severity: 'error' }],
-      },
+        assert.equal(cached, undefined, 'cache should be keyed by exact code content');
     });
 
-    cache.set(uri, entry);
+    it('invalidates direct dependency entries', () => {
+        const cache = new CompilationCache<AnalysisResult>({ maxSize: 100 });
+        const depUri = 'file:///dep.pike';
+        const mainUri = 'file:///main.pike';
 
-    assert.ok(cache.has(uri));
-    assert.equal(entry.result.diagnostics.length, 1);
-  });
+        cache.store(depUri, 'int dep = 1;', createResult(['dep']));
+        cache.store(mainUri, 'inherit "dep";', createResult(['main']), [depUri]);
 
-  it('43.2.7: should handle cache with multiple files', async () => {
-    // TODO: Implement CompilationCache.multiFile()
-    const files = [
-      { uri: 'file:///a.pike', content: 'int a;' },
-      { uri: 'file:///b.pike', content: 'int b;' },
-      { uri: 'file:///c.pike', content: 'int c;' },
-    ];
-    const cache = new Map<string, any>();
+        const invalidated = cache.invalidate(depUri);
 
-    files.forEach(file => {
-      cache.set(
-        file.uri,
-        createMockCompilationEntry({
-          code: file.content,
-        })
-      );
+        assert.deepEqual(invalidated, [depUri]);
+        assert.equal(cache.get(depUri, 'int dep = 1;'), undefined);
+        assert.ok(cache.get(mainUri, 'inherit "dep";'), 'non-transitive invalidation should keep dependent entry');
     });
 
-    assert.equal(cache.size, 3);
-  });
+    it('invalidates transitive dependents through dependency graph', () => {
+        const cache = new CompilationCache<AnalysisResult>({ maxSize: 100 });
 
-  it('43.2.8: should track compilation timestamps', async () => {
-    // TODO: Implement CompilationCache.timestamps()
-    const before = Date.now();
-    const uri = 'file:///test.pike';
-    const cache = new Map<string, any>();
+        const uriA = 'file:///a.pike';
+        const uriB = 'file:///b.pike';
+        const uriC = 'file:///c.pike';
 
-    cache.set(
-      uri,
-      createMockCompilationEntry({
-        code: 'int x;',
-        timestamp: before,
-      })
-    );
+        cache.store(uriA, 'inherit "b";', createResult(['A']), [uriB]);
+        cache.store(uriB, 'inherit "c";', createResult(['B']), [uriC]);
+        cache.store(uriC, 'int c = 1;', createResult(['C']));
 
-    const after = Date.now();
-    const entry = cache.get(uri);
+        const invalidated = cache.invalidate(uriC, true).sort();
 
-    assert.ok(entry.timestamp >= before && entry.timestamp <= after);
-  });
+        assert.deepEqual(invalidated, [uriA, uriB, uriC].sort());
+        assert.equal(cache.size, 0);
+    });
 
-  it('43.2.9: should handle cache eviction based on time', async () => {
-    // TODO: Implement CompilationCache.timeEviction()
-    const maxAge = 1000; // 1 second
-    const now = Date.now();
-    const cache = new Map<string, any>();
+    it('keeps compilation diagnostics in cached result', () => {
+        const cache = new CompilationCache<AnalysisResult>({ maxSize: 100 });
+        const uri = 'file:///broken.pike';
+        const code = 'int x = ;';
+        const diagnostics = [{ message: 'Syntax error', severity: 'error' as const }];
 
-    // Old entry
-    cache.set(
-      'old.pike',
-      createMockCompilationEntry({
-        code: 'int x;',
-        timestamp: now - maxAge - 100,
-      })
-    );
+        cache.store(uri, code, createResult([], diagnostics));
+        const cached = cache.get(uri, code);
 
-    // New entry
-    cache.set(
-      'new.pike',
-      createMockCompilationEntry({
-        code: 'int y;',
-        timestamp: now,
-      })
-    );
+        assert.ok(cached);
+        assert.equal(cached?.result.diagnostics.length, 1);
+        assert.equal(cached?.result.diagnostics[0]?.message, 'Syntax error');
+    });
 
-    // Evict old entries
-    const oldEntry = cache.get('old.pike');
-    if (oldEntry && now - oldEntry.timestamp > maxAge) {
-      cache.delete('old.pike');
-    }
+    it('evicts entries older than max age threshold', () => {
+        const cache = new CompilationCache<AnalysisResult>({ maxSize: 100, clock: () => 10_000 });
 
-    assert.equal(cache.size, 1);
-    assert.ok(cache.has('new.pike'));
-    assert.ok(!cache.has('old.pike'));
-  });
+        cache.store('file:///old.pike', 'int old;', createResult(['old']), [], 1_000);
+        cache.store('file:///new.pike', 'int fresh;', createResult(['fresh']), [], 9_800);
 
-  it('43.2.10: should serialize cache to disk', async () => {
-    // TODO: Implement CompilationCache.serialize()
-    const cache = new Map<string, any>();
+        const evicted = cache.evictOlderThan(3_000, 10_000);
 
-    cache.set(
-      'test.pike',
-      createMockCompilationEntry({
-        code: 'int x;',
-        result: { symbols: [] },
-      })
-    );
+        assert.deepEqual(evicted, ['file:///old.pike']);
+        assert.equal(cache.get('file:///old.pike', 'int old;'), undefined);
+        assert.ok(cache.get('file:///new.pike', 'int fresh;'));
+    });
 
-    const serialized = JSON.stringify(Array.from(cache.entries()));
-    const deserialized = new Map(JSON.parse(serialized));
+    it('serializes and deserializes cache entries', () => {
+        const cache = new CompilationCache<AnalysisResult>({ maxSize: 100 });
 
-    assert.equal(deserialized.size, 1);
-    assert.ok(deserialized.has('test.pike'));
-  });
+        cache.store('file:///a.pike', 'int a;', createResult(['a']), ['file:///shared.pike'], 123);
+        cache.store('file:///b.pike', 'int b;', createResult(['b']), [], 456);
 
-  it('43.2.11: should deserialize cache from disk', async () => {
-    // TODO: Implement CompilationCache.deserialize()
-    const data: [string, any][] = [
-      [
-        'test.pike',
-        createMockCompilationEntry({
-          code: 'int x;',
-          result: { symbols: [] },
-        }),
-      ],
-    ];
+        const serialized = cache.serialize();
+        const restored = CompilationCache.deserialize<AnalysisResult>(serialized, { maxSize: 100 });
 
-    const cache = new Map(data);
+        const restoredA = restored.get('file:///a.pike', 'int a;');
+        const restoredB = restored.get('file:///b.pike', 'int b;');
 
-    assert.equal(cache.size, 1);
-    assert.ok(cache.has('test.pike'));
-  });
+        assert.ok(restoredA);
+        assert.ok(restoredB);
+        assert.deepEqual(restoredA?.dependencies, ['file:///shared.pike']);
+        assert.equal(restoredA?.timestamp, 123);
+        assert.deepEqual(restoredB?.result.symbols, ['b']);
+    });
 
-  it('43.2.12: should handle cache corruption gracefully', async () => {
-    // TODO: Implement CompilationCache.errorHandling()
-    const cache = new Map<string, any>();
+    it('handles corrupted serialized payload without throwing', () => {
+        const corrupted = '{this-is-not-json';
 
-    // Corrupted entry
-    cache.set('corrupted.pike', { invalid: 'data' });
+        const restored = CompilationCache.deserialize<AnalysisResult>(corrupted, { maxSize: 100 });
 
-    try {
-      const entry = cache.get('corrupted.pike');
-      // Should handle corruption
-      if (!entry || !entry.code) {
-        cache.delete('corrupted.pike');
-      }
-    } catch (e) {
-      cache.delete('corrupted.pike');
-    }
-
-    assert.equal(cache.size, 0);
-  });
-});
-
-// ============================================================================
-// Test Summary
-// ============================================================================
-
-describe.skip('Phase 8 Task 43: Caching Test Summary', () => {
-  it('should have 2 subtasks with comprehensive coverage', () => {
-    const subtasks = ['43.1: LRU Cache', '43.2: Compilation Cache'];
-
-    assert.equal(subtasks.length, 2);
-  });
-
-  it('should have placeholder tests for all caching features', () => {
-    const totalTests = 12 + 12;
-    assert.equal(totalTests, 24, 'Should have 24 total caching tests');
-  });
-
-  it('should cover all caching capabilities', () => {
-    const capabilities = ['lruCache', 'compilationCache'];
-
-    assert.equal(capabilities.length, 2);
-  });
-
-  it('should test cache performance characteristics', () => {
-    const performanceTests = [
-      'eviction',
-      'hitRate',
-      'concurrentAccess',
-      'sizeCalculation',
-      'timeEviction',
-    ];
-
-    assert.ok(performanceTests.length >= 5);
-  });
+        assert.equal(restored.size, 0);
+        assert.equal(restored.getStats().hits, 0);
+        assert.equal(restored.getStats().misses, 0);
+    });
 });


### PR DESCRIPTION
## Summary
- Implement a strict-typed TypeScript-side `LRUCache` with hit/miss/eviction stats, hit-rate calculation, weighted sizing, access-order updates, and bounded eviction.
- Implement a `CompilationCache` wrapper that supports code-sensitive lookups, dependency tracking, direct/transitive invalidation, time-based eviction, and safe serialization/deserialization.
- Replace `pike-analyzer/caching.test.ts` placeholder TODO suites with active regression tests asserting exact cache behavior across LRU and compilation-cache scenarios.

## Verification
- `bun test src/tests/pike-analyzer/caching.test.ts`
- `bun test src/tests/document-cache.test.ts`
- `bun test src/tests/pike-analyzer`
- `bun run typecheck`
- `bun run build`
- `lsp_diagnostics` on modified files

## Notes
- `bun test src/tests/pike-analyzer` still reports an existing module-resolution issue in `intelligence.test.ts` (`@pike-lsp/core`), outside this change.
- `bun run typecheck` and `bun run build` currently fail due pre-existing workspace/package setup issues and unrelated baseline errors in this branch.

Closes #875