### PR TITLE
fix: S3: ESLint must be zero-error — disable-comments require a reason

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:all": "./scripts/run-tests.sh",
     "lint:package-boundaries": "node scripts/check-cross-package-relative-imports.mjs",
     "typecheck": "bunx tsc --build --dry",
-    "lint": "bun run lint:package-boundaries && eslint . --ext .ts,.tsx,.js",
+    "lint": "bun run lint:package-boundaries && bun scripts/check-eslint-disable-reasons.mjs && eslint . --ext .ts,.tsx,.js",
     "lint:fix": "eslint . --ext .ts,.tsx,.js --fix",
     "format": "prettier --write \"**/*.{ts,tsx,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,json,md}\"",

--- a/packages/vscode-pike/src/test/integration/core-regression.e2e.test.ts
+++ b/packages/vscode-pike/src/test/integration/core-regression.e2e.test.ts
@@ -7,7 +7,7 @@ import { hoverText, labelOf, normalizeLocations, positionForRegex, waitFor } fro
 let vscode: any;
 let vscodeAvailable = true;
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;

--- a/packages/vscode-pike/src/test/integration/e2e-workflows.test.ts
+++ b/packages/vscode-pike/src/test/integration/e2e-workflows.test.ts
@@ -7,7 +7,7 @@ import { labelOf, normalizeLocations, positionForRegex, waitFor } from './helper
 let vscode: any;
 let vscodeAvailable = true;
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;

--- a/packages/vscode-pike/src/test/integration/error-handling.test.ts
+++ b/packages/vscode-pike/src/test/integration/error-handling.test.ts
@@ -25,7 +25,7 @@ import { suite, test } from 'mocha';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
   vscodeAvailable = true;
 } catch {
@@ -41,8 +41,9 @@ suite('Error Handling Tests', () => {
   suiteSetup(async function () {
     this.timeout(60000);
 
-    workspaceFolder = vscode.workspace.workspaceFolders?.[0]!;
-    assert.ok(workspaceFolder, 'Workspace folder should exist');
+    const firstWorkspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    assert.ok(firstWorkspaceFolder, 'Workspace folder should exist');
+    workspaceFolder = firstWorkspaceFolder;
 
     const extension = vscode.extensions.getExtension('pike-lsp.vscode-pike');
     assert.ok(extension, 'Extension should be found');

--- a/packages/vscode-pike/src/test/integration/extension.test.ts
+++ b/packages/vscode-pike/src/test/integration/extension.test.ts
@@ -15,7 +15,7 @@ import { suite, test } from 'mocha';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
   vscodeAvailable = true;
 } catch {

--- a/packages/vscode-pike/src/test/integration/include-navigation.test.ts
+++ b/packages/vscode-pike/src/test/integration/include-navigation.test.ts
@@ -14,7 +14,7 @@ import { normalizeLocations, waitFor } from './helpers';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;

--- a/packages/vscode-pike/src/test/integration/lsp-features.test.ts
+++ b/packages/vscode-pike/src/test/integration/lsp-features.test.ts
@@ -49,7 +49,7 @@ import {
 let vscode: any;
 let vscodeAvailable = true;
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;

--- a/packages/vscode-pike/src/test/integration/performance-tests.test.ts
+++ b/packages/vscode-pike/src/test/integration/performance-tests.test.ts
@@ -33,7 +33,7 @@ import { suite, test } from 'mocha';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
   vscodeAvailable = true;
 } catch {
@@ -54,8 +54,9 @@ suite('Performance Benchmark Tests', () => {
     }
     this.timeout(60000);
 
-    workspaceFolder = vscode.workspace.workspaceFolders?.[0]!;
-    assert.ok(workspaceFolder, 'Workspace folder should exist');
+    const firstWorkspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    assert.ok(firstWorkspaceFolder, 'Workspace folder should exist');
+    workspaceFolder = firstWorkspaceFolder;
 
     const extension = vscode.extensions.getExtension('pike-lsp.vscode-pike');
     assert.ok(extension, 'Extension should be found');

--- a/packages/vscode-pike/src/test/integration/responsiveness.test.ts
+++ b/packages/vscode-pike/src/test/integration/responsiveness.test.ts
@@ -24,7 +24,7 @@ import { suite, test } from 'mocha';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
   vscodeAvailable = true;
 } catch {
@@ -42,8 +42,9 @@ suite('Responsiveness E2E Tests', () => {
     this.timeout(60000);
 
     // Ensure workspace folder exists
-    workspaceFolder = vscode.workspace.workspaceFolders?.[0]!;
-    assert.ok(workspaceFolder, 'Workspace folder should exist');
+    const firstWorkspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    assert.ok(firstWorkspaceFolder, 'Workspace folder should exist');
+    workspaceFolder = firstWorkspaceFolder;
 
     // Explicitly activate the extension before running tests
     const extension = vscode.extensions.getExtension('pike-lsp.vscode-pike');

--- a/packages/vscode-pike/src/test/integration/smart-completion.test.ts
+++ b/packages/vscode-pike/src/test/integration/smart-completion.test.ts
@@ -28,7 +28,7 @@ import { labelOf, positionForRegex, waitFor } from './helpers';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;

--- a/packages/vscode-pike/src/test/integration/source-tree-features.e2e.test.ts
+++ b/packages/vscode-pike/src/test/integration/source-tree-features.e2e.test.ts
@@ -9,7 +9,7 @@ import { positionForRegex, waitFor, withTimeout } from './helpers';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;

--- a/packages/vscode-pike/src/test/integration/stdlib-e2e.test.ts
+++ b/packages/vscode-pike/src/test/integration/stdlib-e2e.test.ts
@@ -28,7 +28,7 @@ import { hoverText, labelOf, normalizeLocations, positionForRegex, waitFor } fro
 let vscode: any;
 let vscodeAvailable = true;
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;

--- a/scripts/check-eslint-disable-reasons.mjs
+++ b/scripts/check-eslint-disable-reasons.mjs
@@ -1,0 +1,83 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { extname, join } from 'node:path';
+
+const ROOT = process.cwd();
+const IGNORE_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+  '.vscode-test',
+]);
+const TARGET_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs']);
+const DISABLE_PATTERN = /(?:\/\/|\/\*+|\*)\s*eslint-disable(?:-next-line|-line)?(?:\s|$)/;
+const REASON_PATTERN = /--\s*\S/;
+
+function collectFiles(directory) {
+  const entries = readdirSync(directory);
+  const files = [];
+
+  for (const entry of entries) {
+    if (IGNORE_DIRS.has(entry)) {
+      continue;
+    }
+
+    const fullPath = join(directory, entry);
+    const stats = statSync(fullPath);
+
+    if (stats.isDirectory()) {
+      files.push(...collectFiles(fullPath));
+      continue;
+    }
+
+    if (TARGET_EXTENSIONS.has(extname(entry))) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function findViolations(filePath) {
+  const lines = readFileSync(filePath, 'utf8').split('\n');
+  const violations = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!DISABLE_PATTERN.test(line)) {
+      continue;
+    }
+
+    if (!REASON_PATTERN.test(line)) {
+      violations.push({
+        filePath,
+        line: i + 1,
+        comment: line.trim(),
+      });
+    }
+  }
+
+  return violations;
+}
+
+function main() {
+  const files = collectFiles(ROOT);
+  const violations = files.flatMap(findViolations);
+
+  if (violations.length === 0) {
+    console.log('✅ All eslint-disable comments include an explicit reason.');
+    return;
+  }
+
+  console.error('❌ Found eslint-disable comments without explicit reasons:');
+  for (const violation of violations) {
+    const relativePath = violation.filePath.replace(`${ROOT}/`, '');
+    console.error(`- ${relativePath}:${violation.line} ${violation.comment}`);
+  }
+  console.error('Add a concise reason using: -- <reason>');
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary
- Implement issue #914: S3: ESLint must be zero-error — disable-comments require a reason
- Apply scoped changes and verification for this standards item

Closes #914