### PR TITLE
fix(#1092): handle switch/case fallthrough initialization tracking

### DIFF
--- a/pike-scripts/LSP.pmod/Analysis.pmod/Diagnostics.pike
+++ b/pike-scripts/LSP.pmod/Analysis.pmod/Diagnostics.pike
@@ -664,8 +664,21 @@ protected array(mapping) analyze_function_body(array tokens, array(string) lines
                 "scope_level": scope_depth + 1,
                 "case_count": 0,
                 "in_case": 0,
-                "has_default": 0
+                "has_default": 0,
+                "last_case_had_break": 0  // Track if previous case ended with break
             ]) });
+        }
+
+        // Handle break statements - track for switch fallthrough
+        if (text == "break") {
+            // Find the most recent switch and mark that the current case ended with break
+            for (int k = sizeof(branch_stack) - 1; k >= 0; k--) {
+                mapping branch = branch_stack[k];
+                if (branch->type == "switch" && branch->in_case) {
+                    branch->last_case_had_break = 1;
+                    break;
+                }
+            }
         }
 
         // Handle case labels - each case starts a new branch
@@ -678,10 +691,22 @@ protected array(mapping) analyze_function_body(array tokens, array(string) lines
                     if (branch->in_case) {
                         branch->branch_states += ({ save_variable_states_fn(variables) });
                     }
+
                     branch->case_count = (branch->case_count || 0) + 1;
-                    // Restore switch's original state for this case
-                    restore_variable_states_fn(variables, branch->saved_states);
+
+                    // Determine starting state for this case:
+                    // If previous case had NO break (fallthrough), carry forward
+                    // the previous case's state. Otherwise, restore pre-switch state.
+                    if (!branch->last_case_had_break && branch->in_case) {
+                        // Fallthrough: keep current variable states
+                        // (don't restore - variables carry over from previous case)
+                    } else {
+                        // No fallthrough: restore to pre-switch state
+                        restore_variable_states_fn(variables, branch->saved_states);
+                    }
+
                     branch->in_case = 1;
+                    branch->last_case_had_break = 0;  // Reset for this new case
                     break;
                 }
             }
@@ -698,10 +723,18 @@ protected array(mapping) analyze_function_body(array tokens, array(string) lines
                         branch->branch_states += ({ save_variable_states_fn(variables) });
                     }
                     branch->case_count = (branch->case_count || 0) + 1;
-                    // Restore switch's original state for default
-                    restore_variable_states_fn(variables, branch->saved_states);
+
+                    // Apply same fallthrough logic for default
+                    if (!branch->last_case_had_break && branch->in_case) {
+                        // Fallthrough: keep current variable states
+                    } else {
+                        // No fallthrough: restore to pre-switch state
+                        restore_variable_states_fn(variables, branch->saved_states);
+                    }
+
                     branch->in_case = 1;
                     branch->has_default = 1;
+                    branch->last_case_had_break = 0;
                     break;
                 }
             }

--- a/test/tests/analysis-tests.pike
+++ b/test/tests/analysis-tests.pike
@@ -104,6 +104,11 @@ int main(int argc, array(string) argv) {
     run_test(test_completion_global_scope, "completion: global scope context");
     run_test(test_completion_position_accuracy, "completion: correct token at cursor position");
 
+    // switch/case fallthrough tests
+    run_test(test_switch_all_cases_init_no_warn, "switch: all cases init with default, no warning");
+    run_test(test_switch_fallthrough_init_no_warn, "switch: fallthrough carries init state");
+    run_test(test_switch_no_default_maybe_init, "switch: no default, not all paths init → warns");
+
     write("\n");
     write("===================\n");
     write("Tests: %d, Passed: %d, Failed: %d\n", test_count, pass_count, fail_count);
@@ -599,5 +604,120 @@ void test_completion_position_accuracy() {
         }
     } else if (ctx->context != "identifier") {
         // Accept other contexts at edge positions
+    }
+}
+
+// =============================================================================
+// switch/case fallthrough Tests
+// =============================================================================
+
+//! Test switch: all cases initialize variable with default, no warning after switch
+void test_switch_all_cases_init_no_warn() {
+    object Analysis = get_analysis();
+    object analysis = Analysis();
+
+    string code = "void test(int x) {\n"
+        "    string s;\n"
+        "    switch (x) {\n"
+        "        case 1:\n"
+        "            s = \"one\";\n"
+        "            break;\n"
+        "        case 2:\n"
+        "            s = \"two\";\n"
+        "            break;\n"
+        "        default:\n"
+        "            s = \"other\";\n"
+        "            break;\n"
+        "    }\n"
+        "    write(\"%s\\n\", s);\n"
+        "}";
+
+    mapping result = analysis->handle_analyze_uninitialized(([
+        "code": code,
+        "filename": "test.pike"
+    ]));
+
+    array diagnostics = result->result->diagnostics || ({});
+
+    // Variable s is initialized in ALL cases (including default) → no warning
+    foreach (diagnostics, mapping diag) {
+        if (diag->variable == "s") {
+            error("Variable s initialized in all switch cases should not warn, got: %s\n", diag->message);
+        }
+    }
+}
+
+//! Test switch: fallthrough carries initialization state from one case to the next
+//!
+//! When case 1 initializes s and has no break, execution falls through to case 2.
+//! Inside case 2, s should be recognized as initialized (not generate a warning).
+void test_switch_fallthrough_init_no_warn() {
+    object Analysis = get_analysis();
+    object analysis = Analysis();
+
+    string code = "void test(int x) {\n"
+        "    string s;\n"
+        "    switch (x) {\n"
+        "        case 1:\n"
+        "            s = \"one\";\n"
+        "        case 2:\n"
+        "            write(\"%s\\n\", s);\n"
+        "            break;\n"
+        "    }\n"
+        "}";
+
+    mapping result = analysis->handle_analyze_uninitialized(([
+        "code": code,
+        "filename": "test.pike"
+    ]));
+
+    array diagnostics = result->result->diagnostics || ({});
+
+    // s is initialized in case 1 and falls through to case 2.
+    // Inside case 2 (after fallthrough), s should be INITIALIZED → no warning.
+    foreach (diagnostics, mapping diag) {
+        if (diag->variable == "s") {
+            error("Variable s should be recognized as initialized in case 2 after "
+                "fallthrough from case 1, got: %s\n", diag->message);
+        }
+    }
+}
+
+//! Test switch: no default, not all cases initialize → warns after switch
+//!
+//! Without a default case, there's an implicit non-matching path where the
+//! variable remains uninitialized. The analyzer should produce a warning.
+void test_switch_no_default_maybe_init() {
+    object Analysis = get_analysis();
+    object analysis = Analysis();
+
+    string code = "void test(int x) {\n"
+        "    string s;\n"
+        "    switch (x) {\n"
+        "        case 1:\n"
+        "            s = \"one\";\n"
+        "            break;\n"
+        "    }\n"
+        "    write(\"%s\\n\", s);\n"
+        "}";
+
+    mapping result = analysis->handle_analyze_uninitialized(([
+        "code": code,
+        "filename": "test.pike"
+    ]));
+
+    array diagnostics = result->result->diagnostics || ({});
+
+    // Without default, s may not be initialized (x could be anything)
+    bool found_warning = false;
+    foreach (diagnostics, mapping diag) {
+        if (diag->variable == "s") {
+            found_warning = true;
+            break;
+        }
+    }
+
+    if (!found_warning) {
+        error("Expected warning for variable s - not all switch paths initialize it\n");
     }
 }


### PR DESCRIPTION
## Summary

Fixes the uninitialized variable analyzer to correctly handle switch/case fallthrough, where variables initialized in one case that falls through to the next are recognized as initialized.

closes #1092

## Root Cause

The switch/case handler in `Diagnostics.pike` treated each case branch independently — when starting a new case, it always restored the pre-switch variable state, losing any initialization from a preceding case that lacked a `break` statement. This caused false-positive "may be uninitialized" warnings for code that relies on fallthrough.

## Changes

- **`pike-scripts/LSP.pmod/Analysis.pmod/Diagnostics.pike`**: Added `last_case_had_break` flag to the switch branch tracking structure. The `break` handler sets this flag. The `case` and `default` handlers check the flag: if the previous case had NO break (fallthrough), the current variable states carry forward instead of being restored to pre-switch state. The switch closing `}` handler already handled default exhaustiveness and implicit non-matching paths correctly.

- **`test/tests/analysis-tests.pike`**: Added 3 tests:
  - `test_switch_all_cases_init_no_warn` — all cases + default initialize variable, no warning after switch
  - `test_switch_fallthrough_init_no_warn` — case 1 initializes and falls through to case 2 where variable is used, no warning
  - `test_switch_no_default_maybe_init` — no default case, not all paths initialize → warns

## Verification

```bash
pike test/tests/analysis-tests.pike
# Tests: 20, Passed: 20, Failed: 0
```

Pre-commit hooks all pass (pike-compile, bridge, server, quality gate, scenarios).

## Checklist

- [x] Tests added for the fix
- [x] All tests pass locally
- [x] Pre-commit hooks pass
- [x] Follows existing code patterns