### PR TITLE
fix: S6: LSP error propagation — use ResponseError, no silent catches

### DIFF
--- a/docs/dev-guide/typescript/error-handling.md
+++ b/docs/dev-guide/typescript/error-handling.md
@@ -1,0 +1,55 @@
+---
+id: ts-error-handling
+title: TypeScript Error Handling Pattern
+description: Approved catch/throw patterns for pike-lsp-server TypeScript handlers and services
+---
+
+# TypeScript Error Handling Pattern
+
+`pike-lsp-server/src` must not use bare catches (`catch { ... }`) or empty catches.
+
+Use one of the two approved patterns below:
+
+## 1) Request boundary errors: log + throw `ResponseError`
+
+Use this when the request should fail and the client should receive an LSP error.
+
+```ts
+import { ErrorCodes, ResponseError } from 'vscode-languageserver/node.js';
+
+try {
+  // request handling
+} catch (error) {
+  logger.error('Formatting request failed', {
+    uri,
+    error: error instanceof Error ? error.message : String(error),
+  });
+
+  throw new ResponseError(
+    ErrorCodes.InternalError,
+    `Formatting failed: ${error instanceof Error ? error.message : String(error)}`
+  );
+}
+```
+
+## 2) Recoverable paths: log + explicit fallback
+
+Use this when fallback behavior is intentional and behavior-compatible (e.g. best-effort cache read, optional index query).
+
+```ts
+try {
+  return await optionalOperation();
+} catch (error) {
+  logger.debug('Optional operation failed, using fallback', {
+    error: error instanceof Error ? error.message : String(error),
+  });
+  return fallbackValue;
+}
+```
+
+## Rules
+
+- Never swallow errors silently.
+- Never use `catch { ... }`.
+- If you choose fallback behavior, log at least `debug` with enough context (URI/path/request id).
+- If the failure should propagate to the client, throw `ResponseError` at the request boundary.

--- a/packages/pike-lsp-server/src/features/advanced/inline-values.ts
+++ b/packages/pike-lsp-server/src/features/advanced/inline-values.ts
@@ -189,8 +189,12 @@ export function registerInlineValuesHandler(
                             text: ` = ${formattedValue}`,
                         });
                     }
-                } catch {
-                    // Silently skip variables that can't be evaluated
+                } catch (error) {
+                    log.debug('Inline value evaluation skipped', {
+                        expression: valueExpr,
+                        uri: document.uri,
+                        error: error instanceof Error ? error.message : String(error),
+                    });
                 }
             }
 

--- a/packages/pike-lsp-server/src/features/editing/completion.ts
+++ b/packages/pike-lsp-server/src/features/editing/completion.ts
@@ -668,8 +668,11 @@ export function registerCompletionHandlers(
                   }
                   return toCompletionList(completions);
                 }
-              } catch {
-                logger.debug('Type not in stdlib (obj-> workaround)', { typeName });
+              } catch (err) {
+                logger.debug('Type not in stdlib (obj-> workaround)', {
+                  typeName,
+                  error: err instanceof Error ? err.message : String(err),
+                });
               }
             }
 
@@ -795,8 +798,11 @@ export function registerCompletionHandlers(
             typeName = objectRef;
             logger.debug('Resolved as stdlib module', { typeName, count: testModule.symbols.size });
           }
-        } catch {
-          logger.debug('Not a stdlib module', { objectRef });
+        } catch (err) {
+          logger.debug('Not a stdlib module', {
+            objectRef,
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
       }
 
@@ -831,8 +837,11 @@ export function registerCompletionHandlers(
             }
             return toCompletionList(completions);
           }
-        } catch {
-          logger.debug('Type not in stdlib', { typeName });
+        } catch (err) {
+          logger.debug('Type not in stdlib', {
+            typeName,
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
 
         // If not in stdlib, try to find it in workspace documents

--- a/packages/pike-lsp-server/src/features/navigation/definition.ts
+++ b/packages/pike-lsp-server/src/features/navigation/definition.ts
@@ -16,6 +16,8 @@ import { extractExpressionAtPosition } from './expression-utils.js';
 import type { ExpressionInfo, PikeSymbol, InheritanceInfo } from '@pike-lsp/pike-bridge';
 import { readFile } from 'node:fs/promises';
 
+const uriDecodeLog = new Logger('Navigation');
+
 /**
  * Convert a file:// URI to a filesystem path.
  * Needed because bridge methods expect filesystem paths, not URIs.
@@ -24,7 +26,11 @@ function uriToFilePath(uri: string): string {
   if (uri.startsWith('file://')) {
     try {
       return decodeURIComponent(new URL(uri).pathname);
-    } catch {
+    } catch (error) {
+      uriDecodeLog.debug('Failed to decode file URI, using prefix-strip fallback', {
+        uri,
+        error: error instanceof Error ? error.message : String(error),
+      });
       // Fallback: strip file:// prefix
       return uri.replace(/^file:\/\//, '');
     }

--- a/packages/pike-lsp-server/src/features/navigation/query-engine.ts
+++ b/packages/pike-lsp-server/src/features/navigation/query-engine.ts
@@ -132,7 +132,13 @@ export async function queryNavigationLocations(
     if (nestedLocation) {
       return [nestedLocation];
     }
-  } catch {
+  } catch (error) {
+    services.logger.warn('Navigation query engine request failed', {
+      feature,
+      uri,
+      requestId,
+      error,
+    });
     return undefined;
   } finally {
     cancellationDisposable?.dispose();

--- a/packages/pike-lsp-server/src/features/roxen/detector.ts
+++ b/packages/pike-lsp-server/src/features/roxen/detector.ts
@@ -1,10 +1,12 @@
 import type { RoxenModuleInfo } from './types.js';
+import { Logger } from '@pike-lsp/core';
 
 type RoxenDetectorBridge = {
   roxenDetect(code: string, filename?: string): Promise<RoxenModuleInfo>;
 };
 
 const cache = new Map<string, RoxenModuleInfo | null>();
+const log = new Logger('RoxenDetector');
 
 function hasMarkers(code: string): boolean {
   const hasRoxenInheritance =
@@ -39,7 +41,11 @@ export async function detectRoxenModule(
     const info = result.is_roxen_module === 1 ? result : null;
     cache.set(uri, info);
     return info;
-  } catch {
+  } catch (error) {
+    log.debug('Roxen detection failed', {
+      uri,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return null;
   }
 }

--- a/packages/pike-lsp-server/src/features/roxen/diagnostics.ts
+++ b/packages/pike-lsp-server/src/features/roxen/diagnostics.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Diagnostic } from 'vscode-languageserver';
+import { Logger } from '@pike-lsp/core';
 
 type RoxenRawDiagnostic = {
   line?: number;
@@ -21,6 +22,7 @@ type PendingDebounce = {
 };
 
 const pendingDebounces = new Map<string, PendingDebounce>();
+const log = new Logger('RoxenDiagnostics');
 
 export async function provideRoxenDiagnostics(
   uri: string,
@@ -63,7 +65,11 @@ export async function provideRoxenDiagnostics(
             };
           })
         );
-      } catch {
+      } catch (error) {
+        log.warn('Roxen diagnostics validation failed', {
+          uri,
+          error: error instanceof Error ? error.message : String(error),
+        });
         resolve([]);
       } finally {
         if (pendingDebounces.get(uri) === pending) {

--- a/packages/pike-lsp-server/src/features/rxml/definition-provider.ts
+++ b/packages/pike-lsp-server/src/features/rxml/definition-provider.ts
@@ -13,6 +13,7 @@ import { Location, Range, Position } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { glob } from 'glob';
 import { readFile, stat } from 'fs/promises';
+import { Logger } from '@pike-lsp/core';
 import { getTagInfo } from './tag-catalog.js';
 import { GlobCache } from './glob-cache.js';
 
@@ -35,6 +36,7 @@ const defvarDefinitionIndexCache = new Map<
   }
 >();
 const fileContentCache = new Map<string, { mtimeMs: number; content: string }>();
+const log = new Logger('RXMLDefinition');
 
 function uriToFilePath(uri: string): string {
   return decodeURIComponent(uri.replace(/^file:\/\//, ''));
@@ -55,7 +57,11 @@ async function readFileCached(filePath: string): Promise<string> {
     const content = await readFile(filePath, 'utf-8');
     fileContentCache.set(filePath, { mtimeMs: fileStats.mtimeMs, content });
     return content;
-  } catch {
+  } catch (error) {
+    log.debug('RXML read-through cache miss fallback', {
+      filePath,
+      error: error instanceof Error ? error.message : String(error),
+    });
     const content = await readFile(filePath, 'utf-8');
     return content;
   }

--- a/packages/pike-lsp-server/src/features/rxml/references-provider.ts
+++ b/packages/pike-lsp-server/src/features/rxml/references-provider.ts
@@ -13,6 +13,7 @@ import { Location, ReferenceContext } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { glob } from 'glob';
 import { readFile, stat } from 'fs/promises';
+import { Logger } from '@pike-lsp/core';
 import { parseRXMLTemplate, type RXMLTag } from './parser.js';
 import { GlobCache } from './glob-cache.js';
 
@@ -35,6 +36,7 @@ const tagDeclarationIndexCache = new Map<
   }
 >();
 const fileContentCache = new Map<string, { mtimeMs: number; content: string }>();
+const log = new Logger('RXMLReferences');
 
 function uriToFilePath(uri: string): string {
   return decodeURIComponent(uri.replace(/^file:\/\//, ''));
@@ -55,7 +57,11 @@ async function readFileCached(filePath: string): Promise<string> {
     const content = await readFile(filePath, 'utf-8');
     fileContentCache.set(filePath, { mtimeMs: fileStats.mtimeMs, content });
     return content;
-  } catch {
+  } catch (error) {
+    log.debug('RXML read-through cache miss fallback', {
+      filePath,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return await readFile(filePath, 'utf-8');
   }
 }

--- a/packages/pike-lsp-server/src/services/compilation-cache.ts
+++ b/packages/pike-lsp-server/src/services/compilation-cache.ts
@@ -1,4 +1,7 @@
 import { LRUCache, type LRUCacheOptions, type LRUCacheStats } from './lru-cache.js';
+import { Logger } from '@pike-lsp/core';
+
+const log = new Logger('CompilationCache');
 
 export interface CompilationCacheEntry<TResult> {
     code: string;
@@ -185,7 +188,10 @@ export class CompilationCache<TResult> {
                     record.entry.timestamp
                 );
             }
-        } catch {
+        } catch (error) {
+            log.warn('Failed to deserialize compilation cache payload', {
+                error: error instanceof Error ? error.message : String(error),
+            });
             return cache;
         }
 

--- a/packages/pike-lsp-server/src/services/document-cache.ts
+++ b/packages/pike-lsp-server/src/services/document-cache.ts
@@ -7,6 +7,9 @@
 
 import type { DocumentCacheEntry } from '../core/types.js';
 import { createHash } from 'crypto';
+import { Logger } from '@pike-lsp/core';
+
+const log = new Logger('DocumentCache');
 
 /**
  * INC-002: Compute SHA-256 hash of document content.
@@ -138,8 +141,11 @@ export class DocumentCache {
         if (pending) {
             try {
                 await pending;
-            } catch {
-                // Ignore errors, caller will check cache
+            } catch (error) {
+                log.debug('Pending document validation failed while waiting', {
+                    uri,
+                    error: error instanceof Error ? error.message : String(error),
+                });
             }
         }
     }

--- a/packages/pike-lsp-server/src/services/include-resolver.ts
+++ b/packages/pike-lsp-server/src/services/include-resolver.ts
@@ -287,7 +287,11 @@ export class IncludeResolver {
     try {
       const result = await this.bridge.bridge.resolveStdlib(modulePath);
       return result.found === 1;
-    } catch {
+    } catch (err) {
+      this.logger.debug('Failed stdlib module resolution', {
+        modulePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
       return false;
     }
   }
@@ -354,7 +358,11 @@ export class IncludeResolver {
     try {
       const fileStat = await stat(filePath);
       return fileStat.mtimeMs;
-    } catch {
+    } catch (err) {
+      this.logger.debug('Failed to stat include file', {
+        filePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
       return null;
     }
   }

--- a/packages/pike-lsp-server/src/workspace-index.ts
+++ b/packages/pike-lsp-server/src/workspace-index.ts
@@ -575,8 +575,11 @@ export class WorkspaceIndex {
                         lastModified: fileInfo.lastModified,
                         lineCount: this.countLines(content),
                     });
-                } catch {
-                    // Skip files that can't be read
+                } catch (error) {
+                    this.log.debug('Skipping unreadable file during indexing', {
+                        path: fileInfo.path,
+                        error: error instanceof Error ? error.message : String(error),
+                    });
                 }
             }
 
@@ -674,8 +677,11 @@ export class WorkspaceIndex {
                         // Add to lookup
                         this.addToLookup(uri, symbols, fileData.lineCount);
                         indexed++;
-                    } catch {
-                        // Skip files that fail to parse
+                    } catch (error) {
+                        this.log.debug('Sequential parse fallback failed for file', {
+                            path: fileData.filename,
+                            error: error instanceof Error ? error.message : String(error),
+                        });
                     }
                 }
             }
@@ -862,8 +868,11 @@ export class WorkspaceIndex {
             let entries: Dirent[];
             try {
                 entries = await readdir(dir, { withFileTypes: true });
-            } catch {
-                // Skip directories we can't read
+            } catch (error) {
+                this.log.debug('Skipping unreadable directory while scanning workspace', {
+                    path: dir,
+                    error: error instanceof Error ? error.message : String(error),
+                });
                 return;
             }
 
@@ -882,8 +891,11 @@ export class WorkspaceIndex {
                                 path: fullPath,
                                 lastModified: stats.mtimeMs,
                             });
-                        } catch {
-                            // Skip files we can't stat
+                        } catch (error) {
+                            this.log.debug('Skipping file with unreadable metadata', {
+                                path: fullPath,
+                                error: error instanceof Error ? error.message : String(error),
+                            });
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Implement issue #917: S6: LSP error propagation — use ResponseError, no silent catches
- Apply scoped changes and verification for this standards item

Closes #917