### PR TITLE
fix: reject pending requests on response processing errors (#908)

### DIFF
--- a/packages/pike-bridge/src/bridge.test.ts
+++ b/packages/pike-bridge/src/bridge.test.ts
@@ -722,6 +722,64 @@ foo(@args);
     );
   });
 
+  it('should emit stderr for non-JSON response lines', () => {
+    const localBridge = new PikeBridge();
+    const stderrMessages: string[] = [];
+
+    localBridge.on('stderr', message => {
+      stderrMessages.push(message);
+    });
+
+    (localBridge as any).handleResponse('not-json-at-all');
+
+    assert.deepEqual(stderrMessages, ['not-json-at-all']);
+    assert.equal((localBridge as any).pendingRequests.size, 0);
+  });
+
+  it('should reject pending requests when response processing fails', () => {
+    const localBridge = new PikeBridge();
+    const timeout = setTimeout(() => undefined, 10000);
+    let rejectedMessage = '';
+    let loggerErrorArgs: unknown[] | null = null;
+    const originalLoggerError = (localBridge as any).logger.error;
+    const originalBuildResponseResult = (localBridge as any).buildResponseResult;
+
+    (localBridge as any).logger.error = (...args: unknown[]) => {
+      loggerErrorArgs = args;
+    };
+    (localBridge as any).buildResponseResult = () => {
+      throw new Error('boom after parse');
+    };
+    (localBridge as any).pendingRequests.set(7, {
+      resolve: () => undefined,
+      reject: (error: Error) => {
+        rejectedMessage = error.message;
+      },
+      timeout,
+    });
+
+    try {
+      (localBridge as any).handleResponse(JSON.stringify({ id: 7, result: { ok: 1 } }));
+
+      assert.equal((localBridge as any).pendingRequests.size, 0);
+      assert.match(
+        rejectedMessage,
+        /Failed to process Pike response: boom after parse/,
+        'Processing failures should reject the pending request immediately'
+      );
+      assert.ok(loggerErrorArgs, 'Processing failures should be logged as errors');
+      assert.equal(loggerErrorArgs?.[0], 'Failed to process Pike response');
+
+      const details = loggerErrorArgs?.[1] as Record<string, unknown> | undefined;
+      assert.equal(details?.['responseId'], 7);
+      assert.equal(details?.['error'], 'boom after parse');
+    } finally {
+      clearTimeout(timeout);
+      (localBridge as any).logger.error = originalLoggerError;
+      (localBridge as any).buildResponseResult = originalBuildResponseResult;
+    }
+  });
+
   it('should reject pending requests on stop even without exit event', async () => {
     const localBridge = new PikeBridge();
     let rejectedMessage = '';

--- a/packages/pike-bridge/src/bridge.ts
+++ b/packages/pike-bridge/src/bridge.ts
@@ -574,17 +574,26 @@ export class PikeBridge extends EventEmitter {
    * Handle a response from the Pike subprocess
    */
   private handleResponse(line: string): void {
+    let response: PikeResponse;
+
     try {
-      const response: PikeResponse = JSON.parse(line);
-      const pending = this.pendingRequests.get(response.id);
+      response = JSON.parse(line);
+    } catch {
+      // Ignore non-JSON lines (might be Pike debug output)
+      this.emit('stderr', line);
+      return;
+    }
 
-      if (!pending) {
-        return; // No pending request for this response
-      }
+    const pending = this.pendingRequests.get(response.id);
 
-      clearTimeout(pending.timeout);
-      this.pendingRequests.delete(response.id);
+    if (!pending) {
+      return; // No pending request for this response
+    }
 
+    clearTimeout(pending.timeout);
+    this.pendingRequests.delete(response.id);
+
+    try {
       if (response.error) {
         this.rejectPendingRequest(pending, response.error.message);
         return;
@@ -592,9 +601,14 @@ export class PikeBridge extends EventEmitter {
 
       const result = this.buildResponseResult(response);
       pending.resolve(result);
-    } catch {
-      // Ignore non-JSON lines (might be Pike debug output)
-      this.emit('stderr', line);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error('Failed to process Pike response', {
+        responseId: response.id,
+        raw: line,
+        error: message,
+      });
+      this.rejectPendingRequest(pending, `Failed to process Pike response: ${message}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Split non-JSON parse handling from post-parse response-processing failures in bridge response handling.
- Keep non-JSON lines routed to `stderr`, but log and immediately reject pending requests on processing errors.
- Add tests covering both stderr passthrough and immediate rejection behavior.

Fixes #908