### PR TITLE
chore: release v0.1.0-alpha.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security** - Security vulnerability fixes
 - **Performance** - User-facing performance notes
 
+## [0.1.0-alpha.40] - 2026-03-31
+
+### Fixed
+
+- **Stale syntax errors** - fixed issue where error diagnostics remained visible after fixing the underlying code by @TheSmuks in https://github.com/TheSmuks/pike-lsp/pull/1053
+
+**Full Changelog**: https://github.com/TheSmuks/pike-lsp/compare/v0.1.0-alpha.39...v0.1.0-alpha.40
+
 ## [0.1.0-alpha.39] - 2026-03-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pike-lsp",
-  "version": "0.1.0-alpha.39",
+  "version": "0.1.0-alpha.40",
   "private": true,
   "description": "Pike Language Server Protocol implementation and VSCode extension",
   "author": "Pike LSP Team",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/core",
-  "version": "0.1.0-alpha.39",
+  "version": "0.1.0-alpha.40",
   "description": "Shared utilities for Pike LSP packages",
   "repository": {
     "type": "git",

--- a/packages/pike-bridge/package.json
+++ b/packages/pike-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/pike-bridge",
-  "version": "0.1.0-alpha.39",
+  "version": "0.1.0-alpha.40",
   "description": "TypeScript <-> Pike subprocess communication layer",
   "repository": {
     "type": "git",

--- a/packages/pike-lsp-server/package.json
+++ b/packages/pike-lsp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pike-lsp/pike-lsp-server",
-  "version": "0.1.0-alpha.39",
+  "version": "0.1.0-alpha.40",
   "description": "Pike Language Server Protocol implementation",
   "type": "module",
   "main": "./dist/server.js",

--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-pike",
   "displayName": "Pike Language Support",
   "description": "Complete language support for Pike including IntelliSense, go-to-definition, find references, diagnostics, hover, signature help, code completion, semantic tokens, call hierarchy, and workspace symbols.",
-  "version": "0.1.0-alpha.39",
+  "version": "0.1.0-alpha.40",
   "publisher": "pike-lsp",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
## Summary

Release v0.1.0-alpha.40 with stale syntax error fix.

## Changes since v0.1.0-alpha.39

### Fixed
- **Stale syntax errors** - fixed issue where error diagnostics remained visible after fixing the underlying code

## Tests

```bash
$ bun run test:packages

3136 pass
16 skip
0 fail
```

Tag: v0.1.0-alpha.40 (already pushed)

Closes #1052