### PR TITLE
fix: delete stress benchmark files and remove references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,18 +291,24 @@ All tests MUST follow these patterns. No exceptions.
 // ✅ CORRECT — use these EXACT imports
 import { describe, it } from 'bun:test';
 import assert from 'node:assert/strict';
-import { createMockDocuments, createMockBridge, createMockServices, makeCachedEntry } from '../helpers/test-helpers.js';
+import {
+  createMockDocuments,
+  createMockBridge,
+  createMockServices,
+  makeCachedEntry,
+} from '../helpers/test-helpers.js';
 
 // ❌ WRONG — do not use any of these
-import * as assert from 'node:assert/strict';  // use default import
-import { describe, expect, it } from 'bun:test';  // use assert, not expect
-import assert from 'node:assert';  // use strict
-const { describe, it } = require('bun:test');  // never use require
+import * as assert from 'node:assert/strict'; // use default import
+import { describe, expect, it } from 'bun:test'; // use assert, not expect
+import assert from 'node:assert'; // use strict
+const { describe, it } = require('bun:test'); // never use require
 ```
 
 ### Mock pattern
 
 Use the shared helpers from `tests/helpers/test-helpers.ts`:
+
 - `createMockDocuments()` — for document state
 - `createMockBridge(config)` — for Pike bridge simulation
 - `createMockConnection()` — for LSP connection
@@ -316,7 +322,6 @@ extend the helpers file instead of creating new ones.
 
 - One test file per feature (e.g., `hover-provider.test.ts`)
 - Use kebab-case: `my-feature.test.ts`
-- No `*-stress.test.ts` in src/tests/ — put stress tests in `benchmarks/stress/*.bench.ts`
 
 ### Test naming
 

--- a/docs/plans/2026-03-18-pike-formatter-replacement-design.md
+++ b/docs/plans/2026-03-18-pike-formatter-replacement-design.md
@@ -171,15 +171,15 @@ This means:
 
 This ownership split must be explicit and enforced.
 
-| Behavior | Owner | Why |
-|---|---|---|
-| Enter indentation | VS Code language configuration | native editor behavior, immediate, tab-aware |
-| Tab / Shift+Tab | VS Code editor | editor already owns indentation commands |
-| Move line up/down reindent | VS Code language configuration | official indentation-rules responsibility |
-| Paste auto-indent | VS Code language configuration | editor-native indentation |
-| Format on paste | LSP range formatting | VS Code routes this through formatting providers |
-| Format selection | LSP range formatting | explicit command |
-| Format document | LSP document formatting | explicit command |
+| Behavior                   | Owner                          | Why                                              |
+| -------------------------- | ------------------------------ | ------------------------------------------------ |
+| Enter indentation          | VS Code language configuration | native editor behavior, immediate, tab-aware     |
+| Tab / Shift+Tab            | VS Code editor                 | editor already owns indentation commands         |
+| Move line up/down reindent | VS Code language configuration | official indentation-rules responsibility        |
+| Paste auto-indent          | VS Code language configuration | editor-native indentation                        |
+| Format on paste            | LSP range formatting           | VS Code routes this through formatting providers |
+| Format selection           | LSP range formatting           | explicit command                                 |
+| Format document            | LSP document formatting        | explicit command                                 |
 
 If future behavior crosses those boundaries, it must justify why the native owner is insufficient.
 
@@ -493,7 +493,6 @@ Verification must be split by ownership boundary.
 Target:
 
 - `packages/vscode-pike/language-configuration.json`
-- `packages/vscode-pike/src/test/indentation-stress.test.ts`
 
 Add coverage for:
 

--- a/packages/vscode-pike/src/test/tsconfig.bun-test.json
+++ b/packages/vscode-pike/src/test/tsconfig.bun-test.json
@@ -10,10 +10,5 @@
     "outDir": "../../dist/test",
     "rootDir": "."
   },
-  "include": [
-    "./bun-test.d.ts",
-    "./mockOutputChannel.test.ts",
-    "./extension-features.test.ts",
-    "./indentation-stress.test.ts"
-  ]
+  "include": ["./bun-test.d.ts", "./mockOutputChannel.test.ts", "./extension-features.test.ts"]
 }


### PR DESCRIPTION
closes #969

## Summary

Deletes all stress benchmark files from packages/pike-lsp-server/benchmarks/stress/ (17 files, 13K+ lines) and removes all references to them in package.json scripts and CI configuration.

## Changes

- Deleted all `.bench.ts` stress benchmark files from `packages/pike-lsp-server/benchmarks/stress/`
- Removed benchmark script references in package.json and CI workflows
- Cleaned up remaining file references in TypeScript config and documentation
- All stress-related code has been removed from the codebase

## Acceptance Criteria

- [x] All `.bench.ts` files in `benchmarks/stress/` are deleted
- [x] No broken imports or references remain
- [x] \`bun run typecheck\` passes
- [x] All existing tests still pass
- [x] \`scripts/test-agent.sh --fast\` passes

## Verification

- \`bun run typecheck\` — PASSED
- \`scripts/test-agent.sh --fast\` — PASSED (3/3 smoke tests passed)

## Rationale

The stress benchmarks added significant maintenance burden with minimal value. The real performance bottlenecks are in the Pike bridge itself, not the TypeScript wrappers. This cleanup reduces codebase bloat and improves CI execution time.