### PR TITLE
fix: add SSL/connection.pike to KNOWN_CRASHES, correct Password.pmod path

### DIFF
--- a/packages/pike-bridge/src/corpus.test.ts
+++ b/packages/pike-bridge/src/corpus.test.ts
@@ -301,7 +301,10 @@ describeSuite('Pike Stdlib Corpus Validation', { timeout: 1800_000 }, () => {
 
     // Known files that crash the Pike subprocess during introspection
     // (heavy C module dependencies that fail to load in test context)
-    const KNOWN_CRASHES = new Set(['modules/Tools.pmod/Standalone.pmod/rsqld.pike']);
+    const KNOWN_CRASHES = new Set([
+      'modules/Tools.pmod/Standalone.pmod/rsqld.pike',
+      '7.8/modules/SSL.pmod/connection.pike',
+    ]);
 
     // Count crashes (bridge timeout/error, not parse failures)
     // Exclude known crashes — these are Pike runtime issues, not analyzer bugs
@@ -481,7 +484,7 @@ describeSuite('Pike Stdlib Corpus Validation', { timeout: 1800_000 }, () => {
       'modules/Crypto.pmod/ECC.pmod',
       'modules/Crypto.pmod/Koremutake.pmod',
       'modules/Crypto.pmod/PGP.pmod',
-      'modules/Crypto.pmod/Password.pike',
+      'modules/Crypto.pmod/Password.pmod',
       'modules/Crypto.pmod/Pipe.pike',
       'modules/Crypto.pmod/RSA.pmod',
       // Filesystem monitoring


### PR DESCRIPTION
## Summary
Two corpus test regressions introduced by PR #1104: an environment-specific SSL crash was not excluded from crash detection, and the Password file extension was incorrectly changed from `.pmod` to `.pike`.

## Linked Issue
Related to #1101, #1102

## Root Cause
PR #1104 added `KNOWN_CRASHES` for rsqld.pike but missed `7.8/modules/SSL.pmod/connection.pike` which also crashes with a 30s timeout due to SSL C module dependencies. Additionally, the file path `modules/Crypto.pmod/Password.pmod` was incorrectly changed to `Password.pike` — the actual file on disk is `.pmod`.

## Changes
- `packages/pike-bridge/src/corpus.test.ts`: Added `7.8/modules/SSL.pmod/connection.pike` to `KNOWN_CRASHES` (SSL C module loading crashes the Pike subprocess during introspection)
- `packages/pike-bridge/src/corpus.test.ts`: Corrected `Password.pike` → `Password.pmod` in `EXPECTED_DIAGNOSTICS` (actual file extension)

## Verification
```bash
PIKE_CORPUS_TEST=1 bun test packages/pike-bridge/src/corpus.test.ts
# Result: 6 pass, 0 fail (34.79s)

bun test packages/pike-lsp-server/src/scenarios/
# Result: 27 pass, 0 fail

bun run typecheck && bun run build
# Result: clean
```

## Checklist
- [x] Scenarios pass (`bun test packages/pike-lsp-server/src/scenarios/`)
- [x] Corpus test passes (6/6)
- [x] Build and typecheck clean
- [x] Pre-commit hooks passed (format, fast regression, quality gate, scenarios)