### PR TITLE
feat: add organize imports command

### DIFF
--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -154,9 +154,21 @@
         "command": "pike.lsp.runFileTests",
         "title": "Run All Tests in File",
         "category": "Pike LSP"
+      },
+      {
+        "command": "pike.lsp.organizeImports",
+        "title": "Organize Imports",
+        "category": "Pike LSP"
       }
     ],
     "menus": {
+      "editor/context": [
+        {
+          "when": "editorTextFocus && editorLangId == pike",
+          "command": "pike.lsp.organizeImports",
+          "group": "1_modification"
+        }
+      ],
       "explorer/context": [
         {
           "when": "explorerResourceIsFolder",

--- a/packages/vscode-pike/src/extension.ts
+++ b/packages/vscode-pike/src/extension.ts
@@ -781,6 +781,16 @@ async function activateInternal(
 
   runtime.track(runFileTestsDisposable);
 
+  const organizeImportsDisposable = commands.registerCommand(
+    'pike.lsp.organizeImports',
+    async () => {
+      if (runtime.isDisposed()) return;
+      await commands.executeCommand('editor.action.organizeImports');
+    }
+  );
+
+  runtime.track(organizeImportsDisposable);
+
   // Register showDiagnostics command - shows diagnostics for current document
   const showDiagnosticsDisposable = commands.registerCommand(
     'pike.lsp.showDiagnostics',


### PR DESCRIPTION
## Summary
Add Pike LSP: Organize Imports command and editor context menu.

## Linked Issue
Closes #1144

## Root Cause
The organize imports feature existed in the server but wasn't exposed via a dedicated command.

## Changes
- packages/vscode-pike/package.json: Add command and editor menu
- packages/vscode-pike/src/extension.ts: Register command handler

## Verification
- bun run typecheck passes
- Pre-push checks pass

## Checklist
- [x] Code change implemented
- [x] TypeScript compiles