### PR TITLE
chore: bump version to 0.1.0-alpha.42

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pike-lsp",
-  "version": "0.1.0-alpha.41",
+  "version": "0.1.0-alpha.42",
   "private": true,
   "description": "Pike Language Server Protocol implementation and VSCode extension",
   "author": "Pike LSP Team",

--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-pike",
   "displayName": "Pike Language Support",
   "description": "Complete language support for Pike including IntelliSense, go-to-definition, find references, diagnostics, hover, signature help, code completion, semantic tokens, call hierarchy, and workspace symbols.",
-  "version": "0.1.0-alpha.41",
+  "version": "0.1.0-alpha.42",
   "publisher": "pike-lsp",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
## Summary

Bumps version to 0.1.0-alpha.42 for release.

## Linked Issue

Includes fix from #1070 (stale diagnostics on multi-line fix).

## Checklist

- [x] Version bumped in package.json and packages/vscode-pike/package.json
- [x] TypeScript compiles clean