### PR TITLE
tech-debt(#1120): Remove protocol leakage from core model

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,71 +3,85 @@ import eslint from '@eslint/js';
 import globals from 'globals';
 
 export default [
-    eslint.configs.recommended,
-    ...tseslint.configs.recommended,
-    {
-        ignores: [
-            '**/dist/**',
-            '**/build/**',
-            '**/out/**',
-            '**/*.tsbuildinfo',
-            '**/coverage/**',
-            '**/.nyc_output/**',
-            '**/.vscode-test/**',
-            '**/*.vsix',
-            '**/*.mjs',
-            '**/scripts/**',
-            '**/.planning/**',
-            '**/*.test.ts',
-            'packages/vscode-pike/**/*.ts',
-            'packages/vscode-pike/server/**/*.js',
-            'docs/**',
-        ],
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    ignores: [
+      '**/dist/**',
+      '**/build/**',
+      '**/out/**',
+      '**/*.tsbuildinfo',
+      '**/coverage/**',
+      '**/.nyc_output/**',
+      '**/.vscode-test/**',
+      '**/*.vsix',
+      '**/*.mjs',
+      '**/scripts/**',
+      '**/.planning/**',
+      '**/*.test.ts',
+      'packages/vscode-pike/**/*.ts',
+      'packages/vscode-pike/server/**/*.js',
+      'docs/**',
+    ],
+  },
+  // TypeDoc generated files need browser globals
+  {
+    files: ['docs/api/typescript/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+      },
     },
-    // TypeDoc generated files need browser globals
-    {
-        files: ['docs/api/typescript/**/*.js'],
-        languageOptions: {
-            globals: {
-                ...globals.browser,
-            },
-        },
-        rules: {
-            '@typescript-eslint/no-unused-vars': 'off',
-            '@typescript-eslint/no-explicit-any': 'off',
-            'no-undef': 'warn',
-            '@typescript-eslint/no-unused-expressions': 'off',
-            '@typescript-eslint/no-this-alias': 'off',
-            'no-redeclare': 'off',
-            'no-prototype-builtins': 'off',
-        },
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      'no-undef': 'warn',
+      '@typescript-eslint/no-unused-expressions': 'off',
+      '@typescript-eslint/no-this-alias': 'off',
+      'no-redeclare': 'off',
+      'no-prototype-builtins': 'off',
     },
-    {
-        languageOptions: {
-            globals: {
-                ...globals.node,
-                ...globals.es2021,
-            },
-        },
-        rules: {
-            '@typescript-eslint/no-unused-vars': ['warn', {
-                argsIgnorePattern: '^_',
-                varsIgnorePattern: '^_'
-            }],
-            '@typescript-eslint/consistent-type-imports': 'off',
-            '@typescript-eslint/no-explicit-any': 'off',
-            '@typescript-eslint/explicit-function-return-type': 'off',
-            '@typescript-eslint/ban-ts-comment': 'error',
-            '@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
-            '@typescript-eslint/no-require-imports': 'off',
-            '@typescript-eslint/ban-types': 'off',
-            'no-console': 'off',
-            'no-unused-labels': 'off',
-            'no-useless-escape': 'off',
-            // ESLint 10 new rules - disable errors
-            'no-useless-assignment': 'off',
-            'preserve-caught-error': 'off',
-            'no-unassigned-vars': 'off',
-        },
+  },
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.es2021,
+      },
     },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+      '@typescript-eslint/consistent-type-imports': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/ban-ts-comment': 'error',
+      '@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
+      '@typescript-eslint/no-require-imports': 'off',
+      '@typescript-eslint/ban-types': 'off',
+      'no-console': 'off',
+      'no-unused-labels': 'off',
+      'no-useless-escape': 'off',
+      // ESLint 10 new rules - disable errors
+      'no-useless-assignment': 'off',
+      'preserve-caught-error': 'off',
+      'no-unassigned-vars': 'off',
+    },
+  },
+  {
+    files: ['packages/pike-lsp-server/src/core/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: ['vscode-languageserver', 'vscode-languageserver/*'],
+        },
+      ],
+    },
+  },
 ];

--- a/packages/pike-lsp-server/src/core/index.ts
+++ b/packages/pike-lsp-server/src/core/index.ts
@@ -11,5 +11,15 @@ export type { ErrorLayer } from '@pike-lsp/core';
 export { Logger, LogLevel } from '@pike-lsp/core';
 
 // Server-specific types remain local
-export type { PikeSettings, DocumentCacheEntry } from './types.js';
+export type {
+  PikeSettings,
+  DocumentCacheEntry,
+  CorePosition,
+  CoreRange,
+  CoreDiagnostic,
+  CoreSymbol,
+  CoreTextDocumentIdentifier,
+  CoreVersionedTextDocumentIdentifier,
+  CoreTextDocumentItem,
+} from './types.js';
 export { defaultSettings } from './types.js';

--- a/packages/pike-lsp-server/src/core/types.ts
+++ b/packages/pike-lsp-server/src/core/types.ts
@@ -6,8 +6,67 @@
  */
 
 import type { PikeSymbol } from '@pike-lsp/pike-bridge';
-import type { Diagnostic, Position } from 'vscode-languageserver/node.js';
 import { DEFAULT_MAX_PROBLEMS, DIAGNOSTIC_DELAY_DEFAULT } from '../constants/index.js';
+
+export interface CorePosition {
+  line: number;
+  character: number;
+}
+
+export interface CoreRange {
+  start: CorePosition;
+  end: CorePosition;
+}
+
+export const CORE_DIAGNOSTIC_SEVERITY = {
+  ERROR: 1,
+  WARNING: 2,
+  INFORMATION: 3,
+  HINT: 4,
+} as const;
+
+export type CoreDiagnosticSeverity =
+  (typeof CORE_DIAGNOSTIC_SEVERITY)[keyof typeof CORE_DIAGNOSTIC_SEVERITY];
+
+export const CORE_DIAGNOSTIC_TAG = {
+  UNNECESSARY: 1,
+  DEPRECATED: 2,
+} as const;
+
+export type CoreDiagnosticTag = (typeof CORE_DIAGNOSTIC_TAG)[keyof typeof CORE_DIAGNOSTIC_TAG];
+
+export interface CoreDiagnosticRelatedInformation {
+  location: {
+    uri: string;
+    range: CoreRange;
+  };
+  message: string;
+}
+
+export interface CoreDiagnostic {
+  range: CoreRange;
+  message: string;
+  severity?: CoreDiagnosticSeverity;
+  code?: string | number;
+  source?: string;
+  tags?: CoreDiagnosticTag[];
+  relatedInformation?: CoreDiagnosticRelatedInformation[];
+}
+
+export interface CoreTextDocumentIdentifier {
+  uri: string;
+}
+
+export interface CoreVersionedTextDocumentIdentifier extends CoreTextDocumentIdentifier {
+  version: number;
+}
+
+export interface CoreTextDocumentItem extends CoreVersionedTextDocumentIdentifier {
+  languageId: string;
+  text: string;
+}
+
+export type CoreSymbol = PikeSymbol;
 
 /**
  * LSP server configuration settings.
@@ -110,13 +169,13 @@ export interface DocumentCacheEntry {
   /** Document version */
   version: number;
   /** Symbols extracted from the document */
-  symbols: PikeSymbol[];
+  symbols: CoreSymbol[];
   /** Diagnostics from parsing/validation */
-  diagnostics: Diagnostic[];
+  diagnostics: CoreDiagnostic[];
   /** Symbol position index for O(1) lookups: symbol_name -> positions[] */
-  symbolPositions: Map<string, Position[]>;
+  symbolPositions: Map<string, CorePosition[]>;
   /** Symbol name index for O(1) lookups: symbol_name -> PikeSymbol */
-  symbolNames: Map<string, PikeSymbol>;
+  symbolNames: Map<string, CoreSymbol>;
   /** Include and import dependencies (optional, populated lazily) */
   dependencies?: DocumentDependencies;
   /** Inheritance information from introspection */

--- a/packages/pike-lsp-server/src/features/diagnostics/index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/index.ts
@@ -10,10 +10,15 @@
  * - change-detection.ts: Incremental change detection
  */
 
-import type { Connection, TextDocuments, Diagnostic, Range } from 'vscode-languageserver/node.js';
+import type {
+  Connection,
+  TextDocuments,
+  Diagnostic as ProtocolDiagnostic,
+  Range,
+} from 'vscode-languageserver/node.js';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Services } from '../../services/index.js';
-import type { PikeSettings, DocumentCacheEntry } from '../../core/types.js';
+import type { PikeSettings, DocumentCacheEntry, CoreDiagnostic } from '../../core/types.js';
 import { TypeDatabase, CompiledProgramInfo } from '../../type-database.js';
 import { Logger } from '@pike-lsp/core';
 import { DIAGNOSTIC_DELAY_DEFAULT, DEFAULT_MAX_PROBLEMS } from '../../constants/index.js';
@@ -21,6 +26,7 @@ import { computeContentHash, computeLineHashes } from '../../services/document-c
 import { RequestScheduler, RequestSupersededError } from '../../services/request-scheduler.js';
 import { detectRoxenModule, provideRoxenDiagnostics } from '../roxen/index.js';
 import { toSchedulerMetricsLogPayload } from '../utils/scheduler-metrics.js';
+import { toProtocolDiagnostics } from '../../services/protocol-mappers.js';
 import { registerDiagnosticsLifecycleHandlers } from './lifecycle.js';
 
 interface PendingChangeState {
@@ -53,7 +59,7 @@ type WorkspaceDiagnosticReportItem =
   | {
       uri: string;
       kind: 'full';
-      items: Diagnostic[];
+      items: ProtocolDiagnostic[];
       resultId: string;
     };
 
@@ -96,7 +102,7 @@ export function applySkippedValidationCacheUpdate(
 export function buildStaleFallbackEntry(
   existingEntry: DocumentCacheEntry | undefined,
   version: number,
-  diagnostics: Diagnostic[],
+  diagnostics: CoreDiagnostic[],
   contentHash: string,
   lineHashes: number[]
 ): DocumentCacheEntry {
@@ -219,7 +225,7 @@ export function registerDiagnosticsHandlers(
 
       return {
         kind: 'full',
-        items: cached?.diagnostics ?? [],
+        items: toProtocolDiagnostics(cached?.diagnostics ?? []),
         resultId,
       };
     });
@@ -265,7 +271,7 @@ export function registerDiagnosticsHandlers(
           items.push({
             uri,
             kind: 'full',
-            items: cached?.diagnostics ?? [],
+            items: toProtocolDiagnostics(cached?.diagnostics ?? []),
             resultId,
           });
         }
@@ -359,7 +365,7 @@ export function registerDiagnosticsHandlers(
         connection.sendDiagnostics({
           uri,
           version: currentVersion,
-          diagnostics: diagnosticsToSend,
+          diagnostics: toProtocolDiagnostics(diagnosticsToSend),
         });
         return;
       }
@@ -669,11 +675,11 @@ export function registerDiagnosticsHandlers(
       const tokenizeData = analyzeResult.result?.tokenize?.tokens;
 
       // Convert Pike diagnostics to LSP diagnostics
-      const diagnostics: Diagnostic[] = [];
+      const diagnostics: CoreDiagnostic[] = [];
       const lines = text.split('\n');
       const seenDiagnostics = new Set<string>();
 
-      const pushDiagnostic = (diagnostic: Diagnostic): void => {
+      const pushDiagnostic = (diagnostic: CoreDiagnostic): void => {
         if (diagnostics.length >= services.globalSettings.maxNumberOfProblems) {
           return;
         }
@@ -1178,7 +1184,7 @@ export function registerDiagnosticsHandlers(
       }
 
       // Send diagnostics
-      connection.sendDiagnostics({ uri, version, diagnostics });
+      connection.sendDiagnostics({ uri, version, diagnostics: toProtocolDiagnostics(diagnostics) });
       log.debug('Sent diagnostics', { uri, count: diagnostics.length });
 
       validationCompletions += 1;
@@ -1210,7 +1216,7 @@ export function registerDiagnosticsHandlers(
       inFlightDiagnosticRequests.delete(uri);
       const liveDocument = documents.get(uri);
       if (liveDocument && liveDocument.version === version) {
-        const fallbackDiagnostic: Diagnostic = {
+        const fallbackDiagnostic: CoreDiagnostic = {
           severity: 1,
           range: {
             start: { line: 0, character: 0 },
@@ -1229,7 +1235,11 @@ export function registerDiagnosticsHandlers(
           lineHashes
         );
         documentCache.set(uri, staleEntry);
-        connection.sendDiagnostics({ uri, version, diagnostics: [fallbackDiagnostic] });
+        connection.sendDiagnostics({
+          uri,
+          version,
+          diagnostics: toProtocolDiagnostics([fallbackDiagnostic]),
+        });
       }
       connection.console.error(`[VALIDATE] ✗ Validation failed for ${uri}: ${err}`);
     }

--- a/packages/pike-lsp-server/src/features/diagnostics/symbol-index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/symbol-index.ts
@@ -5,7 +5,7 @@
  * Extracted from diagnostics.ts for maintainability (Issue #136).
  */
 
-import type { Position } from 'vscode-languageserver/node.js';
+import type { CorePosition } from '../../core/types.js';
 import type { PikeSymbol, PikeToken } from '@pike-lsp/pike-bridge';
 import { createLexicalExclusionMap } from '../../utils/lexical-exclusion-map.js';
 import { Logger } from '@pike-lsp/core';
@@ -111,8 +111,8 @@ export async function buildSymbolPositionIndex(
       text: string
     ) => Promise<{ occurrences: Array<{ text: string; line: number; character: number }> }>;
   }
-): Promise<Map<string, Position[]>> {
-  const index = new Map<string, Position[]>();
+): Promise<Map<string, CorePosition[]>> {
+  const index = new Map<string, CorePosition[]>();
   const exclusions = createLexicalExclusionMap(text);
 
   // Build set of symbol names we care about AND map to definition lines
@@ -169,7 +169,7 @@ export async function buildSymbolPositionIndex(
               : ' ';
 
           if (!/\w/.test(beforeChar) && !/\w/.test(afterChar)) {
-            const pos: Position = {
+            const pos: CorePosition = {
               line: lineIdx,
               character: token.character,
             };
@@ -206,7 +206,7 @@ export async function buildSymbolPositionIndex(
             continue;
           }
 
-          const pos: Position = {
+          const pos: CorePosition = {
             line: occ.line - 1, // Convert 1-indexed to 0-indexed
             character: occ.character,
           };
@@ -241,8 +241,8 @@ export async function buildSymbolPositionIndex(
 export function buildSymbolPositionIndexRegex(
   text: string,
   symbols: PikeSymbol[]
-): Map<string, Position[]> {
-  const index = new Map<string, Position[]>();
+): Map<string, CorePosition[]> {
+  const index = new Map<string, CorePosition[]>();
   const lines = text.split('\n');
   const exclusions = createLexicalExclusionMap(text);
 
@@ -253,7 +253,7 @@ export function buildSymbolPositionIndexRegex(
       continue;
     }
 
-    const positions: Position[] = [];
+    const positions: CorePosition[] = [];
 
     // Search for all occurrences of the symbol name
     for (let lineNum = 0; lineNum < lines.length; lineNum++) {

--- a/packages/pike-lsp-server/src/features/diagnostics/utils.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/utils.ts
@@ -5,10 +5,10 @@
  * Extracted from diagnostics.ts for maintainability (Issue #136).
  */
 
-import type { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver/node.js';
-import { DiagnosticTag } from 'vscode-languageserver/node.js';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { PikeSymbol, PikeDiagnostic } from '@pike-lsp/pike-bridge';
+import type { CoreDiagnostic, CoreDiagnosticSeverity, CoreRange } from '../../core/types.js';
+import { CORE_DIAGNOSTIC_SEVERITY, CORE_DIAGNOSTIC_TAG } from '../../core/types.js';
 import { PatternHelpers } from '../../utils/regex-patterns.js';
 
 /**
@@ -43,16 +43,16 @@ export function extractDeprecatedFromSymbols(symbols: PikeSymbol[]): PikeSymbol[
 /**
  * Convert Pike severity to LSP severity
  */
-export function convertSeverity(severity: string): DiagnosticSeverity {
+export function convertSeverity(severity: string): CoreDiagnosticSeverity {
   switch (severity) {
     case 'error':
-      return 1; // DiagnosticSeverity.Error
+      return CORE_DIAGNOSTIC_SEVERITY.ERROR;
     case 'warning':
-      return 2; // DiagnosticSeverity.Warning
+      return CORE_DIAGNOSTIC_SEVERITY.WARNING;
     case 'info':
-      return 3; // DiagnosticSeverity.Information
+      return CORE_DIAGNOSTIC_SEVERITY.INFORMATION;
     default:
-      return 1; // DiagnosticSeverity.Error
+      return CORE_DIAGNOSTIC_SEVERITY.ERROR;
   }
 }
 
@@ -61,7 +61,7 @@ export function convertSeverity(severity: string): DiagnosticSeverity {
  */
 export interface DiagnosticRelatedLocation {
   uri: string;
-  range: { start: { line: number; character: number }; end: { line: number; character: number } };
+  range: CoreRange;
   message: string;
 }
 
@@ -80,7 +80,7 @@ export function convertDiagnostic(
   document: TextDocument,
   options?: { deprecated?: boolean; code?: string; relatedLocation?: DiagnosticRelatedLocation },
   linesArg?: string[] // PERF-420: Optional pre-split lines for performance
-): Diagnostic {
+): CoreDiagnostic {
   const line = Math.max(0, (pikeDiag.position.line ?? 1) - 1);
   const lineNumber = pikeDiag.position.line ?? line + 1;
   const columnNumber = pikeDiag.position.column ?? 1;
@@ -131,7 +131,7 @@ export function convertDiagnostic(
   }
 
   // Build diagnostic
-  const diagnostic: Diagnostic = {
+  const diagnostic: CoreDiagnostic = {
     severity: convertSeverity(pikeDiag.severity),
     range: {
       start: { line, character: startChar },
@@ -181,7 +181,7 @@ export function convertDiagnostic(
 
   // Add tags for deprecated symbols
   if (options?.deprecated) {
-    diagnostic.tags = [DiagnosticTag.Deprecated];
+    diagnostic.tags = [CORE_DIAGNOSTIC_TAG.DEPRECATED];
   }
 
   // Add related information (see also links)

--- a/packages/pike-lsp-server/src/services/protocol-mappers.ts
+++ b/packages/pike-lsp-server/src/services/protocol-mappers.ts
@@ -1,0 +1,171 @@
+import type {
+  CoreDiagnostic,
+  CoreDiagnosticRelatedInformation,
+  CoreDiagnosticTag,
+  CorePosition,
+  CoreRange,
+  CoreSymbol,
+  CoreTextDocumentIdentifier,
+  CoreTextDocumentItem,
+  CoreVersionedTextDocumentIdentifier,
+} from '../core/types.js';
+import type {
+  Diagnostic,
+  DiagnosticRelatedInformation,
+  Position,
+  Range,
+  TextDocumentIdentifier,
+  TextDocumentItem,
+  VersionedTextDocumentIdentifier,
+} from 'vscode-languageserver/node.js';
+import type { PikeSymbol } from '@pike-lsp/pike-bridge';
+
+export function toCorePosition(position: Position): CorePosition {
+  return { line: position.line, character: position.character };
+}
+
+export function toProtocolPosition(position: CorePosition): Position {
+  return { line: position.line, character: position.character };
+}
+
+export function toCoreRange(range: Range): CoreRange {
+  return { start: toCorePosition(range.start), end: toCorePosition(range.end) };
+}
+
+export function toProtocolRange(range: CoreRange): Range {
+  return { start: toProtocolPosition(range.start), end: toProtocolPosition(range.end) };
+}
+
+function toCoreRelatedInformation(
+  info: DiagnosticRelatedInformation
+): CoreDiagnosticRelatedInformation {
+  return {
+    location: {
+      uri: info.location.uri,
+      range: toCoreRange(info.location.range),
+    },
+    message: info.message,
+  };
+}
+
+function toProtocolRelatedInformation(
+  info: CoreDiagnosticRelatedInformation
+): DiagnosticRelatedInformation {
+  return {
+    location: {
+      uri: info.location.uri,
+      range: toProtocolRange(info.location.range),
+    },
+    message: info.message,
+  };
+}
+
+export function toCoreDiagnostic(diagnostic: Diagnostic): CoreDiagnostic {
+  const coreDiagnostic: CoreDiagnostic = {
+    range: toCoreRange(diagnostic.range),
+    message: diagnostic.message,
+  };
+
+  if (diagnostic.severity !== undefined) {
+    coreDiagnostic.severity = diagnostic.severity;
+  }
+  if (typeof diagnostic.code === 'string' || typeof diagnostic.code === 'number') {
+    coreDiagnostic.code = diagnostic.code;
+  }
+  if (diagnostic.source !== undefined) {
+    coreDiagnostic.source = diagnostic.source;
+  }
+  if (diagnostic.tags) {
+    coreDiagnostic.tags = diagnostic.tags as CoreDiagnosticTag[];
+  }
+  if (diagnostic.relatedInformation) {
+    coreDiagnostic.relatedInformation = diagnostic.relatedInformation.map(toCoreRelatedInformation);
+  }
+
+  return coreDiagnostic;
+}
+
+export function toProtocolDiagnostic(diagnostic: CoreDiagnostic): Diagnostic {
+  const protocolDiagnostic: Diagnostic = {
+    range: toProtocolRange(diagnostic.range),
+    message: diagnostic.message,
+  };
+
+  if (diagnostic.severity !== undefined) {
+    protocolDiagnostic.severity = diagnostic.severity;
+  }
+  if (diagnostic.code !== undefined) {
+    protocolDiagnostic.code = diagnostic.code;
+  }
+  if (diagnostic.source !== undefined) {
+    protocolDiagnostic.source = diagnostic.source;
+  }
+  if (diagnostic.tags) {
+    protocolDiagnostic.tags = diagnostic.tags as Exclude<Diagnostic['tags'], undefined>;
+  }
+  if (diagnostic.relatedInformation) {
+    protocolDiagnostic.relatedInformation = diagnostic.relatedInformation.map(
+      toProtocolRelatedInformation
+    );
+  }
+
+  return protocolDiagnostic;
+}
+
+export function toCoreDiagnostics(diagnostics: readonly Diagnostic[]): CoreDiagnostic[] {
+  return diagnostics.map(toCoreDiagnostic);
+}
+
+export function toProtocolDiagnostics(diagnostics: readonly CoreDiagnostic[]): Diagnostic[] {
+  return diagnostics.map(toProtocolDiagnostic);
+}
+
+export function toCoreTextDocumentIdentifier(
+  identifier: TextDocumentIdentifier
+): CoreTextDocumentIdentifier {
+  return { uri: identifier.uri };
+}
+
+export function toProtocolTextDocumentIdentifier(
+  identifier: CoreTextDocumentIdentifier
+): TextDocumentIdentifier {
+  return { uri: identifier.uri };
+}
+
+export function toCoreVersionedTextDocumentIdentifier(
+  identifier: VersionedTextDocumentIdentifier
+): CoreVersionedTextDocumentIdentifier {
+  return { uri: identifier.uri, version: identifier.version };
+}
+
+export function toProtocolVersionedTextDocumentIdentifier(
+  identifier: CoreVersionedTextDocumentIdentifier
+): VersionedTextDocumentIdentifier {
+  return { uri: identifier.uri, version: identifier.version };
+}
+
+export function toCoreTextDocumentItem(item: TextDocumentItem): CoreTextDocumentItem {
+  return {
+    uri: item.uri,
+    languageId: item.languageId,
+    version: item.version,
+    text: item.text,
+  };
+}
+
+export function toProtocolTextDocumentItem(item: CoreTextDocumentItem): TextDocumentItem {
+  return {
+    uri: item.uri,
+    languageId: item.languageId,
+    version: item.version,
+    text: item.text,
+  };
+}
+
+export function toCoreSymbol(symbol: PikeSymbol): CoreSymbol {
+  return symbol;
+}
+
+export function toProtocolSymbol(symbol: CoreSymbol): PikeSymbol {
+  return symbol;
+}


### PR DESCRIPTION
## Summary
RFC invariant #5: protocol-agnostic DTOs. Core engine no longer depends on LSP transport types.

fixes #1120

## Root Cause
Core types.ts imported from vscode-languageserver, violating architecture boundary and RFC invariant #5.

## Changes
- Added protocol-agnostic internal DTOs in core/types.ts
- Updated DocumentCacheEntry to use internal DTOs exclusively  
- Created protocol-mappers.ts with boundary translation functions
- Updated diagnostics features to map only at transport boundary
- Added ESLint rule to block vscode-languageserver imports in core/**

## Verification
```bash
# Zero protocol imports in core
grep "vscode-languageserver" packages/pike-lsp-server/src/core/**/*.ts
# (no matches)

# All scenarios pass
bun test packages/pike-lsp-server/src/scenarios/
# 45 pass, 1 skip, 0 fail

# Build clean
bun run build
# ✅
```

## Checklist
- [x] Zero vscode-languageserver imports in src/core/**
- [x] Core defines pure internal DTOs
- [x] Adapter layer is exclusive translation boundary
- [x] All scenario tests pass
- [x] ESLint enforces boundary rule
- [x] Tracker row updated