### PR TITLE
feat: expose server-backed settings (group 1)

### DIFF
--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -267,6 +267,28 @@
           "type": "boolean",
           "default": true,
           "description": "Remove unused imports when organizing imports. When false, imports are only sorted."
+        },
+        "pike.maxNumberOfProblems": {
+          "type": "number",
+          "default": 100,
+          "minimum": 10,
+          "maximum": 1000,
+          "description": "Maximum number of diagnostics to report per file"
+        },
+        "pike.inlayHints.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable inlay hints for Pike code"
+        },
+        "pike.inlayHints.parameterNames": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show parameter name hints in inlay hints"
+        },
+        "pike.inlineValues.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable inline values in Pike code"
         }
       }
     }

--- a/packages/vscode-pike/src/extension.ts
+++ b/packages/vscode-pike/src/extension.ts
@@ -400,6 +400,14 @@ class ExtensionRuntime {
           PIKE_INCLUDE_PATH: normalizedIncludePaths.join(pathSeparator),
           PIKE_PROGRAM_PATH: normalizedProgramPaths.join(pathSeparator),
         },
+        maxNumberOfProblems: config.get<number>('maxNumberOfProblems', 100),
+        inlayHints: {
+          enabled: config.get<boolean>('inlayHints.enabled', true),
+          parameterNames: config.get<boolean>('inlayHints.parameterNames', true),
+        },
+        inlineValues: {
+          enabled: config.get<boolean>('inlineValues.enabled', true),
+        },
       },
       middleware: this.createMiddleware(),
       outputChannel: this.outputChannel,


### PR DESCRIPTION
## Summary
Expose 4 server-backed settings in VSCode configuration for better user control.

## Linked Issues
Closes #1152 
Closes #1153 
Closes #1154 
Closes #1155

## Changes
- packages/vscode-pike/package.json: Add 4 new settings
- packages/vscode-pike/src/extension.ts: Pass settings via initializationOptions

## New Settings
1. `pike.maxNumberOfProblems` (number, default: 100) - Max diagnostics per file
2. `pike.inlayHints.enabled` (boolean, default: true) - Master switch for inlay hints
3. `pike.inlayHints.parameterNames` (boolean, default: true) - Control parameter name hints
4. `pike.inlineValues.enabled` (boolean, default: true) - Toggle inline values

## Verification
- bun run typecheck passes
- Pre-push checks pass

## Checklist
- [x] Settings exposed in package.json
- [x] Settings passed to server via initializationOptions
- [x] TypeScript compiles
- [x] Defaults match server expectations