### PR TITLE
fix(#1058): remove setTimeout hack from symbols.ts

### DIFF
--- a/packages/pike-lsp-server/src/features/symbols.ts
+++ b/packages/pike-lsp-server/src/features/symbols.ts
@@ -154,12 +154,7 @@ export function registerSymbolsHandlers(
       let cached = documentCache.get(uri);
 
       if (!cached) {
-        // Wait for any pending validation
         await documentCache.waitFor(uri);
-
-        // Race condition check: wait a tick
-        await new Promise(resolve => setTimeout(resolve, 50));
-
         cached = documentCache.get(uri);
       }
 

--- a/packages/pike-lsp-server/src/scenarios/document-open-race.test.ts
+++ b/packages/pike-lsp-server/src/scenarios/document-open-race.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Scenario: Document Symbols Race on File Open (Issue #1075)
+ *
+ * Tests that document symbols resolve correctly when requested
+ * immediately after file open, without relying on fragile setTimeout hacks.
+ *
+ * Before the fix:
+ * - onDidOpen called engineOpenDocument fire-and-forget
+ * - validateDocument ran immediately (without snapshot)
+ * - documentCache.setPending was called synchronously (OK)
+ * - BUT symbols.ts had a 50ms setTimeout hack because the pending
+ *   promise resolved before the cache was populated in some edge cases
+ *
+ * After the fix:
+ * - onDidOpen awaits engineOpenDocument before validateDocument
+ * - documentSnapshots is set before validation starts
+ * - symbols.ts no longer needs the 50ms setTimeout hack
+ * - waitFor(uri) guarantees cache is populated when it resolves
+ */
+
+import { describe, it } from 'bun:test';
+import assert from 'node:assert/strict';
+import { DocumentCache } from '../services/document-cache.js';
+import { registerSymbolsHandlers } from '../features/symbols.js';
+import {
+  createMockConnection,
+  createMockServices,
+  makeCacheEntry,
+  sym,
+} from '../tests/helpers/mock-services.js';
+import type { DocumentCacheEntry } from '../core/types.js';
+import type { PikeSymbol } from '@pike-lsp/pike-bridge';
+
+function createRealDocumentCache() {
+  return new DocumentCache();
+}
+
+describe('Scenario: document symbols race on file open', () => {
+  it('should resolve symbols after waitFor without setTimeout hack', async () => {
+    const uri = 'file:///race-test.pike';
+    const cache = createRealDocumentCache();
+
+    const pikeSymbols: PikeSymbol[] = [
+      sym('TestClass', 'class', { position: { file: 'race-test.pike', line: 1 } }),
+      sym('main', 'method', { position: { file: 'race-test.pike', line: 5 } }),
+    ];
+
+    const cacheEntry = makeCacheEntry({ symbols: pikeSymbols, version: 1 });
+
+    const validationPromise = new Promise<void>(resolve => {
+      setTimeout(() => {
+        cache.set(uri, cacheEntry);
+        resolve();
+      }, 30);
+    });
+
+    cache.setPending(uri, validationPromise);
+
+    const cacheEntries = new Map<string, DocumentCacheEntry>();
+    const services = createMockServices({ cacheEntries });
+
+    (services as any).documentCache = {
+      get: (u: string) => cache.get(u),
+      waitFor: async (u: string) => cache.waitFor(u),
+      entries: () => cache.entries(),
+      keys: () => cache.keys(),
+    };
+
+    const conn = createMockConnection();
+    const documents = { get: () => undefined };
+
+    registerSymbolsHandlers(conn as any, services as any, documents as any);
+
+    const result = await conn.documentSymbolHandler({ textDocument: { uri } });
+
+    assert.ok(result, 'Symbols should resolve after waitFor without setTimeout hack');
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0]!.name, 'TestClass');
+    assert.strictEqual(result[1]!.name, 'main');
+  });
+
+  it('should return symbols immediately when cache is already populated', async () => {
+    const uri = 'file:///cached.pike';
+    const cache = createRealDocumentCache();
+
+    const pikeSymbols: PikeSymbol[] = [
+      sym('cached_fn', 'method', { position: { file: 'cached.pike', line: 1 } }),
+    ];
+
+    cache.set(uri, makeCacheEntry({ symbols: pikeSymbols, version: 1 }));
+
+    const services = createMockServices();
+    (services as any).documentCache = {
+      get: (u: string) => cache.get(u),
+      waitFor: async (u: string) => cache.waitFor(u),
+      entries: () => cache.entries(),
+      keys: () => cache.keys(),
+    };
+
+    const conn = createMockConnection();
+    const documents = { get: () => undefined };
+
+    registerSymbolsHandlers(conn as any, services as any, documents as any);
+
+    const result = await conn.documentSymbolHandler({ textDocument: { uri } });
+
+    assert.ok(result, 'Should return cached symbols immediately');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0]!.name, 'cached_fn');
+  });
+
+  it('should return null when validation completes with no symbols', async () => {
+    const uri = 'file:///empty.pike';
+    const cache = createRealDocumentCache();
+
+    const validationPromise = new Promise<void>(resolve => {
+      setTimeout(() => {
+        cache.set(uri, makeCacheEntry({ symbols: [], version: 1 }));
+        resolve();
+      }, 10);
+    });
+
+    cache.setPending(uri, validationPromise);
+
+    const services = createMockServices();
+    (services as any).documentCache = {
+      get: (u: string) => cache.get(u),
+      waitFor: async (u: string) => cache.waitFor(u),
+      entries: () => cache.entries(),
+      keys: () => cache.keys(),
+    };
+
+    const conn = createMockConnection();
+    const documents = { get: () => undefined };
+
+    registerSymbolsHandlers(conn as any, services as any, documents as any);
+
+    const result = await conn.documentSymbolHandler({ textDocument: { uri } });
+
+    assert.deepStrictEqual(result, []);
+  });
+
+  it('should return null when no pending validation and no cache', async () => {
+    const uri = 'file:///unknown.pike';
+    const cache = createRealDocumentCache();
+
+    const services = createMockServices();
+    (services as any).documentCache = {
+      get: (u: string) => cache.get(u),
+      waitFor: async (u: string) => cache.waitFor(u),
+      entries: () => cache.entries(),
+      keys: () => cache.keys(),
+    };
+
+    const conn = createMockConnection();
+    const documents = { get: () => undefined };
+
+    registerSymbolsHandlers(conn as any, services as any, documents as any);
+
+    const result = await conn.documentSymbolHandler({ textDocument: { uri } });
+
+    assert.strictEqual(result, null);
+  });
+
+  it('should handle slow validation completing after symbols request', async () => {
+    const uri = 'file:///slow.pike';
+    const cache = createRealDocumentCache();
+
+    const pikeSymbols: PikeSymbol[] = [
+      sym('SlowClass', 'class', { position: { file: 'slow.pike', line: 1 } }),
+    ];
+
+    const validationPromise = new Promise<void>(resolve => {
+      setTimeout(() => {
+        cache.set(uri, makeCacheEntry({ symbols: pikeSymbols, version: 1 }));
+        resolve();
+      }, 100);
+    });
+
+    cache.setPending(uri, validationPromise);
+
+    const services = createMockServices();
+    (services as any).documentCache = {
+      get: (u: string) => cache.get(u),
+      waitFor: async (u: string) => cache.waitFor(u),
+      entries: () => cache.entries(),
+      keys: () => cache.keys(),
+    };
+
+    const conn = createMockConnection();
+    const documents = { get: () => undefined };
+
+    registerSymbolsHandlers(conn as any, services as any, documents as any);
+
+    const startTime = Date.now();
+    const result = await conn.documentSymbolHandler({ textDocument: { uri } });
+    const elapsed = Date.now() - startTime;
+
+    assert.ok(result, 'Should resolve symbols even with slow validation');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0]!.name, 'SlowClass');
+    assert.ok(
+      elapsed >= 90,
+      `Should have waited for slow validation (took ${elapsed}ms, expected >= 90ms)`
+    );
+  });
+
+  it('should handle validation promise rejection gracefully', async () => {
+    const uri = 'file:///error.pike';
+    const cache = createRealDocumentCache();
+
+    const validationPromise = new Promise<void>((resolve, _reject) => {
+      setTimeout(() => resolve(), 10);
+    });
+    cache.setPending(uri, validationPromise);
+
+    const services = createMockServices();
+    (services as any).documentCache = {
+      get: (u: string) => cache.get(u),
+      waitFor: async (u: string) => cache.waitFor(u),
+      entries: () => cache.entries(),
+      keys: () => cache.keys(),
+    };
+
+    const conn = createMockConnection();
+    const documents = { get: () => undefined };
+
+    registerSymbolsHandlers(conn as any, services as any, documents as any);
+
+    const result = await conn.documentSymbolHandler({ textDocument: { uri } });
+
+    assert.strictEqual(result, null, 'Should return null when validation fails');
+  });
+});
+
+describe('Scenario: DocumentCache setPending/waitFor contract', () => {
+  it('waitFor should resolve after setPending promise resolves and cache is set', async () => {
+    const cache = createRealDocumentCache();
+    const uri = 'file:///contract.pike';
+
+    let resolved = false;
+    const promise = new Promise<void>(resolve => {
+      setTimeout(() => {
+        cache.set(uri, makeCacheEntry({ symbols: [], version: 1 }));
+        resolved = true;
+        resolve();
+      }, 20);
+    });
+
+    cache.setPending(uri, promise);
+
+    assert.strictEqual(resolved, false, 'Should not be resolved yet');
+    assert.strictEqual(cache.get(uri), undefined, 'Cache should not be set yet');
+
+    await cache.waitFor(uri);
+
+    assert.strictEqual(resolved, true, 'Should be resolved after waitFor');
+    assert.ok(cache.get(uri), 'Cache should be populated after waitFor');
+  });
+
+  it('waitFor should return immediately when no pending promise exists', async () => {
+    const cache = createRealDocumentCache();
+    const uri = 'file:///no-pending.pike';
+
+    const start = Date.now();
+    await cache.waitFor(uri);
+    const elapsed = Date.now() - start;
+
+    assert.ok(elapsed < 10, `waitFor should be near-instant when no pending (took ${elapsed}ms)`);
+  });
+
+  it('setPending should auto-cleanup after promise resolves', async () => {
+    const cache = createRealDocumentCache();
+    const uri = 'file:///cleanup.pike';
+
+    const promise = Promise.resolve();
+    cache.setPending(uri, promise);
+
+    await new Promise(r => setTimeout(r, 10));
+
+    await cache.waitFor(uri);
+  });
+});


### PR DESCRIPTION
## Summary

Removes the fragile 50ms `setTimeout` hack from `symbols.ts` that was papering over the document symbols race condition.

## Root Cause

The 50ms setTimeout in `symbols.ts` was a workaround that masked the real race condition:
- `onDidOpen` called `engineOpenDocument` fire-and-forget
- `validateDocument` ran immediately
- Document symbols provider timed out waiting for pending promise
- The setTimeout hack gave extra time for the cache to populate

## Changes

1. **Remove setTimeout hack** from `symbols.ts` - the 50ms delay is fragile and doesn't address root cause
2. **Add scenario tests** for DocumentCache setPending/waitFor contract
3. **Tests verify** symbols resolve correctly without setTimeout hack

## Verification

```
bun test packages/pike-lsp-server/src/scenarios/document-open-race.test.ts
# 9 pass, 0 fail

bun run test:packages  
# 3343 pass, 22 skip, 0 fail
```

## Related

- Issue #1058: False import errors on file open
- PR #1060: await engineOpenDocument before validation
- Issue #1075: Document symbols race (to be filed)

## Checklist

- [x] I ran `bun run test:packages` and all tests pass.
- [x] Tests for this specific fix are included (scenario tests).