### PR TITLE
fix(#1093): recognize ::create() calls as initializers for uninitialized variables

### DIFF
--- a/pike-scripts/LSP.pmod/Analysis.pmod/Diagnostics.pike
+++ b/pike-scripts/LSP.pmod/Analysis.pmod/Diagnostics.pike
@@ -680,6 +680,27 @@ protected array(mapping) analyze_function_body(array tokens, array(string) lines
             }
         }
 
+        // Handle ::create() calls - parent constructor may initialize variables
+        // Token pattern: "::" "create" "("
+        if (text == "::") {
+            int next = find_next_meaningful_token_fn(tokens, i + 1, end_idx);
+            if (next >= 0 && tokens[next]->text == "create") {
+                int after_create = find_next_meaningful_token_fn(tokens, next + 1, end_idx);
+                if (after_create >= 0 && tokens[after_create]->text == "(") {
+                    // ::create() detected — parent constructor may have initialized
+                    // class-level variables. Since the token-level analyzer cannot
+                    // trace inheritance chains, conservatively mark all currently
+                    // uninitialized tracked variables as initialized.
+                    foreach (indices(variables), string var_name) {
+                        mapping var_info = variables[var_name];
+                        if (var_info->state == STATE_UNINITIALIZED) {
+                            var_info->state = STATE_INITIALIZED;
+                        }
+                    }
+                }
+            }
+        }
+
         // Handle switch statements - save state for each case branch
         // Switch is similar to if/else but with multiple case branches
         if (text == "switch") {

--- a/test/tests/analysis-tests.pike
+++ b/test/tests/analysis-tests.pike
@@ -121,6 +121,11 @@ int main(int argc, array(string) argv) {
     run_test(test_preprocessor_if_only_init_no_warn, "preprocessor: #if-only init - no warning");
     run_test(test_preprocessor_nested_no_warn, "preprocessor: nested #if blocks - no warning");
 
+    // ::create() inheritance tests (Issue #1093)
+    run_test(test_inheritance_create_suppresses_warning, "inheritance: ::create() suppresses uninit warning");
+    run_test(test_inheritance_create_already_init_stays, "inheritance: already-initialized vars unaffected");
+    run_test(test_inheritance_create_with_args, "inheritance: ::create(args) also suppresses warning");
+
     write("\n");
     write("===================\n");
     write("Tests: %d, Passed: %d, Failed: %d\n", test_count, pass_count, fail_count);
@@ -996,6 +1001,99 @@ void test_preprocessor_nested_no_warn() {
     foreach (diagnostics, mapping diag) {
         if (diag->variable == "s") {
             error("Variable s initialized in all nested preprocessor branches should not warn, got: %s\n",
+                diag->message);
+        }
+    }
+}
+
+// =============================================================================
+// ::create() inheritance Tests (Issue #1093)
+// =============================================================================
+
+//! Test that ::create() suppresses uninitialized warnings for variables used after
+//!
+//! When a function calls ::create() (parent constructor), the parent may initialize
+//! class-level variables. The token-level analyzer cannot trace inheritance, so it
+//! conservatively marks all currently-uninitialized variables as initialized.
+void test_inheritance_create_suppresses_warning() {
+    object Analysis = get_analysis();
+    object analysis = Analysis();
+
+    string code = "void create() {\n"
+        "    string name;\n"
+        "    ::create();\n"
+        "    write(\"%s\\n\", name);\n"
+        "}";
+
+    mapping result = analysis->handle_analyze_uninitialized(([
+        "code": code,
+        "filename": "test.pike"
+    ]));
+
+    array diagnostics = result->result->diagnostics || ({});
+
+    // After ::create(), name should be considered initialized — no warning
+    foreach (diagnostics, mapping diag) {
+        if (diag->variable == "name") {
+            error("Variable name used after ::create() should not warn, got: %s\n",
+                diag->message);
+        }
+    }
+}
+
+//! Test that already-initialized variables are unaffected by ::create()
+//!
+//! Variables initialized before the ::create() call should remain INITIALIZED.
+void test_inheritance_create_already_init_stays() {
+    object Analysis = get_analysis();
+    object analysis = Analysis();
+
+    string code = "void create(string config) {\n"
+        "    string name = config;\n"
+        "    ::create();\n"
+        "    write(\"%s\\n\", name);\n"
+        "}";
+
+    mapping result = analysis->handle_analyze_uninitialized(([
+        "code": code,
+        "filename": "test.pike"
+    ]));
+
+    array diagnostics = result->result->diagnostics || ({});
+
+    // name was initialized before ::create() — should still have no warning
+    foreach (diagnostics, mapping diag) {
+        if (diag->variable == "name") {
+            error("Already-initialized variable should not warn, got: %s\n",
+                diag->message);
+        }
+    }
+}
+
+//! Test that ::create() with arguments also suppresses warnings
+//!
+//! The pattern ::create(args) should also be recognized.
+void test_inheritance_create_with_args() {
+    object Analysis = get_analysis();
+    object analysis = Analysis();
+
+    string code = "void create(int x) {\n"
+        "    string label;\n"
+        "    ::create(x);\n"
+        "    write(\"%s\\n\", label);\n"
+        "}";
+
+    mapping result = analysis->handle_analyze_uninitialized(([
+        "code": code,
+        "filename": "test.pike"
+    ]));
+
+    array diagnostics = result->result->diagnostics || ({});
+
+    // After ::create(x), label should be considered initialized — no warning
+    foreach (diagnostics, mapping diag) {
+        if (diag->variable == "label") {
+            error("Variable label used after ::create(x) should not warn, got: %s\n",
                 diag->message);
         }
     }


### PR DESCRIPTION
## Summary

Detects `::create()` calls in function bodies and conservatively marks all currently-uninitialized tracked variables as initialized, eliminating false-positive warnings for code that relies on parent constructor initialization.

closes #1093

## Root Cause

The token-level analyzer cannot trace through inheritance chains to determine which variables a parent constructor initializes. When a class method calls `::create()`, the parent may initialize class-level variables, but the analyzer still treats them as uninitialized, producing false-positive warnings.

## Changes

- **`pike-scripts/LSP.pmod/Analysis.pmod/Diagnostics.pike`**: Added `::` token handler that detects the `::create(` pattern. When found, iterates all tracked variables and marks those currently in `STATE_UNINITIALIZED` as `STATE_INITIALIZED`. This is a conservative approach — we can't know exactly which variables the parent initializes, so we suppress warnings for all currently-uninitialized variables after the `::create()` call.

- **`test/tests/analysis-tests.pike`**: Added 3 tests:
  - `test_inheritance_create_suppresses_warning` — uninitialized variable used after `::create()` produces no warning
  - `test_inheritance_create_already_init_stays` — already-initialized variables remain initialized
  - `test_inheritance_create_with_args` — `::create(args)` (with arguments) also suppresses warnings

## Verification

```bash
pike test/tests/analysis-tests.pike
# Tests: 25, Passed: 25, Failed: 0
```

Pre-commit hooks all pass (pike-compile, bridge, server, quality gate, scenarios).

## Checklist

- [x] Tests added for the fix
- [x] All tests pass locally
- [x] Pre-commit hooks pass
- [x] Follows existing code patterns