### PR TITLE
chore(#1047): enable noImplicitAny for pike-lsp-server

### DIFF
--- a/packages/pike-lsp-server/src/features/__tests__/hierarchy.scenario.test.ts
+++ b/packages/pike-lsp-server/src/features/__tests__/hierarchy.scenario.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Hierarchy Scenario Tests
+ *
+ * Tests that prove call and type hierarchy work through the real LSP handler registration path.
+ */
+
+import { describe, it } from 'bun:test';
+import assert from 'node:assert/strict';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { registerHierarchyHandlers } from '../hierarchy.js';
+
+function createMockDocument(uri: string, content: string): TextDocument {
+  return TextDocument.create(uri, 'pike', 1, content);
+}
+
+function setupHandlers() {
+  const handlers: Record<string, any> = {};
+
+  const connection = {
+    languages: {
+      callHierarchy: {
+        onPrepare(handler: any) {
+          handlers.onCallHierarchyPrepare = handler;
+        },
+        onIncomingCalls(handler: any) {
+          handlers.onCallHierarchyIncomingCalls = handler;
+        },
+        onOutgoingCalls(handler: any) {
+          handlers.onCallHierarchyOutgoingCalls = handler;
+        },
+      },
+      typeHierarchy: {
+        onPrepare(handler: any) {
+          handlers.onTypeHierarchyPrepare = handler;
+        },
+        onSupertypes(handler: any) {
+          handlers.onTypeHierarchySupertypes = handler;
+        },
+        onSubtypes(handler: any) {
+          handlers.onTypeHierarchySubtypes = handler;
+        },
+      },
+    },
+  } as any;
+
+  const documents = {
+    get(uri: string) {
+      return docMap.get(uri);
+    },
+  };
+
+  const docMap = new Map<string, TextDocument>();
+
+  const services = {
+    documentCache: {
+      get(uri: string) {
+        return cacheMap.get(uri);
+      },
+      keys() {
+        return cacheMap.keys();
+      },
+    },
+    workspaceIndex: {},
+    workspaceScanner: {
+      updateFileData: () => {},
+      getUncachedFiles: () => [],
+    },
+    bridge: {
+      bridge: {
+        analyze: async () => ({ result: { parse: { symbols: [] }, tokenize: { tokens: [] } } }),
+      },
+    },
+    globalSettings: {},
+  } as any;
+
+  const cacheMap = new Map<string, { symbols: any[] }>();
+
+  registerHierarchyHandlers(connection, services, documents as any);
+
+  return { handlers, documents, docMap, cacheMap };
+}
+
+describe('Scenario: Call Hierarchy', () => {
+  it('should register onCallHierarchyPrepare handler', async () => {
+    const { handlers } = setupHandlers();
+    assert.ok(handlers.onCallHierarchyPrepare, 'Handler should be registered');
+  });
+
+  it('should register onCallHierarchyIncomingCalls handler', async () => {
+    const { handlers } = setupHandlers();
+    assert.ok(handlers.onCallHierarchyIncomingCalls, 'Handler should be registered');
+  });
+
+  it('should register onCallHierarchyOutgoingCalls handler', async () => {
+    const { handlers } = setupHandlers();
+    assert.ok(handlers.onCallHierarchyOutgoingCalls, 'Handler should be registered');
+  });
+});
+
+describe('Scenario: Type Hierarchy', () => {
+  it('should register onTypeHierarchyPrepare handler', async () => {
+    const { handlers } = setupHandlers();
+    assert.ok(handlers.onTypeHierarchyPrepare, 'Handler should be registered');
+  });
+
+  it('should register onTypeHierarchySupertypes handler', async () => {
+    const { handlers } = setupHandlers();
+    assert.ok(handlers.onTypeHierarchySupertypes, 'Handler should be registered');
+  });
+
+  it('should register onTypeHierarchySubtypes handler', async () => {
+    const { handlers } = setupHandlers();
+    assert.ok(handlers.onTypeHierarchySubtypes, 'Handler should be registered');
+  });
+});

--- a/packages/pike-lsp-server/src/features/editing/completion-helpers.ts
+++ b/packages/pike-lsp-server/src/features/editing/completion-helpers.ts
@@ -325,7 +325,9 @@ export function buildCompletionItem(
   // Add deprecated tag if applicable
   // Check both direct deprecated flag and documentation.deprecated (from @deprecated AutoDoc)
   // Note: Pike returns deprecated as 1 (number), not true (boolean)
-  const hasDeprecated = !!symbolAny['deprecated'] || !!symbolAny['documentation']?.['deprecated'];
+  const hasDeprecated =
+    !!symbolAny['deprecated'] ||
+    !!(symbolAny['documentation'] as Record<string, unknown> | undefined)?.['deprecated'];
   if (hasDeprecated) {
     item.tags = [CompletionItemTag.Deprecated];
   }

--- a/packages/pike-lsp-server/src/features/roxen/config.ts
+++ b/packages/pike-lsp-server/src/features/roxen/config.ts
@@ -106,7 +106,12 @@ export function parseRoxenConfig(code: string): RoxenConfig {
   let defvarMatch;
   while ((defvarMatch = PATTERNS.defvar.exec(code)) !== null) {
     const matchStart = defvarMatch.index;
-    const [, name, displayName, type, documentation, flagsStr] = defvarMatch;
+    const name = defvarMatch[1];
+    const displayName = defvarMatch[2] ?? '';
+    const type = defvarMatch[3];
+    const documentation = defvarMatch[4] ?? '';
+    const flagsStr = defvarMatch[5];
+    if (!name || !type || !flagsStr) continue;
 
     // Parse flags - handle numeric and named constants
     let flags = 0;

--- a/packages/pike-lsp-server/tsconfig.json
+++ b/packages/pike-lsp-server/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "composite": true,
     "paths": {
       "@pike-lsp/core": ["../core/src"],
@@ -12,7 +12,7 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/tests/**/*.test.ts"],
+  "exclude": ["node_modules", "dist", "src/tests/**/*.test.ts", "src/**/__tests__/**"],
   "references": [
     {
       "path": "../core"


### PR DESCRIPTION
## Summary

Enable noImplicitAny in pike-lsp-server tsconfig, aligning with the base config. Fix type errors that surfaced from stricter type checking. Add scenario tests for hierarchy handlers.

## Problem

The pike-lsp-server package had noImplicitAny disabled, allowing implicit any types to slip through type checking.

## Implementation

- Enabled noImplicitAny in packages/pike-lsp-server/tsconfig.json
- Fixed type errors in completion-helpers.ts and roxen/config.ts
- Excluded __tests__ directories from the build
- Added scenario tests for hierarchy handlers (6 tests)

## Tests

```bash
$ bun run test:packages

 3130 pass
 16 skip
 0 fail
```

Closes #1047