### PR TITLE
fix: decode moniker paths from file URIs (#909)

### DIFF
--- a/packages/pike-lsp-server/src/features/advanced/moniker.ts
+++ b/packages/pike-lsp-server/src/features/advanced/moniker.ts
@@ -11,11 +11,12 @@
  */
 
 import type { PikeSymbol } from '@pike-lsp/pike-bridge';
-import { Connection, Moniker, MonikerParams } from 'vscode-languageserver/node.js';
+import { Connection, Moniker, MonikerParams, UniquenessLevel } from 'vscode-languageserver/node.js';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { TextDocuments } from 'vscode-languageserver/node.js';
 import type { Services } from '../../services/index.js';
 import { Logger } from '@pike-lsp/core';
+import { uriToFsPath } from '../../utils/uri-path.js';
 
 /**
  * Supported moniker schemes for Pike
@@ -57,8 +58,7 @@ export function registerMonikerHandler(
     return {
       scheme: scheme,
       identifier: uniqueId,
-      // @ts-expect-error - unique is optional in older LSP versions
-      unique: uniqueId,
+      unique: UniquenessLevel.scheme,
     };
   }
 
@@ -137,7 +137,7 @@ export function registerMonikerHandler(
       }
 
       // Generate moniker for the found symbol
-      const filePath = uri.replace(/^file:\/\//, '').replace(/^\//, '');
+      const filePath = uriToFsPath(uri);
       const scheme = getSchemeForKind(foundSymbol.kind);
 
       const moniker = generateMoniker(foundSymbol.name, foundSymbol.kind, filePath, scheme);
@@ -154,8 +154,8 @@ export function registerMonikerHandler(
   /**
    * Handler for $/logMessage - log message from client (noop, for protocol compliance)
    */
-  connection.onRequest('$/logMessage', async params => {
-    log.debug('Log message request', params);
+  connection.onRequest('$/logMessage', async (params: unknown) => {
+    log.debug('Log message request', { params });
     return null;
   });
 

--- a/packages/pike-lsp-server/src/tests/helpers/mock-services.ts
+++ b/packages/pike-lsp-server/src/tests/helpers/mock-services.ts
@@ -131,6 +131,7 @@ export interface MockConnection {
   typeHierarchySubtypesHandler: TypeHierarchySubtypesHandler;
   semanticTokensHandler: any;
   semanticTokensDeltaHandler: any;
+  monikerHandler: any;
   getRequestHandler(method: string): ((params: unknown) => unknown) | undefined;
 }
 
@@ -153,6 +154,7 @@ export function createMockConnection(): MockConnection {
   let _typeHierarchySubtypesHandler: TypeHierarchySubtypesHandler | null = null;
   let _semanticTokensHandler: any = null;
   let _semanticTokensDeltaHandler: any = null;
+  let _monikerHandler: any = null;
   const _requestHandlers = new Map<string, (params: unknown) => unknown>();
 
   return {
@@ -220,7 +222,9 @@ export function createMockConnection(): MockConnection {
         },
       },
       moniker: {
-        on(_handler: any) {},
+        on(handler: any) {
+          _monikerHandler = handler;
+        },
       },
     },
     get definitionHandler(): DefinitionHandler {
@@ -279,6 +283,10 @@ export function createMockConnection(): MockConnection {
       if (!_semanticTokensDeltaHandler)
         throw new Error('No semantic tokens delta handler registered');
       return _semanticTokensDeltaHandler;
+    },
+    get monikerHandler(): any {
+      if (!_monikerHandler) throw new Error('No moniker handler registered');
+      return _monikerHandler;
     },
     getRequestHandler(method: string): ((params: unknown) => unknown) | undefined {
       return _requestHandlers.get(method);

--- a/packages/pike-lsp-server/src/tests/runtime-protocol-compliance.test.ts
+++ b/packages/pike-lsp-server/src/tests/runtime-protocol-compliance.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from 'bun:test';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { registerNavigationHandlers } from '../features/navigation/index.js';
 import { registerCompletionHandlers } from '../features/editing/completion.js';
@@ -8,7 +7,11 @@ import {
   createMockConnection,
   createMockDocuments,
   createMockServices,
+  makeCacheEntry,
+  sym,
 } from './helpers/mock-services.js';
+
+const { describe, it, expect } = require('bun:test');
 
 const documents = createMockDocuments(new Map<string, TextDocument>());
 const services = createMockServices();
@@ -94,5 +97,41 @@ describe('Runtime Protocol Compliance', () => {
     const result = await cancelRequestHandler?.({ id: 42 });
     expect(result).toBeNull();
     expect(seen).toEqual(['42']);
+  });
+
+  it('decodes encoded file URIs when generating monikers', async () => {
+    const uri = 'file:///tmp/encoded%20dir/alpha%23beta.pike';
+    const document = TextDocument.create(uri, 'pike', 1, 'void encodedSymbol() {}\n');
+    const documentsWithFile = createMockDocuments(new Map([[uri, document]]));
+    const servicesWithCache = createMockServices({
+      cacheEntries: new Map([
+        [
+          uri,
+          makeCacheEntry({
+            symbols: [
+              sym('encodedSymbol', 'function', {
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 0, character: 22 },
+                },
+              }),
+            ],
+          }),
+        ],
+      ]),
+    });
+
+    const connection = createMockConnection();
+    registerMonikerHandler(connection as any, servicesWithCache as any, documentsWithFile as any);
+
+    const monikerHandler = connection.monikerHandler;
+    const result = await monikerHandler({ textDocument: { uri }, position: { line: 0, character: 5 } });
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toMatchObject({
+      scheme: 'pike',
+      identifier: '/tmp/encoded dir/alpha#beta/encodedSymbol',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Use shared URI-to-filesystem conversion for moniker path generation so percent-encoded paths decode correctly.
- Extend runtime protocol compliance mocks/tests to validate decoded moniker identifiers.
- Align moniker URI handling with existing server URI normalization utilities.

Fixes #909