### PR TITLE
fix(#1014): make skip path test more robust with polling

### DIFF
--- a/packages/pike-lsp-server/src/scenarios/scenario-runner.test.ts
+++ b/packages/pike-lsp-server/src/scenarios/scenario-runner.test.ts
@@ -309,7 +309,11 @@ describe('Scenario: sendDiagnostics on skip path', () => {
       });
     }
 
-    await new Promise(r => setTimeout(r, 200));
+    // Wait for diagnostics to be published (polling for up to 2 seconds)
+    const startTime = Date.now();
+    while (diags.length <= openCount && Date.now() - startTime < 2000) {
+      await new Promise(r => setTimeout(r, 50));
+    }
 
     // MUST have published again (even if skipped, sendDiagnostics must be called)
     assert.ok(


### PR DESCRIPTION
## Summary

Makes the `Scenario: sendDiagnostics on skip path` test more robust by replacing a fixed 200ms timeout with a polling loop that waits up to 2 seconds for diagnostics to be published.

### Problem

The test was flaky:
- Passed when run in isolation
- Failed when run with the full test suite (timing variations)

### Solution

Replace `await new Promise(r => setTimeout(r, 200))` with a polling loop that:
- Waits up to 2 seconds for diagnostics to be published
- Checks every 50ms
- Exits early once diagnostics are received

### Test plan

- [x] Test passes in isolation
- [ ] Test passes with full suite (needs CI verification)

Closes #1014