### PR TITLE
perf(#1078): remove duplicate CI steps, parallelize Pike build, deduplicate lockfile checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,12 +94,6 @@ jobs:
           pike --version
           which pike
 
-      - name: Check Pike strict_types pragmas
-        run: bash scripts/check-pike-strict-types.sh
-
-      - name: Build all packages
-        run: bun run build
-
       - name: Run package test suite
         run: bun run test:packages
 
@@ -218,7 +212,7 @@ jobs:
           tar -xzf "$PIKE_ARCHIVE" -C "$BUILD_DIR" --strip-components=1
           cd "$BUILD_DIR/src"
           ./configure --prefix="$PIKE_PREFIX"
-          make -j1
+          make -j$(nproc)
           make install
           echo "$PIKE_PREFIX/bin" >> "$GITHUB_PATH"
 
@@ -250,9 +244,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Check forbidden lockfiles
-        run: bash scripts/check-lockfiles.sh
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -296,24 +287,21 @@ jobs:
       matrix:
         include:
           - category: core-lsp
-            grep: "LSP Feature E2E Tests|Core Regression E2E Tests"
+            grep: 'LSP Feature E2E Tests|Core Regression E2E Tests'
             optional: false
           - category: completion-navigation
-            grep: "Smart Completion E2E Tests|Include/Import/Inherit Navigation E2E Tests|Stdlib E2E Tests"
+            grep: 'Smart Completion E2E Tests|Include/Import/Inherit Navigation E2E Tests|Stdlib E2E Tests'
             optional: false
           - category: reliability-workflows
-            grep: "Error Handling Tests|Responsiveness E2E Tests|E2E Workflow Tests|Waterfall Loading E2E Tests"
+            grep: 'Error Handling Tests|Responsiveness E2E Tests|E2E Workflow Tests|Waterfall Loading E2E Tests'
             optional: true
           - category: performance
-            grep: "Performance Benchmark Tests"
+            grep: 'Performance Benchmark Tests'
             optional: false
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Check forbidden lockfiles
-        run: bash scripts/check-lockfiles.sh
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

Phase 1 of CI pipeline optimization (#1078) — three zero-risk fixes that reduce CI wall-clock time.

### Bug 1 fix — Remove duplicate strict_types + build steps (reversed from issue)

**Note**: The issue's analysis was reversed. The pre-Pike steps at lines 78-85 are NOT no-ops:
- `check-pike-strict-types.sh` uses pure bash text parsing — does NOT invoke the Pike runtime
- `bun run build` = `bunx tsc --build` — pure TypeScript compilation, no Pike needed

Both work correctly before Pike install and serve as **fast early-gate checks** before the expensive `apt-get install pike8.0`. The real waste is the POST-Pike duplicates at lines 97-101, which repeat the exact same checks that already passed. Removed those.

### Bug 2 fix — Parallelize Pike from-source compilation

Changed `make -j1` to `make -j$(nproc)` for Pike compilation in `pike-test` job. On GitHub Actions `ubuntu-24.04` runners (2-4 cores), this should cut Pike build time from ~10-15min to ~3-5min.

### Structural fix — Lockfile check deduplication

Removed lockfile checks from downstream jobs (`build-extension`, `vscode-e2e-category`) that already have `needs: [test, pike-test]`. Both `test` and `pike-test` check lockfiles — downstream jobs inherit that guarantee. Reduced from 8 invocations to 2 per CI run.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/test.yml` | Remove post-Pike duplicate strict_types + build steps |
| `.github/workflows/test.yml` | `make -j1` to `make -j$(nproc)` for Pike compilation |
| `.github/workflows/test.yml` | Remove lockfile checks from `build-extension` and `vscode-e2e-category` |

## Expected Impact

- **~30-60s** saved per CI run from removed duplicate steps
- **~7-12min** saved on Pike compilation with parallel make (biggest win)
- **No change** in test coverage, correctness, or cross-version testing
- Lockfile check reduced from 8 to 2 invocations (architectural cleanup)

## Verification

- [x] YAML lint passes
- [x] All 6 jobs still present in workflow
- [x] `test` job: lint, build, install Pike, tests (correct ordering)
- [x] `make -j$(nproc)` used for Pike compilation
- [x] Lockfile checks only in `test` and `pike-test` (entry-point jobs)
- [x] Pre-commit hooks passed (lockfile check, strict_types, typecheck, Pike compile)

Part of #1078. Follow-up PRs: Phase 2 (artifact sharing), Phase 3 (bench opt-in).
