### PR TITLE
feat: adopt vscode-go architectural patterns

### DIFF
--- a/packages/vscode-pike/src/config.ts
+++ b/packages/vscode-pike/src/config.ts
@@ -1,0 +1,90 @@
+/**
+ * Config Manager (vscode-go pattern)
+ *
+ * Typed, URI-aware config helpers. All settings access goes through here.
+ * Inspired by vscode-go's getGoConfig() / getGoplsConfig() pattern.
+ *
+ * Usage:
+ *   import { getPikeConfig, getServerConfig } from './config.js';
+ *
+ *   const config = getPikeConfig();
+ *   const pikePath = config.get<string>('pikePath', 'pike');
+ *
+ *   // Per-folder override:
+ *   const config = getPikeConfig(document.uri);
+ */
+
+import * as vscode from 'vscode';
+
+/** Pike extension settings shape */
+export interface PikeSettings {
+  pikePath: string;
+  maxNumberOfProblems: number;
+  diagnosticDelay: number;
+  modulePaths: string[];
+  includePaths: string[];
+  enableRoxen: boolean;
+  trace: { server: 'off' | 'messages' | 'verbose' };
+}
+
+/** Default settings values */
+export const defaultPikeSettings: PikeSettings = {
+  pikePath: 'pike',
+  maxNumberOfProblems: 100,
+  diagnosticDelay: 300,
+  modulePaths: [],
+  includePaths: [],
+  enableRoxen: false,
+  trace: { server: 'off' },
+};
+
+/**
+ * Get Pike configuration, optionally scoped to a specific document URI.
+ *
+ * Declared as a const (not function) so it can be stubbed in tests.
+ */
+export const getPikeConfig = (uri?: vscode.Uri): vscode.WorkspaceConfiguration => {
+  return vscode.workspace.getConfiguration('pike', uri ?? null);
+};
+
+/**
+ * Get server-specific configuration.
+ */
+export const getServerConfig = (uri?: vscode.Uri): vscode.WorkspaceConfiguration => {
+  return vscode.workspace.getConfiguration('pike.server', uri ?? null);
+};
+
+/**
+ * Read all Pike settings as a typed object.
+ * Respects per-folder overrides when URI is provided.
+ */
+export function readPikeSettings(uri?: vscode.Uri): PikeSettings {
+  const config = getPikeConfig(uri);
+  return {
+    pikePath: config.get<string>('pikePath', defaultPikeSettings.pikePath),
+    maxNumberOfProblems: config.get<number>(
+      'maxNumberOfProblems',
+      defaultPikeSettings.maxNumberOfProblems
+    ),
+    diagnosticDelay: config.get<number>('diagnosticDelay', defaultPikeSettings.diagnosticDelay),
+    modulePaths: config.get<string[]>('modulePaths', defaultPikeSettings.modulePaths),
+    includePaths: config.get<string[]>('includePaths', defaultPikeSettings.includePaths),
+    enableRoxen: config.get<boolean>('enableRoxen', defaultPikeSettings.enableRoxen),
+    trace: config.get<{ server: 'off' | 'messages' | 'verbose' }>(
+      'trace',
+      defaultPikeSettings.trace
+    ),
+  };
+}
+
+/**
+ * Listen for configuration changes and call back with new settings.
+ * Returns a disposable to unsubscribe.
+ */
+export function onConfigChanged(callback: (settings: PikeSettings) => void): vscode.Disposable {
+  return vscode.workspace.onDidChangeConfiguration(event => {
+    if (event.affectsConfiguration('pike')) {
+      callback(readPikeSettings());
+    }
+  });
+}

--- a/packages/vscode-pike/src/extension-info.ts
+++ b/packages/vscode-pike/src/extension-info.ts
@@ -1,0 +1,55 @@
+/**
+ * ExtensionInfo (vscode-go pattern)
+ *
+ * Centralized metadata about the extension and its environment.
+ * Single source of truth for version, preview mode, cloud IDE detection.
+ *
+ * Usage:
+ *   import { extensionInfo } from './extension-info.js';
+ *   console.log(extensionInfo.version);  // "0.1.0-alpha.34"
+ *   console.log(extensionInfo.isPreview); // true for pre-release
+ *   console.log(extensionInfo.isInCloudIDE); // true for Codespaces/Gitpod
+ */
+
+import * as vscode from 'vscode';
+
+export class ExtensionInfo {
+  /** Extension version from package.json */
+  readonly version: string | undefined;
+
+  /** Application name (e.g., "VS Code", "VSCodium") */
+  readonly appName: string;
+
+  /** True if running a prerelease/preview version */
+  readonly isPreview: boolean;
+
+  /** True if running in a cloud IDE (Codespaces, Gitpod, etc.) */
+  readonly isInCloudIDE: boolean;
+
+  /** Pike language ID(s) this extension handles */
+  readonly languageIds: readonly string[] = ['pike', 'pike-rxml'] as const;
+
+  constructor() {
+    const packageJSON = vscode.extensions.getExtension('smuks.pike-language')?.packageJSON;
+    this.version = packageJSON?.version;
+    this.appName = vscode.env.appName;
+
+    // Preview = prerelease version (contains alpha, beta, rc)
+    this.isPreview = /alpha|beta|rc|dev|nightly/i.test(this.version ?? '');
+
+    // Cloud IDE detection
+    this.isInCloudIDE =
+      !!process.env['CODESPACES'] ||
+      !!process.env['GITPOD_WORKSPACE_ID'] ||
+      !!process.env['CLOUD_SHELL'] ||
+      !!process.env['CODEBERG_WORKSPACES'];
+  }
+
+  /** Short display string for logs/messages */
+  get displayString(): string {
+    return `Pike LSP v${this.version ?? 'unknown'} (${this.appName})`;
+  }
+}
+
+/** Singleton instance — import and use directly */
+export const extensionInfo = new ExtensionInfo();

--- a/packages/vscode-pike/src/pike-installer.ts
+++ b/packages/vscode-pike/src/pike-installer.ts
@@ -1,0 +1,135 @@
+/**
+ * Pike Installation Detection (vscode-go pattern)
+ *
+ * Detects Pike installation, prompts user if missing, provides
+ * actionable options (install, configure path, detect again).
+ *
+ * Inspired by vscode-go's promptForMissingTool() and maybeInstallImportantTools().
+ *
+ * Usage:
+ *   import { ensurePikeInstalled } from './pike-installer.js';
+ *   const pikePath = await ensurePikeInstalled();
+ */
+
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import { getGlobalState, setGlobalState, StateKeys } from './state.js';
+
+export interface PikeDetectionResult {
+  /** Path to Pike executable */
+  path: string;
+  /** Pike version string */
+  version: string;
+  /** How Pike was found */
+  source: 'path' | 'config' | 'which' | 'common';
+}
+
+/**
+ * Detect Pike installation using multiple strategies.
+ * Returns null if Pike is not found.
+ */
+export async function detectPike(): Promise<PikeDetectionResult | null> {
+  // Strategy 1: Check user-configured path
+  const config = vscode.workspace.getConfiguration('pike');
+  const configuredPath = config.get<string>('pikePath', '');
+  if (configuredPath) {
+    const version = await getPikeVersion(configuredPath);
+    if (version) {
+      return { path: configuredPath, version, source: 'config' };
+    }
+  }
+
+  // Strategy 2: Check PATH
+  const pathVersion = await getPikeVersion('pike');
+  if (pathVersion) {
+    return { path: 'pike', version: pathVersion, source: 'path' };
+  }
+
+  // Strategy 3: Check common install locations
+  const commonPaths = [
+    '/usr/local/bin/pike',
+    '/usr/bin/pike',
+    '/opt/pike/bin/pike',
+    `${process.env['HOME']}/pike-install/pike/8.0.1116/bin/pike`,
+    `${process.env['HOME']}/.local/bin/pike`,
+  ];
+
+  for (const candidate of commonPaths) {
+    const version = await getPikeVersion(candidate);
+    if (version) {
+      return { path: candidate, version, source: 'common' };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Ensure Pike is installed. Prompts user if not found.
+ * Returns the Pike path or null if user declined.
+ */
+export async function ensurePikeInstalled(): Promise<string | null> {
+  const detected = await detectPike();
+
+  if (detected) {
+    await setGlobalState(StateKeys.LAST_PIKE_VERSION, detected.version);
+    return detected.path;
+  }
+
+  // Check if user previously dismissed
+  const dismissed = getGlobalState<boolean>(StateKeys.PIKE_INSTALL_DISMISSED);
+  if (dismissed) {
+    return null;
+  }
+
+  // Show actionable prompt
+  const action = await vscode.window.showWarningMessage(
+    'Pike not found. The Pike Language Server requires Pike to analyze your code.',
+    'Configure Path',
+    'Install Pike',
+    'Not Now'
+  );
+
+  switch (action) {
+    case 'Configure Path':
+      await vscode.commands.executeCommand('workbench.action.openSettings', 'pike.pikePath');
+      return null;
+
+    case 'Install Pike':
+      await vscode.env.openExternal(vscode.Uri.parse('https://pike.lysator.liu.se/download/'));
+      return null;
+
+    case 'Not Now':
+      await setGlobalState(StateKeys.PIKE_INSTALL_DISMISSED, true);
+      return null;
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Get Pike version from a given executable path.
+ */
+async function getPikeVersion(pikePath: string): Promise<string | null> {
+  return new Promise(resolve => {
+    const proc = cp.spawn(pikePath, ['--version']);
+    let output = '';
+    proc.stderr?.on('data', (data: Buffer) => {
+      output += data.toString();
+    });
+    proc.stdout?.on('data', (data: Buffer) => {
+      output += data.toString();
+    });
+    proc.on('close', () => {
+      const match = output.match(/Pike v(\d+\.\d+(?:\.\d+)?)/);
+      resolve(match?.[1] ?? null);
+    });
+    proc.on('error', () => resolve(null));
+    // Timeout after 5 seconds
+    setTimeout(() => {
+      proc.kill();
+      resolve(null);
+    }, 5000);
+  });
+}

--- a/packages/vscode-pike/src/state.ts
+++ b/packages/vscode-pike/src/state.ts
@@ -1,0 +1,69 @@
+/**
+ * State Management (vscode-go pattern)
+ *
+ * Typed wrappers for VS Code's globalState and workspaceState.
+ * Persist user preferences across sessions.
+ *
+ * Usage:
+ *   import { getGlobalState, setGlobalState, getWorkspaceState, setWorkspaceState } from './state.js';
+ *
+ *   // Persist last-used Pike version
+ *   setGlobalState('lastPikeVersion', '8.0.1116');
+ *   const lastVersion = getGlobalState<string>('lastPikeVersion');
+ */
+
+import * as vscode from 'vscode';
+
+let globalState: vscode.Memento;
+let workspaceState: vscode.Memento;
+
+/**
+ * Initialize state managers. Call once during extension activation.
+ */
+export function initState(context: vscode.ExtensionContext): void {
+  globalState = context.globalState;
+  workspaceState = context.workspaceState;
+}
+
+/**
+ * Get a value from global state (persists across all workspaces).
+ */
+export function getGlobalState<T>(key: string, defaultValue?: T): T | undefined {
+  return globalState?.get<T>(key, defaultValue as T);
+}
+
+/**
+ * Set a value in global state.
+ */
+export async function setGlobalState<T>(key: string, value: T): Promise<void> {
+  await globalState?.update(key, value);
+}
+
+/**
+ * Get a value from workspace state (persists per-workspace).
+ */
+export function getWorkspaceState<T>(key: string, defaultValue?: T): T | undefined {
+  return workspaceState?.get<T>(key, defaultValue as T);
+}
+
+/**
+ * Set a value in workspace state.
+ */
+export async function setWorkspaceState<T>(key: string, value: T): Promise<void> {
+  await workspaceState?.update(key, value);
+}
+
+// ---------------------------------------------------------------------------
+// Common state keys (centralized, avoid magic strings)
+// ---------------------------------------------------------------------------
+
+export const StateKeys = {
+  /** Last detected Pike version */
+  LAST_PIKE_VERSION: 'pike.lastVersion',
+  /** Whether user dismissed the install prompt */
+  PIKE_INSTALL_DISMISSED: 'pike.installDismissed',
+  /** Last time health check ran */
+  LAST_HEALTH_CHECK: 'pike.lastHealthCheck',
+  /** Server restart count (for crash detection) */
+  RESTART_COUNT: 'pike.restartCount',
+} as const;


### PR DESCRIPTION
## Summary

Transfer 4 architectural patterns from vscode-go for better extension maintainability and consistency.

## Linked Issue

closes #948

## Changes

- `config.ts`: Config manager with getPikeConfig(uri)/getServerConfig(uri), typed PikeSettings, onConfigChanged subscription
- `extension-info.ts`: ExtensionInfo class with version, isPreview, isInCloudIDE detection (Codespaces, Gitpod, Cloud Shell)
- `state.ts`: State management with getGlobalState/setGlobalState, getWorkspaceState/setWorkspaceState, StateKeys constants
- `pike-installer.ts`: Pike installation detection with multi-strategy lookup, actionable prompts (configure/install/dismiss)

## Verification

All 2182 tests pass. Build passes. TypeScript compiles clean.