### PR TITLE
chore: release v0.1.0-alpha.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pike-lsp",
-  "version": "0.1.0-alpha.34",
+  "version": "0.1.0-alpha.38",
   "private": true,
   "description": "Pike Language Server Protocol implementation and VSCode extension",
   "author": "Pike LSP Team",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/core",
-  "version": "0.1.0-alpha.21",
+  "version": "0.1.0-alpha.38",
   "description": "Shared utilities for Pike LSP packages",
   "repository": {
     "type": "git",

--- a/packages/pike-bridge/package.json
+++ b/packages/pike-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/pike-bridge",
-  "version": "0.1.0-alpha.21",
+  "version": "0.1.0-alpha.38",
   "description": "TypeScript <-> Pike subprocess communication layer",
   "repository": {
     "type": "git",

--- a/packages/pike-lsp-server/package.json
+++ b/packages/pike-lsp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/pike-lsp-server",
-  "version": "0.1.0-alpha.21",
+  "version": "0.1.0-alpha.38",
   "description": "Pike Language Server Protocol implementation",
   "type": "module",
   "main": "./dist/server.js",

--- a/packages/pike-lsp-server/src/tests/advanced/inline-values-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/advanced/inline-values-provider.test.ts
@@ -19,9 +19,8 @@ describe('Inline Values Provider', () => {
 
     it('should format strings with quotes', async () => {
       // Import the handler registration function
-      const { registerInlineValuesHandler } = await import(
-        '../../features/advanced/inline-values.js'
-      );
+      const { registerInlineValuesHandler } =
+        await import('../../features/advanced/inline-values.js');
 
       // Create mock services with inline values enabled
       const inlineValues: InlineValue[] = [];
@@ -52,22 +51,18 @@ describe('Inline Values Provider', () => {
         get: () => TextDocument.create('file:///test.pike', 'pike', 1, 'int x = 42;'),
       };
 
-      registerInlineValuesHandler(
-        connection as any,
-        services as any,
-        documents as any
-      );
+      registerInlineValuesHandler(connection as any, services as any, documents as any);
 
       // Handler was registered
       assert.ok((connection as any)._inlineValueHandler, 'Handler should be registered');
     });
 
     it('should return null when inline values disabled', async () => {
-      const { registerInlineValuesHandler } = await import(
-        '../../features/advanced/inline-values.js'
-      );
+      const { registerInlineValuesHandler } =
+        await import('../../features/advanced/inline-values.js');
 
-      let registeredHandler: ((params: InlineValueParams) => Promise<InlineValue[] | null>) | null = null;
+      let registeredHandler: ((params: InlineValueParams) => Promise<InlineValue[] | null>) | null =
+        null;
 
       const connection = {
         languages: {
@@ -97,7 +92,10 @@ describe('Inline Values Provider', () => {
       const params: InlineValueParams = {
         textDocument: { uri: 'file:///test.pike' },
         range: { start: { line: 0, character: 0 }, end: { line: 10, character: 0 } },
-        context: { frameId: 0, stoppedLocation: { start: { line: 0, character: 0 }, end: { line: 10, character: 0 } } },
+        context: {
+          frameId: 0,
+          stoppedLocation: { start: { line: 0, character: 0 }, end: { line: 10, character: 0 } },
+        },
       };
 
       assert.ok(registeredHandler, 'Handler should be registered');
@@ -106,12 +104,12 @@ describe('Inline Values Provider', () => {
     });
 
     it('should return null when no document in cache', async () => {
-      const { registerInlineValuesHandler } = await import(
-        '../../features/advanced/inline-values.js'
-      );
+      const { registerInlineValuesHandler } =
+        await import('../../features/advanced/inline-values.js');
 
       let capturedResult: InlineValue[] | null = undefined;
-      let registeredHandler: ((params: InlineValueParams) => Promise<InlineValue[] | null>) | null = null;
+      let registeredHandler: ((params: InlineValueParams) => Promise<InlineValue[] | null>) | null =
+        null;
 
       const connection = {
         languages: {
@@ -140,7 +138,10 @@ describe('Inline Values Provider', () => {
         const params: InlineValueParams = {
           textDocument: { uri: 'file:///test.pike' },
           range: { start: { line: 0, character: 0 }, end: { line: 10, character: 0 } },
-          context: { frameId: 0, stoppedLocation: { start: { line: 0, character: 0 }, end: { line: 10, character: 0 } } },
+          context: {
+            frameId: 0,
+            stoppedLocation: { start: { line: 0, character: 0 }, end: { line: 10, character: 0 } },
+          },
         };
         capturedResult = await registeredHandler(params);
       }
@@ -152,11 +153,11 @@ describe('Inline Values Provider', () => {
   describe('Variable detection', () => {
     it('should detect local variables from symbols', async () => {
       // This tests that the handler uses cached symbols for variable detection
-      const { registerInlineValuesHandler } = await import(
-        '../../features/advanced/inline-values.js'
-      );
+      const { registerInlineValuesHandler } =
+        await import('../../features/advanced/inline-values.js');
 
-      let registeredHandler: ((params: InlineValueParams) => Promise<InlineValue[] | null>) | null = null;
+      let registeredHandler: ((params: InlineValueParams) => Promise<InlineValue[] | null>) | null =
+        null;
 
       const connection = {
         languages: {
@@ -196,11 +197,11 @@ describe('Inline Values Provider', () => {
     });
 
     it('should detect local variables in methods', async () => {
-      const { registerInlineValuesHandler } = await import(
-        '../../features/advanced/inline-values.js'
-      );
+      const { registerInlineValuesHandler } =
+        await import('../../features/advanced/inline-values.js');
 
-      let registeredHandler: ((params: InlineValueParams) => Promise<InlineValue[] | null>) | null = null;
+      let registeredHandler: ((params: InlineValueParams) => Promise<InlineValue[] | null>) | null =
+        null;
 
       const connection = {
         languages: {
@@ -252,9 +253,8 @@ describe('Inline Values Provider', () => {
 
   describe('Configuration', () => {
     it('should respect inlineValues.enabled setting', async () => {
-      const { registerInlineValuesHandler } = await import(
-        '../../features/advanced/inline-values.js'
-      );
+      const { registerInlineValuesHandler } =
+        await import('../../features/advanced/inline-values.js');
 
       // Test that handler is registered regardless of config (config checked at call time)
       let handlerRegistered = false;
@@ -269,11 +269,7 @@ describe('Inline Values Provider', () => {
         sendDiagnostics: () => {},
       };
 
-      registerInlineValuesHandler(
-        connection as any,
-        { globalSettings: {} } as any,
-        {} as any
-      );
+      registerInlineValuesHandler(connection as any, { globalSettings: {} } as any, {} as any);
 
       assert.ok(handlerRegistered, 'Handler should always be registered');
     });

--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-pike",
   "displayName": "Pike Language Support",
   "description": "Complete language support for Pike including IntelliSense, go-to-definition, find references, diagnostics, hover, signature help, code completion, semantic tokens, call hierarchy, and workspace symbols.",
-  "version": "0.1.0-alpha.34",
+  "version": "0.1.0-alpha.38",
   "publisher": "pike-lsp",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
## Summary

This PR bumps the version to v0.1.0-alpha.38 for release.

## Linked Issue

N/A - Release version bump

## Root Cause

After 4 merged PRs since v0.1.0-alpha.37, a new release is needed to package the latest improvements.

## Changes

- `package.json` and `packages/*/package.json`: version bumped from 0.1.0-alpha.37 to 0.1.0-alpha.38

## Verification

- Tag `v0.1.0-alpha.38` created and pushed
- Extension packaging will be done via `cd packages/vscode-pike && bun run package`
- GitHub release will be created after merge

## Checklist

- [x] Version bumped in all package.json files
- [x] Tag created: v0.1.0-alpha.38
- [ ] Extension packaged after merge
- [ ] GitHub release created after merge

## Notes for Reviewer

Merged PRs since v0.1.0-alpha.37:
- #1029: test(#1027,#1028,#1030): add tests for definition-utils, getters-setters, module-scanner (+67 tests)
- #1032: test(#1031): add tests for catalog-manager (+15 tests)
- #1035: test(#1034): add tests for glob-cache (+15 tests)
- #1038: test(#1037): add tests for request-id (+10 tests)

Total: +107 new tests