### PR TITLE
feat: wire Pike install prompt into activation

### DIFF
--- a/packages/vscode-pike/src/extension.ts
+++ b/packages/vscode-pike/src/extension.ts
@@ -34,6 +34,8 @@ import {
 import { computeFormattingWindow, isIndentationSensitiveChange } from './format-on-change';
 import { PIKE_LANGUAGE_IDS } from './constants';
 import { detectPike, getModulePathSuggestions, PikeDetectionResult } from './pike-detector';
+import { initState } from './state.js';
+import { ensurePikeInstalled } from './pike-installer.js';
 import {
   LanguageClient,
   LanguageClientOptions,
@@ -571,8 +573,19 @@ async function activateInternal(
   context: ExtensionContext,
   testOutputChannel?: OutputChannel
 ): Promise<ExtensionApi> {
+  initState(context);
+
   const runtime = new ExtensionRuntime(context, testOutputChannel);
   activeRuntime = runtime;
+
+  const config = workspace.getConfiguration('pike');
+  const pikePath = config.get<string>('pikePath', 'pike');
+  if (pikePath === 'pike') {
+    const detection = await detectPike();
+    if (!detection) {
+      void ensurePikeInstalled();
+    }
+  }
 
   const runWithPike = async (uri: string, symbolName?: string): Promise<void> => {
     const parsed = Uri.parse(uri);


### PR DESCRIPTION
## Summary
Wire the existing missing-Pike install prompt into the activation flow to improve first-run onboarding.

## Linked Issue
Closes #1143

## Root Cause
The extension had the installer UI in pike-installer.ts but it was not triggered during activation. Users without Pike installed would see silent failures instead of actionable guidance.

## Changes
- packages/vscode-pike/src/extension.ts:
  - Initialize state management during activation (required for dismissal tracking)
  - Detect Pike installation after activation starts
  - Show install prompt only if user has not configured a custom pikePath
  - Use non-blocking prompt to avoid delaying activation

## Verification
- bun run typecheck passes
- Extension compiles without errors

## Checklist
- [x] Code change implemented
- [x] TypeScript compiles