### PR TITLE
chore: release v0.1.0-alpha.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security** - Security vulnerability fixes
 - **Performance** - User-facing performance notes
 
+## [0.1.0-alpha.39] - 2026-03-31
+
+### Added
+
+- **Color presentation** - added `colorProvider` capability with hex color detection (#RGB, #RRGGBB, #RRGGBBAA) and color picker integration by @TheSmuks in https://github.com/TheSmuks/pike-lsp/pull/1049
+
+### Fixed
+
+- **Nested switch/case formatting** - fixed indentation for nested switch/case blocks by @TheSmuks in https://github.com/TheSmuks/pike-lsp/pull/1044
+
+### Changed
+
+- **Type safety** - enabled `noImplicitAny` in pike-lsp-server for stricter type checking by @TheSmuks in https://github.com/TheSmuks/pike-lsp/pull/1050
+
+**Full Changelog**: https://github.com/TheSmuks/pike-lsp/compare/v0.1.0-alpha.38...v0.1.0-alpha.39
+
 ## [0.1.0-alpha.38] - 2026-03-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pike-lsp",
-  "version": "0.1.0-alpha.38",
+  "version": "0.1.0-alpha.39",
   "private": true,
   "description": "Pike Language Server Protocol implementation and VSCode extension",
   "author": "Pike LSP Team",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/core",
-  "version": "0.1.0-alpha.38",
+  "version": "0.1.0-alpha.39",
   "description": "Shared utilities for Pike LSP packages",
   "repository": {
     "type": "git",

--- a/packages/pike-bridge/package.json
+++ b/packages/pike-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/pike-bridge",
-  "version": "0.1.0-alpha.38",
+  "version": "0.1.0-alpha.39",
   "description": "TypeScript <-> Pike subprocess communication layer",
   "repository": {
     "type": "git",

--- a/packages/pike-lsp-server/package.json
+++ b/packages/pike-lsp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/pike-lsp-server",
-  "version": "0.1.0-alpha.38",
+  "version": "0.1.0-alpha.39",
   "description": "Pike Language Server Protocol implementation",
   "type": "module",
   "main": "./dist/server.js",

--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-pike",
   "displayName": "Pike Language Support",
   "description": "Complete language support for Pike including IntelliSense, go-to-definition, find references, diagnostics, hover, signature help, code completion, semantic tokens, call hierarchy, and workspace symbols.",
-  "version": "0.1.0-alpha.38",
+  "version": "0.1.0-alpha.39",
   "publisher": "pike-lsp",
   "license": "MIT",
   "icon": "images/icon.png",

--- a/scripts/release-alpha39.sh
+++ b/scripts/release-alpha39.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Manual release for alpha.39
+set -euo pipefail
+
+NEW_VERSION="0.1.0-alpha.39"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=== RELEASING v$NEW_VERSION ==="
+
+# Update workspace versions
+for pkg in packages/*/package.json; do
+  if [ -f "$pkg" ]; then
+    sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$NEW_VERSION\"/" "$pkg"
+    echo "Updated: $pkg"
+  fi
+done
+
+# Update root version
+sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$NEW_VERSION\"/" package.json
+echo "Updated: package.json"
+
+echo "Done updating versions to $NEW_VERSION"


### PR DESCRIPTION
## Summary

Release v0.1.0-alpha.39 with color presentation support and nested switch/case formatting fix.

Closes #1052

## Changes since v0.1.0-alpha.38

### Added
- **Color presentation** - `colorProvider` capability with hex color detection (#RGB, #RRGGBB, #RRGGBBAA) and color picker integration

### Fixed
- **Nested switch/case formatting** - fixed indentation for nested switch/case blocks

### Changed
- **Type safety** - enabled `noImplicitAny` in pike-lsp-server for stricter type checking

## Tests

```bash
$ bun run test:packages

 3130 pass
 16 skip
 0 fail
```

Tag: v0.1.0-alpha.39 (already pushed)