### PR TITLE
chore: bump version to alpha.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security** - Security vulnerability fixes
 - **Performance** - User-facing performance notes
 
+## [0.1.0-alpha.34] - 2026-03-26
+
+### Added
+
+- **Repository policy enforcement guards** - added lockfile/package-manager guardrails, eslint-disable reason checks, strict Pike `#pragma strict_types` coverage checks, and pre-push strict-types validation with explicit non-compliance listing.
+
+### Fixed
+
+- **Strict typing and runtime capability registration** - fixed strict-mode regressions around on-type formatting, linked editing, and VS Code reference result normalization.
+- **CI throughput and merge safety defaults** - enabled fail-fast behavior across test matrices used by PR validation and stabilized workflow execution order for policy checks.
+
+### Changed
+
+- **Formatting governance for packages** - enforced package-scoped Prettier formatting checks in pre-commit and standardized package source formatting to keep `.prettierrc` policy-compliant and reproducible.
+
 ## [0.1.0-alpha.33] - 2026-03-26
 
 ### Added
@@ -33,22 +48,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Regression coverage expansion** - converted placeholder-heavy and skip-heavy suites into executable behavioral tests for scheduler, bridge health, analyzer caching, compatibility, and control-flow diagnostics.
 
-## [0.1.0-alpha.32] - 2026-03-26
-
-### Added
-
-- **Pull diagnostics and snapshot-driven editor tooling** - shipped pull-diagnostics handlers/capabilities, inline snapshot hover test infrastructure, runnable/test code lens commands, and workspace indexing progress reporting.
-- **Structural search and replace command** - added command surface and extension wiring for structural search/replace workflows.
-
-### Fixed
-
-- **Language correctness in edge syntax contexts** - fixed references, inlay hints, semantic tokens, and folding behavior to ignore comments and string literals in tricky multiline and inline cases.
-- **Formatting reliability and on-type behavior** - stabilized formatting context/on-type indentation behavior and added regression coverage around formatter depth handling.
-- **CI/E2E throughput and merge gating** - parallelized VS Code E2E by category matrix, kept flaky reliability slice non-blocking when needed, and restored required `vscode-e2e` status gating compatibility.
-
-### Changed
-
-- **Contributor testing policy** - tightened docs to require regression-focused tests for all feature and bug-fix PRs.
-
+[0.1.0-alpha.34]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.34
 [0.1.0-alpha.33]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.33
-[0.1.0-alpha.32]: https://github.com/TheSmuks/pike-lsp/releases/tag/v0.1.0-alpha.32

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pike-lsp",
-  "version": "0.1.0-alpha.33",
+  "version": "0.1.0-alpha.34",
   "private": true,
   "description": "Pike Language Server Protocol implementation and VSCode extension",
   "author": "Pike LSP Team",

--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-pike",
   "displayName": "Pike Language Support",
   "description": "Complete language support for Pike including IntelliSense, go-to-definition, find references, diagnostics, hover, signature help, code completion, semantic tokens, call hierarchy, and workspace symbols.",
-  "version": "0.1.0-alpha.33",
+  "version": "0.1.0-alpha.34",
   "publisher": "pike-lsp",
   "license": "MIT",
   "icon": "images/icon.png",

--- a/packages/vscode-pike/src/test/integration/core-regression.e2e.test.ts
+++ b/packages/vscode-pike/src/test/integration/core-regression.e2e.test.ts
@@ -7,7 +7,7 @@ import { hoverText, labelOf, normalizeLocations, positionForRegex, waitFor } fro
 let vscode: any;
 let vscodeAvailable = true;
 try {
-// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;

--- a/packages/vscode-pike/src/test/integration/e2e-workflows.test.ts
+++ b/packages/vscode-pike/src/test/integration/e2e-workflows.test.ts
@@ -7,7 +7,7 @@ import { labelOf, normalizeLocations, positionForRegex, waitFor } from './helper
 let vscode: any;
 let vscodeAvailable = true;
 try {
-// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;

--- a/packages/vscode-pike/src/test/integration/error-handling.test.ts
+++ b/packages/vscode-pike/src/test/integration/error-handling.test.ts
@@ -25,7 +25,7 @@ import { suite, test } from 'mocha';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
   vscodeAvailable = true;
 } catch {

--- a/packages/vscode-pike/src/test/integration/extension.test.ts
+++ b/packages/vscode-pike/src/test/integration/extension.test.ts
@@ -15,7 +15,7 @@ import { suite, test } from 'mocha';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
   vscodeAvailable = true;
 } catch {

--- a/packages/vscode-pike/src/test/integration/include-navigation.test.ts
+++ b/packages/vscode-pike/src/test/integration/include-navigation.test.ts
@@ -14,7 +14,7 @@ import { normalizeLocations, waitFor } from './helpers';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;

--- a/packages/vscode-pike/src/test/integration/lsp-features.test.ts
+++ b/packages/vscode-pike/src/test/integration/lsp-features.test.ts
@@ -49,7 +49,7 @@ import {
 let vscode: any;
 let vscodeAvailable = true;
 try {
-// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;

--- a/packages/vscode-pike/src/test/integration/performance-tests.test.ts
+++ b/packages/vscode-pike/src/test/integration/performance-tests.test.ts
@@ -33,7 +33,7 @@ import { suite, test } from 'mocha';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
   vscodeAvailable = true;
 } catch {

--- a/packages/vscode-pike/src/test/integration/responsiveness.test.ts
+++ b/packages/vscode-pike/src/test/integration/responsiveness.test.ts
@@ -24,7 +24,7 @@ import { suite, test } from 'mocha';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
   vscodeAvailable = true;
 } catch {

--- a/packages/vscode-pike/src/test/integration/smart-completion.test.ts
+++ b/packages/vscode-pike/src/test/integration/smart-completion.test.ts
@@ -28,7 +28,7 @@ import { labelOf, positionForRegex, waitFor } from './helpers';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;

--- a/packages/vscode-pike/src/test/integration/source-tree-features.e2e.test.ts
+++ b/packages/vscode-pike/src/test/integration/source-tree-features.e2e.test.ts
@@ -9,7 +9,7 @@ import { positionForRegex, waitFor, withTimeout } from './helpers';
 let vscode: any;
 let vscodeAvailable = true;
 try {
-// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;

--- a/packages/vscode-pike/src/test/integration/stdlib-e2e.test.ts
+++ b/packages/vscode-pike/src/test/integration/stdlib-e2e.test.ts
@@ -28,7 +28,7 @@ import { hoverText, labelOf, normalizeLocations, positionForRegex, waitFor } fro
 let vscode: any;
 let vscodeAvailable = true;
 try {
-// eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- VS Code integration tests use CommonJS require for the vscode runtime module
   vscode = require('vscode');
 } catch {
   vscodeAvailable = false;


### PR DESCRIPTION
## Summary
- bump version to 0.1.0-alpha.34 in root and VS Code extension package manifests
- update changelog for the alpha.34 release notes
- include required Prettier cleanup to satisfy new package format checks