### PR TITLE
ci: Add fail-fast dependencies on testing-pyramid job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -298,7 +298,7 @@ jobs:
 
   build-extension:
     runs-on: ubuntu-24.04
-    needs: [test]
+    needs: [test, testing-pyramid]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
 
     steps:
@@ -351,7 +351,7 @@ jobs:
   vscode-e2e-category:
     name: vscode-e2e (${{ matrix.category }})
     runs-on: ubuntu-24.04
-    needs: [test]
+    needs: [test, testing-pyramid]
     timeout-minutes: 25
     continue-on-error: ${{ matrix.optional }}
     strategy:
@@ -479,7 +479,7 @@ jobs:
 
   vscode-e2e-source-trees:
     runs-on: ubuntu-24.04
-    needs: [test]
+    needs: [test, testing-pyramid]
     if: ${{ vars.PIKE_SRC != '' && vars.ROXEN_SRC != '' }}
     timeout-minutes: 35
 


### PR DESCRIPTION
## Summary
Make downstream jobs depend on testing-pyramid so CI fails fast when pyramid tests fail.

## Changes
- build-extension now needs: [test, testing-pyramid]
- vscode-e2e-category now needs: [test, testing-pyramid]  
- vscode-e2e-source-trees now needs: [test, testing-pyramid]

## Why
Previously, if testing-pyramid failed, other expensive jobs (E2E tests) would still run, wasting CI time and resources.

## Verification
- YAML syntax validated
- No breaking changes to job logic