### PR TITLE
perf: make workspace-index search cache eviction O(1) (#907)

### DIFF
--- a/packages/pike-lsp-server/src/tests/workspace-index-file-loading.test.ts
+++ b/packages/pike-lsp-server/src/tests/workspace-index-file-loading.test.ts
@@ -143,6 +143,25 @@ describe('WorkspaceIndex file loading', () => {
     }
   });
 
+  it('evicts the oldest search cache entry when the cache is full', () => {
+    const index = new WorkspaceIndex({ isRunning: () => true } as any);
+
+    for (let i = 0; i < 100; i++) {
+      const results = index.searchSymbols(`query-${i}`, 1);
+      expect(results).toEqual([]);
+    }
+
+    expect((index as any).searchCache.size).toBe(100);
+    expect(Array.from((index as any).searchCache.keys())[0]).toBe('query-0:1');
+
+    const evictedResults = index.searchSymbols('query-100', 1);
+    expect(evictedResults).toEqual([]);
+    expect((index as any).searchCache.size).toBe(100);
+    expect((index as any).searchCache.has('query-0:1')).toBe(false);
+    expect((index as any).searchCache.has('query-1:1')).toBe(true);
+    expect((index as any).searchCache.has('query-100:1')).toBe(true);
+  });
+
   it('keeps container metadata without mutating source symbols', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'workspace-index-container-'));
     try {

--- a/packages/pike-lsp-server/src/workspace-index.ts
+++ b/packages/pike-lsp-server/src/workspace-index.ts
@@ -413,18 +413,9 @@ export class WorkspaceIndex {
         // Return top results
         const finalResults = matched.slice(0, limit).map(m => m.result);
 
-        // PERF-430: Store in cache (with LRU eviction)
         if (this.searchCache.size >= WorkspaceIndex.SEARCH_CACHE_MAX_SIZE) {
-            // Remove oldest entry
-            let oldestKey: string | null = null;
-            let oldestTime = Infinity;
-            for (const [key, entry] of this.searchCache) {
-                if (entry.timestamp < oldestTime) {
-                    oldestTime = entry.timestamp;
-                    oldestKey = key;
-                }
-            }
-            if (oldestKey) {
+            const oldestKey = this.searchCache.keys().next().value;
+            if (oldestKey !== undefined) {
                 this.searchCache.delete(oldestKey);
             }
         }


### PR DESCRIPTION
## Summary
- Replace full-map oldest-entry scan in workspace search cache eviction with O(1) insertion-order eviction.
- Preserve cache size cap and existing cache behavior.
- Add regression coverage to verify oldest query eviction at capacity.

Fixes #907