### PR TITLE
feat(#1045): add color presentation support with scenario tests

### DIFF
--- a/packages/pike-lsp-server/src/features/advanced/__tests__/color-presentation.scenario.test.ts
+++ b/packages/pike-lsp-server/src/features/advanced/__tests__/color-presentation.scenario.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Color Presentation Scenario Tests
+ *
+ * Scenario tests that prove the color-presentation feature works through
+ * the real LSP handler registration path.
+ *
+ * Tests the actual code in color-presentation.ts:
+ * - findColors() via the registered textDocument/documentColor handler
+ * - getColorPresentations() via the registered textDocument/colorPresentation handler
+ *
+ * These tests MUST fail if color-presentation.ts is deleted or if
+ * findColors() / getColorPresentations() return wrong results.
+ */
+
+import { describe, it } from 'bun:test';
+import assert from 'node:assert/strict';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import type {
+  Color,
+  ColorInformation,
+  ColorPresentation,
+  DocumentColorParams,
+  ColorPresentationParams,
+} from 'vscode-languageserver/node.js';
+import { registerColorPresentationHandler } from '../color-presentation.js';
+
+function setupHandler() {
+  let documentColorHandler: (params: DocumentColorParams) => Promise<ColorInformation[] | null>;
+  let colorPresentationHandler: (
+    params: ColorPresentationParams
+  ) => Promise<ColorPresentation[] | null>;
+
+  const docMap = new Map<string, TextDocument>();
+
+  const connection = {
+    onDocumentColor(handler: (params: DocumentColorParams) => Promise<ColorInformation[] | null>) {
+      documentColorHandler = handler;
+    },
+    onColorPresentation(
+      handler: (params: ColorPresentationParams) => Promise<ColorPresentation[] | null>
+    ) {
+      colorPresentationHandler = handler;
+    },
+  };
+
+  const documents = {
+    get(uri: string) {
+      return docMap.get(uri);
+    },
+  };
+
+  registerColorPresentationHandler(connection as any, {} as any, documents as any);
+
+  return {
+    documentColorHandler: documentColorHandler!,
+    colorPresentationHandler: colorPresentationHandler!,
+    openDocument(uri: string, content: string, version = 1) {
+      const doc = TextDocument.create(uri, 'pike', version, content);
+      docMap.set(uri, doc);
+      return doc;
+    },
+  };
+}
+
+describe('Scenario: textDocument/documentColor', () => {
+  it('should find #RGB shorthand hex color', async () => {
+    const { documentColorHandler, openDocument } = setupHandler();
+    const uri = 'file:///test-rgb.pike';
+    openDocument(uri, 'string bg = "#f00";\n');
+
+    const result = await documentColorHandler({
+      textDocument: { uri },
+    });
+
+    assert.ok(result, 'Should return color information');
+    assert.strictEqual(result.length, 1, 'Should find exactly one color');
+
+    const info = result[0]!;
+    assert.deepStrictEqual(info.range, {
+      start: { line: 0, character: 13 },
+      end: { line: 0, character: 17 },
+    });
+
+    const expectedRed = parseInt('ff', 16) / 255;
+    assert.strictEqual(info.color.red, expectedRed);
+    assert.strictEqual(info.color.green, 0);
+    assert.strictEqual(info.color.blue, 0);
+    assert.strictEqual(info.color.alpha, 1);
+  });
+
+  it('should find #RRGGBB hex color', async () => {
+    const { documentColorHandler, openDocument } = setupHandler();
+    const uri = 'file:///test-rrggbb.pike';
+    openDocument(uri, 'string color = "#1a2b3c";\n');
+
+    const result = await documentColorHandler({
+      textDocument: { uri },
+    });
+
+    assert.ok(result, 'Should return color information');
+    assert.strictEqual(result.length, 1, 'Should find exactly one color');
+
+    const info = result[0]!;
+    assert.deepStrictEqual(info.range, {
+      start: { line: 0, character: 16 },
+      end: { line: 0, character: 23 },
+    });
+
+    assert.strictEqual(info.color.red, parseInt('1a', 16) / 255);
+    assert.strictEqual(info.color.green, parseInt('2b', 16) / 255);
+    assert.strictEqual(info.color.blue, parseInt('3c', 16) / 255);
+    assert.strictEqual(info.color.alpha, 1);
+  });
+
+  it('should find #RRGGBBAA hex color with alpha', async () => {
+    const { documentColorHandler, openDocument } = setupHandler();
+    const uri = 'file:///test-rrggbbaa.pike';
+    openDocument(uri, 'string overlay = "#ff000080";\n');
+
+    const result = await documentColorHandler({
+      textDocument: { uri },
+    });
+
+    assert.ok(result, 'Should return color information');
+    assert.strictEqual(result.length, 1, 'Should find exactly one color');
+
+    const info = result[0]!;
+    assert.deepStrictEqual(info.range, {
+      start: { line: 0, character: 18 },
+      end: { line: 0, character: 27 },
+    });
+
+    assert.strictEqual(info.color.red, 1);
+    assert.strictEqual(info.color.green, 0);
+    assert.strictEqual(info.color.blue, 0);
+    assert.strictEqual(info.color.alpha, parseInt('80', 16) / 255);
+  });
+
+  it('should find multiple hex colors in one document', async () => {
+    const { documentColorHandler, openDocument } = setupHandler();
+    const uri = 'file:///test-multi.pike';
+    openDocument(
+      uri,
+      ['string red = "#f00";', 'string green = "#00ff00";', 'string blue = "#0000ffcc";'].join('\n')
+    );
+
+    const result = await documentColorHandler({
+      textDocument: { uri },
+    });
+
+    assert.ok(result, 'Should return color information');
+    assert.strictEqual(result.length, 3, 'Should find three colors');
+
+    assert.strictEqual(result[0]!.range.start.line, 0);
+    assert.strictEqual(result[1]!.range.start.line, 1);
+    assert.strictEqual(result[2]!.range.start.line, 2);
+  });
+
+  it('should return null for unknown document URI', async () => {
+    const { documentColorHandler } = setupHandler();
+
+    const result = await documentColorHandler({
+      textDocument: { uri: 'file:///nonexistent.pike' },
+    });
+
+    assert.strictEqual(result, null, 'Should return null for missing document');
+  });
+
+  it('should return empty array for document with no hex colors', async () => {
+    const { documentColorHandler, openDocument } = setupHandler();
+    const uri = 'file:///test-no-colors.pike';
+    openDocument(uri, 'int x = 42;\nstring s = "hello";\n');
+
+    const result = await documentColorHandler({
+      textDocument: { uri },
+    });
+
+    assert.ok(result, 'Should return array');
+    assert.strictEqual(result.length, 0, 'Should find no colors');
+  });
+
+  it('should handle #RGB shorthand with mixed case', async () => {
+    const { documentColorHandler, openDocument } = setupHandler();
+    const uri = 'file:///test-mixed-case.pike';
+    openDocument(uri, 'string c = "#AbC";\n');
+
+    const result = await documentColorHandler({
+      textDocument: { uri },
+    });
+
+    assert.ok(result);
+    assert.strictEqual(result.length, 1);
+
+    const color = result[0]!.color;
+    assert.strictEqual(color.red, parseInt('aa', 16) / 255);
+    assert.strictEqual(color.green, parseInt('bb', 16) / 255);
+    assert.strictEqual(color.blue, parseInt('cc', 16) / 255);
+  });
+});
+
+describe('Scenario: textDocument/colorPresentation', () => {
+  it('should return hex presentation for opaque color', async () => {
+    const { colorPresentationHandler } = setupHandler();
+
+    const result = await colorPresentationHandler({
+      textDocument: { uri: 'file:///test.pike' },
+      color: { red: 1, green: 0, blue: 0, alpha: 1 } as Color,
+      range: {
+        start: { line: 0, character: 10 },
+        end: { line: 0, character: 14 },
+      },
+    });
+
+    assert.ok(result, 'Should return presentations');
+    assert.ok(result.length >= 2, 'Should have at least hex and rgb formats');
+
+    const hexPresentation = result.find(p => p.label.startsWith('#') && p.label.length === 7);
+    assert.ok(hexPresentation, 'Should include #RRGGBB format');
+    assert.strictEqual(hexPresentation!.label, '#ff0000');
+  });
+
+  it('should return rgba presentation with alpha', async () => {
+    const { colorPresentationHandler } = setupHandler();
+
+    const result = await colorPresentationHandler({
+      textDocument: { uri: 'file:///test.pike' },
+      color: { red: 0, green: 0.5, blue: 1, alpha: 0.75 } as Color,
+      range: {
+        start: { line: 0, character: 5 },
+        end: { line: 0, character: 15 },
+      },
+    });
+
+    assert.ok(result, 'Should return presentations');
+
+    const rgbaPresentation = result.find(p => p.label.startsWith('rgba('));
+    assert.ok(rgbaPresentation, 'Should include rgba format');
+    assert.ok(rgbaPresentation!.label.includes('0.75'), 'Should include alpha value');
+  });
+
+  it('should include #RRGGBBAA when alpha < 1', async () => {
+    const { colorPresentationHandler } = setupHandler();
+
+    const result = await colorPresentationHandler({
+      textDocument: { uri: 'file:///test.pike' },
+      color: { red: 1, green: 0, blue: 0, alpha: 0.5 } as Color,
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 10 },
+      },
+    });
+
+    assert.ok(result);
+
+    const rrggbbaa = result.find(p => p.label.startsWith('#') && p.label.length === 9);
+    assert.ok(rrggbbaa, 'Should include #RRGGBBAA when alpha < 1');
+    assert.strictEqual(rrggbbaa!.label, '#ff000080');
+  });
+
+  it('should NOT include #RRGGBBAA when alpha is 1', async () => {
+    const { colorPresentationHandler } = setupHandler();
+
+    const result = await colorPresentationHandler({
+      textDocument: { uri: 'file:///test.pike' },
+      color: { red: 1, green: 1, blue: 1, alpha: 1 } as Color,
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 7 },
+      },
+    });
+
+    assert.ok(result);
+
+    const rrggbbaa = result.find(p => p.label.startsWith('#') && p.label.length === 9);
+    assert.strictEqual(rrggbbaa, undefined, 'Should NOT include #RRGGBBAA when fully opaque');
+  });
+
+  it('should include text edits replacing the original range', async () => {
+    const { colorPresentationHandler } = setupHandler();
+    const range = {
+      start: { line: 2, character: 10 },
+      end: { line: 2, character: 17 },
+    };
+
+    const result = await colorPresentationHandler({
+      textDocument: { uri: 'file:///test.pike' },
+      color: { red: 0, green: 0, blue: 0, alpha: 1 } as Color,
+      range,
+    });
+
+    assert.ok(result);
+    assert.ok(result.length > 0);
+
+    for (const presentation of result) {
+      assert.ok(presentation.textEdit, `Presentation "${presentation.label}" should have textEdit`);
+      assert.deepStrictEqual(
+        presentation.textEdit!.range,
+        range,
+        `Presentation "${presentation.label}" should use the provided range`
+      );
+      assert.strictEqual(
+        presentation.textEdit!.newText,
+        presentation.label,
+        `Presentation "${presentation.label}" textEdit.newText should match label`
+      );
+    }
+  });
+
+  it('should return rgb() format presentation', async () => {
+    const { colorPresentationHandler } = setupHandler();
+
+    const result = await colorPresentationHandler({
+      textDocument: { uri: 'file:///test.pike' },
+      color: { red: 1, green: 0.5, blue: 0, alpha: 1 } as Color,
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 7 },
+      },
+    });
+
+    assert.ok(result);
+
+    const rgbPresentation = result.find(
+      p => p.label.startsWith('rgb(') && !p.label.startsWith('rgba(')
+    );
+    assert.ok(rgbPresentation, 'Should include rgb() format');
+    assert.strictEqual(rgbPresentation!.label, 'rgb(255, 128, 0)');
+  });
+});
+
+describe('Scenario: documentColor + colorPresentation end-to-end', () => {
+  it('should detect a color and then present it in all formats', async () => {
+    const { documentColorHandler, colorPresentationHandler, openDocument } = setupHandler();
+    const uri = 'file:///test-e2e.pike';
+    openDocument(uri, 'string bg = "#ff8800";\n');
+
+    const colors = await documentColorHandler({
+      textDocument: { uri },
+    });
+
+    assert.ok(colors);
+    assert.strictEqual(colors.length, 1);
+
+    const detected = colors[0]!;
+
+    const presentations = await colorPresentationHandler({
+      textDocument: { uri },
+      color: detected.color,
+      range: detected.range,
+    });
+
+    assert.ok(presentations);
+    assert.ok(presentations.length >= 3, 'Should have hex, rgb, and rgba formats');
+
+    const hex = presentations.find(p => p.label === '#ff8800');
+    assert.ok(hex, 'Should have exact hex representation');
+    assert.ok(hex!.textEdit, 'Hex presentation should have text edit');
+    assert.strictEqual(hex!.textEdit!.newText, '#ff8800');
+  });
+
+  it('should detect #RGB and allow replacing with full #RRGGBB', async () => {
+    const { documentColorHandler, colorPresentationHandler, openDocument } = setupHandler();
+    const uri = 'file:///test-rgb-e2e.pike';
+    openDocument(uri, 'string bg = "#f80";\n');
+
+    const colors = await documentColorHandler({
+      textDocument: { uri },
+    });
+
+    assert.ok(colors);
+    assert.strictEqual(colors.length, 1);
+
+    const detected = colors[0]!;
+    assert.deepStrictEqual(detected.range, {
+      start: { line: 0, character: 13 },
+      end: { line: 0, character: 17 },
+    });
+
+    const presentations = await colorPresentationHandler({
+      textDocument: { uri },
+      color: detected.color,
+      range: detected.range,
+    });
+
+    assert.ok(presentations);
+    const hexPresentation = presentations.find(
+      p => p.label.startsWith('#') && p.label.length === 7
+    );
+    assert.ok(hexPresentation, 'Should offer #RRGGBB expansion of #RGB');
+    assert.ok(
+      hexPresentation!.textEdit!.range.start.character === 13,
+      'Text edit should target the original #RGB position'
+    );
+  });
+});

--- a/packages/pike-lsp-server/src/features/advanced/color-presentation.ts
+++ b/packages/pike-lsp-server/src/features/advanced/color-presentation.ts
@@ -1,0 +1,207 @@
+/**
+ * Color Presentation Handler
+ *
+ * Provides color detection and presentation for hex color literals in Pike code.
+ *
+ * Features:
+ * - Find hex colors (#RGB, #RRGGBB, #RRGGBBAA) in Pike source
+ * - Present color information with editable range
+ * - Return presentation formats (hex, rgb) for color picker integration
+ */
+
+import {
+  Connection,
+  Color,
+  ColorInformation,
+  ColorPresentation,
+} from 'vscode-languageserver/node.js';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { TextDocuments } from 'vscode-languageserver/node.js';
+import type { Services } from '../../services/index.js';
+import { Logger } from '@pike-lsp/core';
+
+/**
+ * Regex matching hex color literals:
+ * - #RGB       (3-digit shorthand)
+ * - #RRGGBB    (6-digit)
+ * - #RRGGBBAA  (8-digit with alpha)
+ */
+const HEX_COLOR_REGEX = /#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b/g;
+
+/**
+ * Parse a hex color string into a Color object.
+ *
+ * Handles:
+ * - #RGB → each digit doubled (e.g. #f00 → #ff0000)
+ * - #RRGGBB → direct mapping
+ * - #RRGGBBAA → direct mapping with alpha
+ *
+ * @param hex - Hex color string WITHOUT the leading '#'
+ * @returns Color with components in [0-1] range
+ */
+export function parseHexColor(hex: string): Color {
+  let r: number, g: number, b: number, a: number;
+
+  if (hex.length === 3) {
+    // #RGB shorthand: each digit is doubled
+    r = parseInt(hex[0]! + hex[0], 16) / 255;
+    g = parseInt(hex[1]! + hex[1], 16) / 255;
+    b = parseInt(hex[2]! + hex[2], 16) / 255;
+    a = 1;
+  } else if (hex.length === 6) {
+    // #RRGGBB
+    r = parseInt(hex.substring(0, 2), 16) / 255;
+    g = parseInt(hex.substring(2, 4), 16) / 255;
+    b = parseInt(hex.substring(4, 6), 16) / 255;
+    a = 1;
+  } else {
+    // #RRGGBBAA
+    r = parseInt(hex.substring(0, 2), 16) / 255;
+    g = parseInt(hex.substring(2, 4), 16) / 255;
+    b = parseInt(hex.substring(4, 6), 16) / 255;
+    a = parseInt(hex.substring(6, 8), 16) / 255;
+  }
+
+  return { red: r, green: g, blue: b, alpha: a };
+}
+
+/**
+ * Find all hex color literals in a text string.
+ *
+ * @param text - Source text to scan
+ * @returns Array of ColorInformation with color values and ranges
+ */
+export function findColors(text: string): ColorInformation[] {
+  const colors: ColorInformation[] = [];
+  const lines = text.split('\n');
+
+  for (let lineNum = 0; lineNum < lines.length; lineNum++) {
+    const line = lines[lineNum] ?? '';
+    let match: RegExpExecArray | null;
+
+    HEX_COLOR_REGEX.lastIndex = 0;
+    while ((match = HEX_COLOR_REGEX.exec(line)) !== null) {
+      const hexPart = match[1]!;
+      const startChar = match.index;
+      const endChar = startChar + match[0].length;
+
+      colors.push({
+        range: {
+          start: { line: lineNum, character: startChar },
+          end: { line: lineNum, character: endChar },
+        },
+        color: parseHexColor(hexPart),
+      });
+    }
+  }
+
+  return colors;
+}
+
+/**
+ * Generate color presentations for a given color value.
+ *
+ * Returns presentations in multiple formats for the color picker:
+ * - #RRGGBB (6-digit hex)
+ * - #RRGGBBAA (8-digit hex with alpha, only if alpha < 1)
+ * - rgb(r, g, b)
+ * - rgba(r, g, b, a)
+ *
+ * @param color - LSP Color object with components in [0-1] range
+ * @returns Array of ColorPresentation objects
+ */
+export function getColorPresentations(color: Color): ColorPresentation[] {
+  const r = Math.round(color.red * 255);
+  const g = Math.round(color.green * 255);
+  const b = Math.round(color.blue * 255);
+  const a = color.alpha;
+
+  const toHex2 = (n: number) => n.toString(16).padStart(2, '0').toLowerCase();
+
+  const presentations: ColorPresentation[] = [];
+
+  // #RRGGBB format
+  presentations.push({
+    label: `#${toHex2(r)}${toHex2(g)}${toHex2(b)}`,
+  });
+
+  // #RRGGBBAA format (only if alpha is not fully opaque)
+  if (a < 1) {
+    const aInt = Math.round(a * 255);
+    presentations.push({
+      label: `#${toHex2(r)}${toHex2(g)}${toHex2(b)}${toHex2(aInt)}`,
+    });
+  }
+
+  // rgb(r, g, b) format
+  presentations.push({
+    label: `rgb(${r}, ${g}, ${b})`,
+  });
+
+  // rgba(r, g, b, a) format
+  presentations.push({
+    label: `rgba(${r}, ${g}, ${b}, ${a.toFixed(2)})`,
+  });
+
+  return presentations;
+}
+
+/**
+ * Register color presentation handlers with the LSP connection.
+ *
+ * Handles:
+ * - textDocument/documentColor - find all colors in a document
+ * - textDocument/colorPresentation - get presentations for a color
+ */
+export function registerColorPresentationHandler(
+  connection: Connection,
+  _services: Services,
+  documents: TextDocuments<TextDocument>
+): void {
+  const log = new Logger('Advanced');
+
+  /**
+   * Handle textDocument/documentColor request.
+   * Finds all hex color literals in the document.
+   */
+  connection.onDocumentColor(async params => {
+    log.debug('Document color request', { uri: params.textDocument.uri });
+    try {
+      const document = documents.get(params.textDocument.uri);
+      if (!document) {
+        return null;
+      }
+
+      const text = document.getText();
+      return findColors(text);
+    } catch (err) {
+      log.error(
+        `Document color failed for ${params.textDocument.uri}: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return null;
+    }
+  });
+
+  /**
+   * Handle textDocument/colorPresentation request.
+   * Returns presentation formats for a given color and range.
+   */
+  connection.onColorPresentation(async params => {
+    log.debug('Color presentation request', { uri: params.textDocument.uri });
+    try {
+      const presentations = getColorPresentations(params.color);
+
+      // Attach text edit for each presentation to replace the original color
+      return presentations.map(p => ({
+        ...p,
+        textEdit: {
+          range: params.range,
+          newText: p.label,
+        },
+      }));
+    } catch (err) {
+      log.error(`Color presentation failed: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    }
+  });
+}

--- a/packages/pike-lsp-server/src/features/advanced/index.ts
+++ b/packages/pike-lsp-server/src/features/advanced/index.ts
@@ -10,6 +10,7 @@
  * - Document Formatting: code formatting
  * - Document Links: clickable file paths
  * - Code Lens: reference counts and quick actions
+ * - Color Presentation: hex color detection and color picker
  *
  * Each handler includes try/catch with logging fallback (SRV-12).
  */
@@ -28,6 +29,7 @@ import { registerCodeLensHandlers } from './code-lens.js';
 import { registerInlineValuesHandler } from './inline-values.js';
 import { registerMonikerHandler } from './moniker.js';
 import { registerOnTypeFormattingHandler } from './on-type-formatting.js';
+import { registerColorPresentationHandler } from './color-presentation.js';
 
 export { registerFoldingRangeHandler } from './folding.js';
 export { registerSemanticTokensHandler } from './semantic-tokens.js';
@@ -40,6 +42,7 @@ export { registerCodeLensHandlers } from './code-lens.js';
 export { registerInlineValuesHandler } from './inline-values.js';
 export { registerMonikerHandler } from './moniker.js';
 export { registerOnTypeFormattingHandler } from './on-type-formatting.js';
+export { registerColorPresentationHandler } from './color-presentation.js';
 
 /**
  * Register all advanced feature handlers with the LSP connection.
@@ -64,4 +67,5 @@ export function registerAdvancedHandlers(
   registerInlineValuesHandler(connection, services, documents);
   registerMonikerHandler(connection, services, documents);
   registerOnTypeFormattingHandler(connection, services, documents);
+  registerColorPresentationHandler(connection, services, documents);
 }

--- a/packages/pike-lsp-server/src/server.ts
+++ b/packages/pike-lsp-server/src/server.ts
@@ -393,6 +393,7 @@ connection.onInitialize(async (params: InitializeParams): Promise<InitializeResu
           firstTriggerCharacter: '\n',
           moreTriggerCharacter: ['}'],
         },
+        colorProvider: true,
         documentLinkProvider: { resolveProvider: true },
         codeLensProvider: { resolveProvider: true },
         linkedEditingRangeProvider: true,


### PR DESCRIPTION
## Summary

Adds color presentation support to the LSP server, enabling color pickers to detect and edit hex color literals (#RGB, #RRGGBB, #RRGGBBAA) in Pike code. Includes 15 scenario tests proving the full LSP stack works.

## Problem

The LSP server did not support color presentation, which allows color pickers to detect and edit hex color literals in Pike code. Issue #1011 was closed but the feature was never actually merged to main.

## Before

```bash
$ grep -rn "colorProvider" packages/pike-lsp-server/src/server.ts
# NO MATCHES - Feature does NOT exist

$ find packages/pike-lsp-server/src/features -name "*color*"
# No color-related handler files exist
```

## Implementation

- Added `colorProvider: true` to server capabilities
- Created `color-presentation.ts` with:
  - `findColors()` - finds hex colors (#RGB, #RRGGBB, #RRGGBBAA)
  - `getColorPresentations()` - returns edit formats for color picker
  - LSP handlers for `textDocument/documentColor` and `textDocument/colorPresentation`
- Registered handlers in `features/advanced/index.ts`
- Added comprehensive scenario tests (15 tests)

## Scenario Test on Old Code (must fail)

```bash
$ rm packages/pike-lsp-server/src/features/advanced/color-presentation.ts
$ bun test ./packages/pike-lsp-server/src/features/advanced/__tests__/color-presentation.scenario.test.ts

# Unhandled error between tests
error: Cannot find module ../color-presentation.js

 0 pass
 1 fail
```

## Scenario Test on New Code (must pass)

```bash
$ bun test ./packages/pike-lsp-server/src/features/advanced/__tests__/color-presentation.scenario.test.ts

 15 pass
 0 fail
```

## Full Suite

```bash
$ bun run test:packages

 3109 pass
 16 skip
 0 fail
```

## Supported Formats

- #RGB (3-digit shorthand)
- #RRGGBB (6-digit)
- #RRGGBBAA (8-digit with alpha)

Fixes #1045