### PR TITLE
fix: S8: Pike parsing must use Parser.Pike — no regex shortcuts

### DIFF
--- a/docs/dev-guide/pike/LSP.pmod-Parser.md
+++ b/docs/dev-guide/pike/LSP.pmod-Parser.md
@@ -20,6 +20,16 @@ Design per CONTEXT.md:
 
 This file acts as a class - instantiate with Parser() from LSP.Parser
 
+## Approved Pike source parsing pattern
+
+For any logic that interprets Pike source syntax (e.g. `import`, `inherit`,
+declaration discovery, symbol extraction), use `Parser.Pike.split()` / `Parser.Pike.tokenize()`
+or `LSP.Parser` handlers.
+
+Do **not** parse Pike source structure with ad-hoc line scanning or regex shortcuts.
+Regex/string matching is still acceptable for non-source concerns such as log filtering,
+protocol message shaping, and external tool output parsing.
+
 Create a new Parser instance
 
 Parse Pike source code and extract symbols
@@ -159,4 +169,3 @@ Detects load_module() and compile_file() calls with string literal arguments
 | `improve_syntax_error_message` | function | 1478 |
 | `type_to_json` | function | 1536 |
 | `content` | function | 1655 |
-

--- a/pike-scripts/LSP.pmod/CompilationCache.pmod
+++ b/pike-scripts/LSP.pmod/CompilationCache.pmod
@@ -336,7 +336,7 @@ class DependencyTrackingCompiler {
         _diagnostics = ({});
     }
 
-    //! Extract dependencies from Pike code using simple regex-based parsing
+    //! Extract dependencies from Pike code using Parser.Pike tokenization
     //! Finds inherit and import directives to track module dependencies
     //! @param code The source code to analyze
     //! @param current_file The file being compiled (for resolving relative paths)
@@ -344,60 +344,73 @@ class DependencyTrackingCompiler {
     private array(string) extract_dependencies(string code, string current_file) {
         array(string) deps = ({});
         array(string) imports = ({});
-        array(string) lines = code / "\n";
+        program PikeParserModule = master()->resolv("Parser.Pike");
 
-        foreach (lines, string line) {
-            // Skip comments
-            line = String.trim_all_whites(line);
-            if (has_prefix(line, "//") || sizeof(line) == 0) continue;
+        if (!PikeParserModule) {
+            return deps;
+        }
 
-            // Look for inherit directives: inherit "path" or inherit Module.Name
-            if (has_prefix(line, "inherit ")) {
-                string rest = line[8..]; // Skip "inherit "
-                rest = String.trim_all_whites(rest);
+        array(string) tokens = PikeParserModule->split(code);
 
-                // Remove trailing semicolon and comments
-                int semicolon = search(rest, ";");
-                if (semicolon >= 0) {
-                    rest = rest[0..semicolon-1];
-                }
-                int comment = search(rest, "//");
-                if (comment >= 0) {
-                    rest = rest[0..comment-1];
-                }
-                rest = String.trim_all_whites(rest);
+        // Normalize directive target extracted from tokens.
+        // Handles quoted inherits and labels (inherit Foo : Label;).
+        string normalize_target(string raw, int is_inherit) {
+            string target = String.trim_all_whites(raw);
+            if (sizeof(target) == 0) {
+                return "";
+            }
 
-                // Remove quotes if present
-                if (has_prefix(rest, "\"") && has_suffix(rest, "\"")) {
-                    rest = rest[1..sizeof(rest)-2];
-                }
-
-                if (sizeof(rest) > 0) {
-                    deps += ({rest});
+            if (is_inherit) {
+                int label_pos = search(target, ":");
+                if (label_pos > 0) {
+                    target = String.trim_all_whites(target[..label_pos - 1]);
                 }
             }
 
-            // Look for import directives: import Module.Name
-            if (has_prefix(line, "import ")) {
-                string rest = line[7..]; // Skip "import "
-                rest = String.trim_all_whites(rest);
+            if (sizeof(target) > 1 &&
+                ((target[0] == '"' && target[-1] == '"') ||
+                 (target[0] == '\'' && target[-1] == '\''))) {
+                target = target[1..<1];
+            }
 
-                // Remove trailing semicolon and comments
-                int semicolon = search(rest, ";");
-                if (semicolon >= 0) {
-                    rest = rest[0..semicolon-1];
-                }
-                int comment = search(rest, "//");
-                if (comment >= 0) {
-                    rest = rest[0..comment-1];
-                }
-                rest = String.trim_all_whites(rest);
+            return String.trim_all_whites(target);
+        };
 
-                if (sizeof(rest) > 0) {
-                    imports += ({rest});
-                    deps += ({rest});
+        for (int i = 0; i < sizeof(tokens); i++) {
+            string tok = String.trim_all_whites(tokens[i]);
+            int is_import = tok == "import";
+            int is_inherit = tok == "inherit";
+
+            if (!is_import && !is_inherit) {
+                continue;
+            }
+
+            int j = i + 1;
+            string raw_target = "";
+
+            while (j < sizeof(tokens)) {
+                string next = tokens[j];
+                string next_trimmed = String.trim_all_whites(next);
+
+                if (has_value(next, "\n") || next_trimmed == ";") {
+                    break;
+                }
+
+                if (sizeof(next_trimmed) > 0) {
+                    raw_target += next_trimmed;
+                }
+                j++;
+            }
+
+            string target = normalize_target(raw_target, is_inherit);
+            if (sizeof(target) > 0) {
+                deps += ({ target });
+                if (is_import) {
+                    imports += ({ target });
                 }
             }
+
+            i = j;
         }
 
         // Add imports to compilation context if available

--- a/pike-scripts/LSP.pmod/Intelligence.pmod/Resolution.pike
+++ b/pike-scripts/LSP.pmod/Intelligence.pmod/Resolution.pike
@@ -476,7 +476,7 @@ protected string read_source_file(string path, void|int max_bytes) {
 //! @param source_path Path to the stdlib source file (may have line number suffix)
 //! @returns Mapping of symbol name to parsed documentation
 //!
-//! Uses extract_autodoc_comments and extract_symbol_name helpers from module.pmod.
+//! Uses extract_autodoc_comments helper and LSP.Parser symbol extraction.
 protected mapping parse_stdlib_documentation(string source_path) {
     // Get helper functions from module.pmod
     program module_program = master()->resolv("LSP.Intelligence.module");
@@ -485,9 +485,8 @@ protected mapping parse_stdlib_documentation(string source_path) {
     }
 
     function extract_autodoc_comments = module_program->extract_autodoc_comments;
-    function extract_symbol_name = module_program->extract_symbol_name;
 
-    if (!extract_autodoc_comments || !extract_symbol_name) {
+    if (!extract_autodoc_comments) {
         return ([]);
     }
 
@@ -517,49 +516,46 @@ protected mapping parse_stdlib_documentation(string source_path) {
         return docs;
     }
 
-    // Parse using Tools.AutoDoc.PikeParser
+    // Parse with LSP.Parser to avoid ad-hoc line parsing.
+    // Associate each symbol with autodoc extracted for its declaration line.
     mixed parse_err = catch {
-        // Extract autodoc comments
         mapping(int:string) autodoc_by_line = extract_autodoc_comments(code);
+        program TypeAnalysisClass = master()->resolv("LSP.Intelligence.TypeAnalysis");
+        object type_analyzer = TypeAnalysisClass ? TypeAnalysisClass(context) : 0;
 
-        // Use simple regex-based extraction for function/method documentation
-        // Look for patterns like: //! @decl type name(args)
-        // or autodoc blocks followed by function definitions
+        program ParserClass = master()->resolv("LSP.Parser");
+        if (!ParserClass) {
+            return 0;
+        }
 
-        array(string) lines = code / "\n";
-        string current_doc = "";
+        object parser = ParserClass();
+        mapping parsed = parser->parse_request(([
+            "code": code,
+            "filename": clean_path,
+            "line": 1
+        ]));
 
-        for (int i = 0; i < sizeof(lines); i++) {
-            string line = lines[i];
-            string trimmed = LSP.Compat.trim_whites(line);
+        array(mapping) symbols = parsed && parsed->result ? parsed->result->symbols || ({}) : ({});
 
-            // Collect autodoc comments
-            if (has_prefix(trimmed, "//!")) {
-                if (sizeof(current_doc) > 0) {
-                    current_doc += "\n" + trimmed[3..];
-                } else {
-                    current_doc = trimmed[3..];
-                }
+        foreach (symbols, mapping sym) {
+            if (!sym || !sym->name || docs[sym->name]) {
                 continue;
             }
 
-            // If we have accumulated docs and hit a non-doc line, try to associate
-            if (sizeof(current_doc) > 0) {
-                // Look for function/method definition
-                // Pattern: type name( or PIKEFUN type name(
-                string name = extract_symbol_name(trimmed);
-                if (sizeof(name) > 0) {
-                    // Get parse_autodoc from sibling TypeAnalysis class
-                    program TypeAnalysisClass = master()->resolv("LSP.Intelligence.TypeAnalysis");
-                    if (TypeAnalysisClass) {
-                        object type_analyzer = TypeAnalysisClass(context);
-                        docs[name] = type_analyzer->parse_autodoc(current_doc);
-                    } else {
-                        // Fallback: store raw doc
-                        docs[name] = ([ "text": current_doc ]);
-                    }
-                }
-                current_doc = "";
+            int decl_line = 0;
+            if (sym->position && intp(sym->position->line)) {
+                decl_line = sym->position->line;
+            }
+
+            if (decl_line <= 0 || !autodoc_by_line[decl_line]) {
+                continue;
+            }
+
+            string doc_text = autodoc_by_line[decl_line];
+            if (type_analyzer) {
+                docs[sym->name] = type_analyzer->parse_autodoc(doc_text);
+            } else {
+                docs[sym->name] = ([ "text": doc_text ]);
             }
         }
     };


### PR DESCRIPTION
## Summary
- Implement issue #919: S8: Pike parsing must use Parser.Pike — no regex shortcuts
- Apply scoped changes and verification for this standards item

Closes #919