### PR TITLE
fix: add #pragma strict_types to test data .pike files

### DIFF
--- a/packages/pike-lsp-server/tests/testdata/completions/members.pike
+++ b/packages/pike-lsp-server/tests/testdata/completions/members.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 class Foo {
   int alpha;
   int beta;

--- a/packages/pike-lsp-server/tests/testdata/diagnostics/missing-semicolon.pike
+++ b/packages/pike-lsp-server/tests/testdata/diagnostics/missing-semicolon.pike
@@ -1,2 +1,3 @@
+#pragma strict_types
 int x = ;
 string name = "test";

--- a/packages/pike-lsp-server/tests/testdata/diagnostics/multi-error.pike
+++ b/packages/pike-lsp-server/tests/testdata/diagnostics/multi-error.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 int a = ;
 string b = "ok";
 int c = ;

--- a/packages/pike-lsp-server/tests/testdata/diagnostics/unmatched-brace.pike
+++ b/packages/pike-lsp-server/tests/testdata/diagnostics/unmatched-brace.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 int main() {
   return 1;
 // missing closing brace

--- a/packages/pike-lsp-server/tests/testdata/diagnostics/valid.pike
+++ b/packages/pike-lsp-server/tests/testdata/diagnostics/valid.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 int x = 1;
 string name = "test";
 void hello(string msg) {

--- a/packages/pike-lsp-server/tests/testdata/hover/functions.pike
+++ b/packages/pike-lsp-server/tests/testdata/hover/functions.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 //! Add two numbers
 //! @param a First number
 //! @param b Second number

--- a/packages/pike-lsp-server/tests/testdata/references/find-all.pike
+++ b/packages/pike-lsp-server/tests/testdata/references/find-all.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 int shared_var = 10;
 
 void caller() {

--- a/packages/pike-lsp-server/tests/testdata/symbols/outline.pike
+++ b/packages/pike-lsp-server/tests/testdata/symbols/outline.pike
@@ -1,3 +1,4 @@
+#pragma strict_types
 int global_var = 42;
 string global_str = "hello";
 


### PR DESCRIPTION
## Summary

CI check-pike-strict-types.sh requires all .pike files to have #pragma strict_types. The test data files created in #947 were missing it, causing test (20.x) to fail on main.

## Linked Issue

Fixes CI regression from #947.

## Changes

Added #pragma strict_types to all 8 testdata .pike files.

## Verification

bash scripts/check-pike-strict-types.sh → 0 violations
bun test → 2182 pass, 0 fail