### PR TITLE
feat: add Run All Tests in File command and code lens

### DIFF
--- a/packages/pike-lsp-server/src/features/advanced/code-lens.ts
+++ b/packages/pike-lsp-server/src/features/advanced/code-lens.ts
@@ -60,6 +60,22 @@ export function registerCodeLensHandlers(
       const testFunctions = isFileTestFile ? discoverTestFunctions(cache.symbols, testPattern) : [];
       const testFunctionNames = new Set(testFunctions.map(t => t.name));
 
+      if (runnableEnabled && isFileTestFile && testFunctions.length > 0) {
+        lenses.push({
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          data: {
+            uri,
+            symbolName: '',
+            kind: 'file',
+            position: { line: 0, character: 0 },
+            lensType: 'run-file-tests',
+          },
+        });
+      }
+
       for (const symbol of cache.symbols) {
         // Show reference counts for classes, methods, variables, and constants
         if (
@@ -146,7 +162,7 @@ export function registerCodeLensHandlers(
         symbolName: string;
         kind: string;
         position: Position;
-        lensType?: 'run-file' | 'run-test';
+        lensType?: 'run-file' | 'run-test' | 'run-file-tests';
       };
 
       if (!data) {

--- a/packages/pike-lsp-server/src/utils/code-lens.ts
+++ b/packages/pike-lsp-server/src/utils/code-lens.ts
@@ -14,7 +14,7 @@ export function buildCodeLensCommand(
 }
 
 export function buildRunnableCodeLensCommand(
-  kind: 'run-file' | 'run-test',
+  kind: 'run-file' | 'run-test' | 'run-file-tests',
   uri: string,
   symbolName: string
 ): Command {
@@ -23,6 +23,14 @@ export function buildRunnableCodeLensCommand(
       title: '▶ Run Test',
       command: 'pike.lsp.runTest',
       arguments: [uri, symbolName],
+    };
+  }
+
+  if (kind === 'run-file-tests') {
+    return {
+      title: '▶ Run All Tests',
+      command: 'pike.lsp.runFileTests',
+      arguments: [uri],
     };
   }
 

--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -143,6 +143,11 @@
         "command": "pike.lsp.runTest",
         "title": "Run Pike Test",
         "category": "Pike LSP"
+      },
+      {
+        "command": "pike.lsp.runFileTests",
+        "title": "Run All Tests in File",
+        "category": "Pike LSP"
       }
     ],
     "menus": {

--- a/packages/vscode-pike/src/extension.ts
+++ b/packages/vscode-pike/src/extension.ts
@@ -757,6 +757,30 @@ async function activateInternal(
 
   runtime.track(runTestDisposable);
 
+  const runFileTestsDisposable = commands.registerCommand(
+    'pike.lsp.runFileTests',
+    async (uri: string) => {
+      if (runtime.isDisposed()) return;
+      if (!uri) {
+        const editor = window.activeTextEditor;
+        if (!editor) {
+          window.showErrorMessage('No active Pike file.');
+          return;
+        }
+        uri = editor.document.uri.toString();
+      }
+      try {
+        await runWithPike(uri);
+      } catch (err) {
+        const safeMessage = anonymizeSensitivePaths(String(err));
+        runtime.getOutputChannel().appendLine(`[pike.lsp.runFileTests] Failed: ${safeMessage}`);
+        window.showErrorMessage(`Failed to run tests: ${safeMessage}`);
+      }
+    }
+  );
+
+  runtime.track(runFileTestsDisposable);
+
   // Register showDiagnostics command - shows diagnostics for current document
   const showDiagnosticsDisposable = commands.registerCommand(
     'pike.lsp.showDiagnostics',


### PR DESCRIPTION
## Summary
Add a file-level command and code lens to run all tests in the current Pike test file.

## Linked Issue
Closes #1141

## Root Cause
Users could only run individual tests via code lens. There was no convenient way to run all tests in a file at once.

## Changes
- packages/vscode-pike/package.json: Add pike.lsp.runFileTests command
- packages/vscode-pike/src/extension.ts: Register command handler that reuses runWithPike
- packages/pike-lsp-server/src/features/advanced/code-lens.ts: Add file-level Run All Tests lens
- packages/pike-lsp-server/src/utils/code-lens.ts: Add run-file-tests lens type

## Verification
- bun run typecheck passes
- Pre-push checks pass

## Checklist
- [x] Code change implemented
- [x] TypeScript compiles
- [x] Reuses existing execution path