### PR TITLE
feat: add noise-control settings (Group 3)

### DIFF
--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -331,6 +331,33 @@
           "type": "boolean",
           "default": true,
           "description": "Enable inline values in Pike code"
+        },
+        "pike.autoDetectPaths": {
+          "type": "boolean",
+          "default": true,
+          "description": "Auto-detect Pike executable and paths on startup"
+        },
+        "pike.promptForMissingPike": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show prompt when Pike is not found"
+        },
+        "pike.showStatusBar": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show Pike status bar item"
+        },
+        "pike.server.autoRestart": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically restart server after unexpected stop"
+        },
+        "pike.formatOnChangeDelay": {
+          "type": "number",
+          "default": 40,
+          "minimum": 0,
+          "maximum": 500,
+          "description": "Debounce delay for format-on-change in milliseconds"
         }
       }
     }

--- a/packages/vscode-pike/src/extension.ts
+++ b/packages/vscode-pike/src/extension.ts
@@ -109,11 +109,20 @@ class ExtensionRuntime {
     testOutputChannel?: OutputChannel
   ) {
     this.outputChannel = testOutputChannel || window.createOutputChannel('Pike Language Server');
-    this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, 100);
-    this.statusBarItem.command = 'pike.lsp.serverActions';
-    this.setStatusBar('idle');
-    this.statusBarItem.show();
-    this.track(this.statusBarItem);
+
+    const config = workspace.getConfiguration('pike');
+    const showStatusBar = config.get<boolean>('showStatusBar', true);
+
+    if (showStatusBar) {
+      this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, 100);
+      this.statusBarItem.command = 'pike.lsp.serverActions';
+      this.setStatusBar('idle');
+      this.statusBarItem.show();
+      this.track(this.statusBarItem);
+    } else {
+      this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, 100);
+      this.statusBarItem.hide();
+    }
   }
 
   private clearRestartTimer(): void {
@@ -132,6 +141,14 @@ class ExtensionRuntime {
 
   private scheduleAutoRestart(reason: string): void {
     if (this.disposed || !this.lspStarted) {
+      return;
+    }
+
+    const config = workspace.getConfiguration('pike');
+    const autoRestart = config.get<boolean>('server.autoRestart', true);
+    if (!autoRestart) {
+      this.outputChannel.appendLine(`[Pike] ${reason}. Auto-restart disabled.`);
+      this.setStatusBar('stopped');
       return;
     }
 
@@ -248,7 +265,12 @@ class ExtensionRuntime {
 
     this.lspStarted = true;
     this.setStatusBar('starting');
-    await autoDetectPikeConfigurationIfNeeded(this.outputChannel);
+
+    const config = workspace.getConfiguration('pike');
+    const autoDetectPaths = config.get<boolean>('autoDetectPaths', true);
+    if (autoDetectPaths) {
+      await autoDetectPikeConfigurationIfNeeded(this.outputChannel);
+    }
 
     const serverModule = this.resolveServerModule();
     if (!serverModule) {
@@ -591,7 +613,10 @@ async function activateInternal(
   if (pikePath === 'pike') {
     const detection = await detectPike();
     if (!detection) {
-      void ensurePikeInstalled();
+      const promptForMissingPike = config.get<boolean>('promptForMissingPike', true);
+      if (promptForMissingPike) {
+        void ensurePikeInstalled();
+      }
     }
   }
 
@@ -1126,47 +1151,50 @@ async function activateInternal(
       clearTimeout(previousTimer);
     }
 
-    const timer = setTimeout(async () => {
-      pendingFormatTimers.delete(uriKey);
+    const timer = setTimeout(
+      async () => {
+        pendingFormatTimers.delete(uriKey);
 
-      if (runtime.isDisposed()) {
-        return;
-      }
-
-      const editor = window.visibleTextEditors.find(e => e.document.uri.toString() === uriKey);
-      const tabSize =
-        typeof editor?.options.tabSize === 'number' ? Math.max(1, editor.options.tabSize) : 4;
-      const insertSpaces =
-        typeof editor?.options.insertSpaces === 'boolean' ? editor.options.insertSpaces : true;
-
-      const range = computeFormattingWindow(event);
-
-      try {
-        formattingDocuments.add(uriKey);
-        const edits = await commands.executeCommand<TextEdit[]>(
-          'vscode.executeFormatRangeProvider',
-          event.document.uri,
-          new Range(
-            new Position(range.startLine, 0),
-            new Position(range.endLine, Number.MAX_SAFE_INTEGER)
-          ),
-          {
-            tabSize,
-            insertSpaces,
-          }
-        );
-
-        if (!edits || edits.length === 0) {
+        if (runtime.isDisposed()) {
           return;
         }
 
-        const workspaceEdit = new WorkspaceEdit();
-        workspaceEdit.set(event.document.uri, edits);
-        await workspace.applyEdit(workspaceEdit);
-      } finally {
-        formattingDocuments.delete(uriKey);
-      }
-    }, 40);
+        const editor = window.visibleTextEditors.find(e => e.document.uri.toString() === uriKey);
+        const tabSize =
+          typeof editor?.options.tabSize === 'number' ? Math.max(1, editor.options.tabSize) : 4;
+        const insertSpaces =
+          typeof editor?.options.insertSpaces === 'boolean' ? editor.options.insertSpaces : true;
+
+        const range = computeFormattingWindow(event);
+
+        try {
+          formattingDocuments.add(uriKey);
+          const edits = await commands.executeCommand<TextEdit[]>(
+            'vscode.executeFormatRangeProvider',
+            event.document.uri,
+            new Range(
+              new Position(range.startLine, 0),
+              new Position(range.endLine, Number.MAX_SAFE_INTEGER)
+            ),
+            {
+              tabSize,
+              insertSpaces,
+            }
+          );
+
+          if (!edits || edits.length === 0) {
+            return;
+          }
+
+          const workspaceEdit = new WorkspaceEdit();
+          workspaceEdit.set(event.document.uri, edits);
+          await workspace.applyEdit(workspaceEdit);
+        } finally {
+          formattingDocuments.delete(uriKey);
+        }
+      },
+      workspace.getConfiguration('pike').get<number>('formatOnChangeDelay', 40)
+    );
 
     pendingFormatTimers.set(uriKey, timer);
   });


### PR DESCRIPTION
## Summary
Implements Group 3 (noise-control) settings for the Pike extension, giving users more control over automatic behaviors and UI elements.

## Linked Issue
closes #1162, closes #1163, closes #1164, closes #1165, closes #1166

## Root Cause
The extension had several hardcoded behaviors that could be intrusive or unwanted in certain workflows. Users needed configurability for:
- Auto-detection during activation
- Missing Pike installation prompts
- Status bar visibility
- Server auto-restart behavior
- Format-on-change delay timing

## Changes
- **extension.ts**: Modified  constructor to conditionally create status bar based on  setting
- **extension.ts**: Updated  to check  setting before scheduling
- **extension.ts**: Modified  to respect  setting
- **extension.ts**: Updated  to check  before showing install prompt
- **extension.ts**: Replaced hardcoded 40ms format delay with  setting value
- **package.json**: Already had the 5 new settings added to configuration schema

## Verification


Result: TypeScript compilation successful, no errors.

## Checklist
- [x] Code follows existing patterns in codebase
- [x] Settings have sensible defaults matching current behavior
- [x] All 5 settings are exposed in VSCode settings UI
- [x] Type check passes
- [x] Build passes
- [x] Issues #1162-#1166 will be closed upon merge
- [x] PR follows template with Summary, Linked Issue, Root Cause, Changes, Verification