### PR TITLE
fix: clarify noisy rehydrate error log for expected ENOENT case

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics/lifecycle.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/lifecycle.ts
@@ -124,10 +124,19 @@ export function registerDiagnosticsLifecycleHandlers(
         workspaceIndex.removeDocument(uri);
       }
 
-      log.error('Workspace index rehydrate failed', {
-        uri,
-        error: err instanceof Error ? err.message : String(err),
-      });
+      const isEnoent =
+        err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+      const isClosed = !documents.get(uri);
+      log.error(
+        isEnoent && isClosed
+          ? 'Workspace index rehydrate skipped — file gone and document closed'
+          : 'Workspace index rehydrate failed',
+        {
+          ...(isEnoent && isClosed
+            ? { uri }
+            : { uri, error: err instanceof Error ? err.message : String(err) }),
+        }
+      );
     } finally {
       if (workspaceRehydrateEpochs.get(uri) === epoch) {
         workspaceRehydrateEpochs.delete(uri);


### PR DESCRIPTION
## Summary

Clarifies a noisy ERROR log in the diagnostics lifecycle rehydrate path — when ENOENT occurs and the document is already closed, this is an expected race, not a real failure.

fixes #1078

## Root Cause

When the workspace index rehydrates a document from disk, it can fail with ENOENT if the document was closed between the rehydrate request and the disk read. The catch block correctly handled this (removed the document from the index), but logged at ERROR level with a generic "rehydrate failed" message.

## Fix

Changed the error message to distinguish the expected case (file gone + document closed) from actual failures. Still uses `log.error()` for compatibility with test mocks that provide `log` as a bare function rather than a Logger instance.

## Verification

- [x] 26 diagnostic pipeline scenario tests pass
- [x] Pre-commit hook passes (fast regression + format + quality gate + scenarios)
- [x] Build passes
