### PR TITLE
feat(auto-import): completions and code actions for unresolved symbols

### DIFF
--- a/.agent-knowledge/reference/discoveries.md
+++ b/.agent-knowledge/reference/discoveries.md
@@ -298,6 +298,25 @@ if (existing.length > 0) throw collisionError;
 
 ## 2026-04-03: Shared Call Context Resolver Prevents Signature/Inlay Drift
 
+## 2026-04-03: Auto-import Feature Hooks into Diagnostic Data + Completion Data
+
+**Finding**: The cleanest auto-import flow is to use structured `Diagnostic.data` metadata for unresolved symbols (`kind`, `symbol`, `importCandidates`) and mirror the same metadata shape in completion `item.data` for resolve-time edits.
+
+**Implementation Pattern**:
+
+1. Emit unresolved diagnostics with code `undefined-symbol.unresolved-import`
+2. Keep diagnostic payload structured (`data`) instead of parsing message strings
+3. Use a dedicated `PikeIntrospectionService.searchImportableSymbols()` to merge workspace + stdlib candidates
+4. Apply deterministic ordering by `score desc`, then lexical tie-breaks
+5. Insert imports at the existing import/include/inherit block boundary
+
+**Files**:
+
+- `packages/pike-lsp-server/src/features/diagnostics/semantic-analyzer.ts`
+- `packages/pike-lsp-server/src/features/advanced/code-actions.ts`
+- `packages/pike-lsp-server/src/features/editing/completion.ts`
+- `packages/pike-lsp-server/src/services/pike-introspection.ts`
+
 **Finding**: Signature help and inlay hints were using independent call parsers, causing mismatch on nested calls, member calls, and comment/string false positives.
 
 **Pattern**:

--- a/packages/pike-lsp-server/src/core/types.ts
+++ b/packages/pike-lsp-server/src/core/types.ts
@@ -49,6 +49,7 @@ export interface CoreDiagnostic {
   severity?: CoreDiagnosticSeverity;
   code?: string | number;
   source?: string;
+  data?: unknown;
   tags?: CoreDiagnosticTag[];
   relatedInformation?: CoreDiagnosticRelatedInformation[];
 }

--- a/packages/pike-lsp-server/src/features/advanced/code-actions.ts
+++ b/packages/pike-lsp-server/src/features/advanced/code-actions.ts
@@ -9,13 +9,114 @@
  * - Returns all applicable actions when filter is empty/undefined
  */
 
-import { Connection, CodeAction, CodeActionKind, TextEdit } from 'vscode-languageserver/node.js';
+import {
+  Connection,
+  CodeAction,
+  CodeActionKind,
+  CodeActionParams,
+  TextEdit,
+} from 'vscode-languageserver/node.js';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { TextDocuments } from 'vscode-languageserver/node.js';
 import type { Services } from '../../services/index.js';
 import { Logger } from '@pike-lsp/core';
 import { getGenerateGetterSetterActions } from './getters-setters.js';
 import { getExtractMethodAction } from './extract-method.js';
+
+interface ImportCandidate {
+  modulePath: string;
+  importKind: 'import' | 'inherit';
+  score: number;
+}
+
+interface UnresolvedDiagnosticData {
+  kind?: string;
+  symbol?: string;
+  importCandidates?: ImportCandidate[];
+}
+
+function toUnresolvedDiagnosticData(value: unknown): UnresolvedDiagnosticData | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const symbol = typeof record['symbol'] === 'string' ? record['symbol'] : undefined;
+  const kind = typeof record['kind'] === 'string' ? record['kind'] : undefined;
+  const importCandidatesRaw = Array.isArray(record['importCandidates'])
+    ? (record['importCandidates'] as unknown[])
+    : [];
+
+  const importCandidates: ImportCandidate[] = [];
+  for (const entry of importCandidatesRaw) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      continue;
+    }
+    const candidate = entry as Record<string, unknown>;
+    const modulePath = typeof candidate['modulePath'] === 'string' ? candidate['modulePath'] : null;
+    const importKind = candidate['importKind'] === 'inherit' ? 'inherit' : 'import';
+    const score = typeof candidate['score'] === 'number' ? candidate['score'] : 0;
+    if (!modulePath) {
+      continue;
+    }
+    importCandidates.push({ modulePath, importKind, score });
+  }
+
+  const result: UnresolvedDiagnosticData = { importCandidates };
+  if (kind !== undefined) {
+    result.kind = kind;
+  }
+  if (symbol !== undefined) {
+    result.symbol = symbol;
+  }
+  return result;
+}
+
+function sortImportCandidates(candidates: ImportCandidate[]): ImportCandidate[] {
+  return [...candidates].sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    if (a.importKind !== b.importKind) {
+      return a.importKind.localeCompare(b.importKind);
+    }
+    return a.modulePath.localeCompare(b.modulePath);
+  });
+}
+
+function getImportInsertionLine(lines: string[]): number {
+  let insertionLine = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = (lines[i] ?? '').trim();
+    if (
+      trimmed.startsWith('#include ') ||
+      trimmed.startsWith('import ') ||
+      trimmed.startsWith('inherit ')
+    ) {
+      insertionLine = i + 1;
+      continue;
+    }
+    if (trimmed === '') {
+      continue;
+    }
+    break;
+  }
+  return insertionLine;
+}
+
+function buildImportStatement(candidate: ImportCandidate): string {
+  return candidate.importKind === 'inherit'
+    ? `inherit ${candidate.modulePath};\n`
+    : `import ${candidate.modulePath};\n`;
+}
+
+function hasImportStatement(lines: string[], candidate: ImportCandidate): boolean {
+  const expected =
+    candidate.importKind === 'inherit'
+      ? `inherit ${candidate.modulePath};`
+      : `import ${candidate.modulePath};`;
+  return lines.some(line => line.trim() === expected);
+}
 
 /**
  * Register code actions handler.
@@ -31,7 +132,7 @@ export function registerCodeActionsHandler(
   /**
    * Code Action handler - provide quick fixes and refactorings
    */
-  connection.onCodeAction((params): CodeAction[] => {
+  connection.onCodeAction(async (params: CodeActionParams): Promise<CodeAction[]> => {
     log.debug('Code action request', { uri: params.textDocument.uri });
     try {
       const uri = params.textDocument.uri;
@@ -107,10 +208,6 @@ export function registerCodeActionsHandler(
           } else if (lt.startsWith('#include ')) {
             importLines.push({ line: i, text: lines[i] ?? '', type: 'include' });
           }
-        }
-
-        if (importLines.length === 0) {
-          return actions;
         }
 
         const unusedImports = new Set<number>();
@@ -203,6 +300,58 @@ export function registerCodeActionsHandler(
 
       // Quick Fixes - only if filter allows
       if (matchesFilter(CodeActionKind.QuickFix)) {
+        for (const diag of diagnostics) {
+          if (diag.code !== 'undefined-symbol.unresolved-import') {
+            continue;
+          }
+
+          const unresolvedData = toUnresolvedDiagnosticData(diag.data);
+          if (!unresolvedData?.symbol) {
+            continue;
+          }
+
+          let candidates = unresolvedData.importCandidates ?? [];
+          if (candidates.length === 0 && services.pikeIntrospection) {
+            candidates = await services.pikeIntrospection.searchImportableSymbols(
+              unresolvedData.symbol,
+              {
+                excludeUri: uri,
+                limit: 8,
+              }
+            );
+          }
+
+          const sortedCandidates = sortImportCandidates(candidates);
+          const insertionLine = getImportInsertionLine(lines);
+
+          for (const candidate of sortedCandidates) {
+            if (hasImportStatement(lines, candidate)) {
+              continue;
+            }
+
+            const statement = buildImportStatement(candidate);
+            const verb = candidate.importKind === 'inherit' ? 'inherit' : 'import';
+            actions.push({
+              title: `Add ${verb} for ${unresolvedData.symbol} from ${candidate.modulePath}`,
+              kind: CodeActionKind.QuickFix,
+              diagnostics: [diag],
+              edit: {
+                changes: {
+                  [uri]: [
+                    {
+                      range: {
+                        start: { line: insertionLine, character: 0 },
+                        end: { line: insertionLine, character: 0 },
+                      },
+                      newText: statement,
+                    },
+                  ],
+                },
+              },
+            });
+          }
+        }
+
         for (const diag of diagnostics) {
           if (diag.message.includes('syntax error') || diag.message.includes('expected')) {
             const diagLine = lines[diag.range.start.line] ?? '';

--- a/packages/pike-lsp-server/src/features/diagnostics/semantic-analyzer.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/semantic-analyzer.ts
@@ -29,6 +29,20 @@ export interface SemanticAnalyzerOptions {
   enableMissingCallbacks: boolean;
 }
 
+export interface UnresolvedImportCandidate {
+  modulePath: string;
+  importKind: 'import' | 'inherit';
+  score: number;
+}
+
+export interface UnresolvedSymbolDiagnosticData {
+  kind: 'unresolved-symbol';
+  symbol: string;
+  importCandidates: UnresolvedImportCandidate[];
+}
+
+const UNRESOLVED_SYMBOL_DIAGNOSTIC_CODE = 'undefined-symbol.unresolved-import';
+
 const DEFAULT_OPTIONS: SemanticAnalyzerOptions = {
   maxProblems: 100,
   enableUndefinedDetection: true,
@@ -356,7 +370,12 @@ function analyzeUndefinedSymbols(
       range,
       message: `Undefined symbol: '${text}'`,
       source: 'pike-semantic',
-      code: 'undefined-symbol',
+      code: UNRESOLVED_SYMBOL_DIAGNOSTIC_CODE,
+      data: {
+        kind: 'unresolved-symbol',
+        symbol: text,
+        importCandidates: [],
+      } satisfies UnresolvedSymbolDiagnosticData,
     });
   }
 

--- a/packages/pike-lsp-server/src/features/editing/completion.ts
+++ b/packages/pike-lsp-server/src/features/editing/completion.ts
@@ -41,6 +41,46 @@ function getSymbolClassname(symbol: PikeSymbol): string | undefined {
   return undefined;
 }
 
+interface AutoImportCompletionData {
+  autoImport: true;
+  symbol: string;
+  modulePath: string;
+  importKind: 'import' | 'inherit';
+}
+
+function getImportInsertionLine(lines: string[]): number {
+  let insertionLine = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = (lines[i] ?? '').trim();
+    if (
+      trimmed.startsWith('#include ') ||
+      trimmed.startsWith('import ') ||
+      trimmed.startsWith('inherit ')
+    ) {
+      insertionLine = i + 1;
+      continue;
+    }
+    if (trimmed === '') {
+      continue;
+    }
+    break;
+  }
+  return insertionLine;
+}
+
+function buildAutoImportStatement(modulePath: string, importKind: 'import' | 'inherit'): string {
+  return importKind === 'inherit' ? `inherit ${modulePath};\n` : `import ${modulePath};\n`;
+}
+
+function hasImportStatement(
+  lines: string[],
+  modulePath: string,
+  importKind: 'import' | 'inherit'
+): boolean {
+  const expected = importKind === 'inherit' ? `inherit ${modulePath};` : `import ${modulePath};`;
+  return lines.some(line => line.trim() === expected);
+}
+
 /**
  * Add Pike predefined macros (__FILE__, __LINE__, etc.) to completions.
  * Only adds macros that match the prefix.
@@ -121,6 +161,100 @@ export function registerCompletionHandlers(
     }
 
     return deduped;
+  }
+
+  async function addAutoImportCompletions(
+    completions: CompletionItem[],
+    params: {
+      uri: string;
+      prefix: string;
+      text: string;
+      lineText: string;
+      localSymbols: PikeSymbol[];
+    }
+  ): Promise<void> {
+    if (!services.pikeIntrospection) {
+      return;
+    }
+
+    const prefix = params.prefix.trim();
+    if (prefix.length === 0) {
+      return;
+    }
+
+    if (params.lineText.includes('->') || params.lineText.includes('::')) {
+      return;
+    }
+
+    const initialLabels = new Set<string>(completions.map(item => item.label));
+    for (const symbol of params.localSymbols) {
+      if (symbol.name) {
+        initialLabels.add(symbol.name);
+      }
+    }
+
+    const lines = params.text.split('\n');
+    const insertionLine = getImportInsertionLine(lines);
+    const candidates = await services.pikeIntrospection.searchImportableSymbols(prefix, {
+      excludeUri: params.uri,
+      limit: 12,
+    });
+
+    const sortedCandidates = [...candidates].sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      if (a.symbol !== b.symbol) {
+        return a.symbol.localeCompare(b.symbol);
+      }
+      if (a.importKind !== b.importKind) {
+        return a.importKind.localeCompare(b.importKind);
+      }
+      return a.modulePath.localeCompare(b.modulePath);
+    });
+
+    for (const candidate of sortedCandidates) {
+      if (!candidate.symbol.toLowerCase().startsWith(prefix.toLowerCase())) {
+        continue;
+      }
+
+      if (initialLabels.has(candidate.symbol)) {
+        continue;
+      }
+
+      if (hasImportStatement(lines, candidate.modulePath, candidate.importKind)) {
+        continue;
+      }
+
+      const statement = buildAutoImportStatement(candidate.modulePath, candidate.importKind);
+      completions.push({
+        label: candidate.symbol,
+        kind:
+          candidate.importKind === 'inherit'
+            ? CompletionItemKind.Class
+            : CompletionItemKind.Function,
+        detail:
+          candidate.importKind === 'inherit'
+            ? `Auto-import via inherit from ${candidate.modulePath}`
+            : `Auto-import from ${candidate.modulePath}`,
+        sortText: `0-auto-${candidate.symbol}-${candidate.modulePath}`,
+        data: {
+          autoImport: true,
+          symbol: candidate.symbol,
+          modulePath: candidate.modulePath,
+          importKind: candidate.importKind,
+        } satisfies AutoImportCompletionData,
+        additionalTextEdits: [
+          {
+            range: {
+              start: { line: insertionLine, character: 0 },
+              end: { line: insertionLine, character: 0 },
+            },
+            newText: statement,
+          },
+        ],
+      });
+    }
   }
 
   /**
@@ -440,6 +574,14 @@ export function registerCompletionHandlers(
               }
             }
           }
+
+          await addAutoImportCompletions(completions, {
+            uri,
+            prefix,
+            text,
+            lineText,
+            localSymbols: cached?.symbols ?? [],
+          });
 
           maybeLogCompletionSchedulerMetrics(uri, 'qe_deduped');
           const macroNames = new Set(completions.map(c => c.label));
@@ -1245,6 +1387,14 @@ export function registerCompletionHandlers(
       }
     }
 
+    await addAutoImportCompletions(completions, {
+      uri,
+      prefix,
+      text,
+      lineText,
+      localSymbols: cached.symbols,
+    });
+
     const existingNames = new Set(completions.map(c => c.label));
     addMacrosToCompletions(completions, existingNames, prefix ?? '');
     return toCompletionList(dedupeCompletionItems(completions));
@@ -1257,7 +1407,24 @@ export function registerCompletionHandlers(
     const data = item.data as
       | { uri?: string; name?: string }
       | { modulePath?: string; name?: string; isStdlib?: boolean }
+      | AutoImportCompletionData
       | undefined;
+
+    if (data && 'autoImport' in data && data.autoImport) {
+      if (!item.additionalTextEdits || item.additionalTextEdits.length === 0) {
+        const statement = buildAutoImportStatement(data.modulePath, data.importKind);
+        item.additionalTextEdits = [
+          {
+            range: {
+              start: { line: 0, character: 0 },
+              end: { line: 0, character: 0 },
+            },
+            newText: statement,
+          },
+        ];
+      }
+      return item;
+    }
 
     // Handle local symbol resolution (existing behavior)
     if (data && 'uri' in data && data.uri && data.name) {
@@ -1275,10 +1442,16 @@ export function registerCompletionHandlers(
     }
 
     // Handle import symbol resolution (new auto-import feature)
-    if (data && 'modulePath' in data && data.modulePath && data.name) {
+    if (
+      data &&
+      'modulePath' in data &&
+      data.modulePath &&
+      'name' in data &&
+      typeof data.name === 'string'
+    ) {
       const modulePath = data.modulePath;
       const symbolName = data.name;
-      const isStdlib = data.isStdlib ?? true;
+      const isStdlib = 'isStdlib' in data ? (data.isStdlib ?? true) : true;
 
       // Look up the symbol to get documentation (async)
       if (services.stdlibIndex && isStdlib) {

--- a/packages/pike-lsp-server/src/runtime/service-runtime-context.ts
+++ b/packages/pike-lsp-server/src/runtime/service-runtime-context.ts
@@ -2,7 +2,12 @@ import type { Services } from '../services/index.js';
 
 type MutableRuntimeServices = Pick<
   Services,
-  'bridge' | 'includeResolver' | 'stdlibIndex' | 'globalSettings' | 'includePaths'
+  | 'bridge'
+  | 'includeResolver'
+  | 'stdlibIndex'
+  | 'pikeIntrospection'
+  | 'globalSettings'
+  | 'includePaths'
 >;
 
 export interface ServiceRuntimeContext {

--- a/packages/pike-lsp-server/src/scenarios/auto-import-code-actions.test.ts
+++ b/packages/pike-lsp-server/src/scenarios/auto-import-code-actions.test.ts
@@ -1,0 +1,229 @@
+import { describe, it } from 'bun:test';
+import assert from 'node:assert/strict';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { CodeActionKind, type CodeAction, type Diagnostic } from 'vscode-languageserver/node.js';
+import { registerCodeActionsHandler } from '../features/advanced/code-actions.js';
+
+type CodeActionHandler = (params: {
+  textDocument: { uri: string };
+  range: { start: { line: number; character: number }; end: { line: number; character: number } };
+  context: { diagnostics: Diagnostic[]; only?: string[] };
+}) => CodeAction[] | Promise<CodeAction[]>;
+
+function createConnection() {
+  let handler: CodeActionHandler | null = null;
+  return {
+    onCodeAction(next: CodeActionHandler) {
+      handler = next;
+    },
+    async getCodeActions(params: Parameters<CodeActionHandler>[0]) {
+      if (!handler) {
+        throw new Error('Code action handler not registered');
+      }
+      return handler(params);
+    },
+  };
+}
+
+function createDocuments(doc: TextDocument) {
+  return {
+    get(uri: string) {
+      return uri === doc.uri ? doc : undefined;
+    },
+  };
+}
+
+function unresolvedDiagnostic(
+  symbol: string,
+  line = 1,
+  character = 7,
+  candidates: Array<{ modulePath: string; importKind: 'import' | 'inherit'; score: number }> = [
+    { modulePath: 'Parser.Pike', importKind: 'import', score: 100 },
+  ]
+): Diagnostic {
+  return {
+    range: {
+      start: { line, character },
+      end: { line, character: character + symbol.length },
+    },
+    severity: 2,
+    source: 'pike-semantic',
+    code: 'undefined-symbol.unresolved-import',
+    message: `Undefined symbol: '${symbol}'`,
+    data: {
+      symbol,
+      kind: 'unresolved-symbol',
+      importCandidates: candidates,
+    },
+  };
+}
+
+function setup(code: string) {
+  const uri = 'file:///auto-import-code-actions.pike';
+  const document = TextDocument.create(uri, 'pike', 1, code);
+  const connection = createConnection();
+
+  const services = {
+    documentCache: {
+      get(requestUri: string) {
+        if (requestUri !== uri) return undefined;
+        return {
+          version: 1,
+          symbols: [],
+          diagnostics: [],
+          symbolPositions: new Map(),
+          symbolNames: new Map(),
+        };
+      },
+    },
+    globalSettings: {
+      pikePath: 'pike',
+      maxNumberOfProblems: 100,
+      diagnosticDelay: 0,
+      organizeImports: { removeUnused: true },
+    },
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    pikeIntrospection: {
+      async searchImportableSymbols() {
+        return [];
+      },
+    },
+  };
+
+  registerCodeActionsHandler(
+    connection as never,
+    services as never,
+    createDocuments(document) as never
+  );
+
+  return {
+    uri,
+    codeActions: async (diagnostics: Diagnostic[], only?: string[]) => {
+      const context: { diagnostics: Diagnostic[]; only?: string[] } = { diagnostics };
+      if (only) {
+        context.only = only;
+      }
+
+      return connection.getCodeActions({
+        textDocument: { uri },
+        range: {
+          start: { line: 1, character: 0 },
+          end: { line: 1, character: 0 },
+        },
+        context,
+      });
+    },
+  };
+}
+
+describe('Scenario: Auto-import code actions for unresolved symbols', () => {
+  it('offers Add import quick fix for a single import candidate', async () => {
+    const test = setup('int main() { return tokenize("a"); }\n');
+    const actions = await test.codeActions([unresolvedDiagnostic('tokenize')]);
+
+    assert.ok(actions.some(action => action.title === 'Add import for tokenize from Parser.Pike'));
+  });
+
+  it('offers Add inherit quick fix when candidate requires inherit', async () => {
+    const test = setup('class Child { int main() { return base_call(); } }\n');
+    const actions = await test.codeActions([
+      unresolvedDiagnostic('base_call', 0, 34, [
+        { modulePath: 'BaseClass', importKind: 'inherit', score: 90 },
+      ]),
+    ]);
+
+    assert.ok(actions.some(action => action.title === 'Add inherit for base_call from BaseClass'));
+  });
+
+  it('sorts ambiguous import candidates deterministically by score then module path', async () => {
+    const test = setup('int main() { return parse(); }\n');
+    const actions = await test.codeActions([
+      unresolvedDiagnostic('parse', 0, 20, [
+        { modulePath: 'Parser.XML', importKind: 'import', score: 80 },
+        { modulePath: 'Parser.Pike', importKind: 'import', score: 80 },
+        { modulePath: 'Parser', importKind: 'import', score: 95 },
+      ]),
+    ]);
+
+    const addImportTitles = actions
+      .filter(
+        action => action.kind === CodeActionKind.QuickFix && action.title.startsWith('Add import')
+      )
+      .map(action => action.title);
+
+    assert.deepStrictEqual(addImportTitles, [
+      'Add import for parse from Parser',
+      'Add import for parse from Parser.Pike',
+      'Add import for parse from Parser.XML',
+    ]);
+  });
+
+  it('respects context.only quickfix filter', async () => {
+    const test = setup('int main() { return tokenize("a"); }\n');
+    const actions = await test.codeActions(
+      [unresolvedDiagnostic('tokenize')],
+      [CodeActionKind.QuickFix]
+    );
+    assert.ok(actions.length > 0);
+    assert.ok(actions.every(action => action.kind === CodeActionKind.QuickFix));
+  });
+
+  it('does not offer import action for unrelated diagnostics', async () => {
+    const test = setup('int main() { return 1 }\n');
+    const actions = await test.codeActions([
+      {
+        range: {
+          start: { line: 0, character: 20 },
+          end: { line: 0, character: 21 },
+        },
+        severity: 1,
+        source: 'pike',
+        code: 'syntax-error',
+        message: 'expected ;',
+      },
+    ]);
+
+    assert.ok(!actions.some(action => action.title.startsWith('Add import for')));
+  });
+
+  it('does not suggest duplicate import when module already imported', async () => {
+    const test = setup('import Parser.Pike;\nint main() { return tokenize("a"); }\n');
+    const actions = await test.codeActions([unresolvedDiagnostic('tokenize')]);
+
+    assert.ok(!actions.some(action => action.title.includes('Parser.Pike')));
+  });
+
+  it('inserts import after existing import block', async () => {
+    const test = setup('import Stdio;\nimport String;\nint main() { return tokenize("a"); }\n');
+    const actions = await test.codeActions([unresolvedDiagnostic('tokenize')]);
+    const target = actions.find(action => action.title.includes('Parser.Pike'));
+
+    assert.ok(target?.edit?.changes);
+    const edits = target?.edit?.changes?.[test.uri] ?? [];
+    assert.ok(edits.length > 0);
+    assert.strictEqual(edits[0]?.range.start.line, 2);
+  });
+
+  it('supports metadata-driven unresolved symbol diagnostics without message parsing', async () => {
+    const test = setup('int main() { return parse(); }\n');
+    const actions = await test.codeActions([
+      {
+        range: {
+          start: { line: 0, character: 20 },
+          end: { line: 0, character: 25 },
+        },
+        severity: 2,
+        source: 'pike-semantic',
+        code: 'undefined-symbol.unresolved-import',
+        message: 'semantic unresolved symbol',
+        data: {
+          symbol: 'parse',
+          kind: 'unresolved-symbol',
+          importCandidates: [{ modulePath: 'Parser', importKind: 'import', score: 100 }],
+        },
+      },
+    ]);
+
+    assert.ok(actions.some(action => action.title === 'Add import for parse from Parser'));
+  });
+});

--- a/packages/pike-lsp-server/src/scenarios/auto-import-completion.test.ts
+++ b/packages/pike-lsp-server/src/scenarios/auto-import-completion.test.ts
@@ -1,0 +1,254 @@
+import { describe, it } from 'bun:test';
+import assert from 'node:assert/strict';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { type CompletionItem, type CompletionList } from 'vscode-languageserver/node.js';
+import { registerCompletionHandlers } from '../features/editing/completion.js';
+
+type CompletionHandler = (params: {
+  textDocument: { uri: string };
+  position: { line: number; character: number };
+  context?: { triggerKind: number; triggerCharacter?: string };
+}) => Promise<CompletionList>;
+
+type ResolveHandler = (item: CompletionItem) => Promise<CompletionItem>;
+
+function createConnection() {
+  let completionHandler: CompletionHandler | null = null;
+  let resolveHandler: ResolveHandler | null = null;
+
+  return {
+    onCompletion(handler: CompletionHandler) {
+      completionHandler = handler;
+    },
+    onCompletionResolve(handler: ResolveHandler) {
+      resolveHandler = handler;
+    },
+    async complete(params: Parameters<CompletionHandler>[0]) {
+      if (!completionHandler) {
+        throw new Error('completion handler not registered');
+      }
+      return completionHandler(params);
+    },
+    async resolve(item: CompletionItem) {
+      if (!resolveHandler) {
+        throw new Error('completion resolve handler not registered');
+      }
+      return resolveHandler(item);
+    },
+  };
+}
+
+function createSearchResult(
+  symbol: string,
+  modulePath: string,
+  importKind: 'import' | 'inherit',
+  score: number
+) {
+  return {
+    symbol,
+    modulePath,
+    importKind,
+    score,
+    source: 'workspace-index',
+  };
+}
+
+function setup(code: string, searchResults: ReturnType<typeof createSearchResult>[] = []) {
+  const uri = 'file:///auto-import-completion.pike';
+  const document = TextDocument.create(uri, 'pike', 1, code);
+  const connection = createConnection();
+
+  const services = {
+    bridge: {
+      isRunning: () => true,
+      engineQuery: async () => ({ result: { result: { status: 'stub' } } }),
+      getCompletionContext: async () => ({
+        context: 'identifier',
+        objectName: '',
+        prefix: '',
+        operator: '',
+      }),
+    },
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    documentCache: {
+      get(requestUri: string) {
+        if (requestUri !== uri) return undefined;
+        return {
+          version: 1,
+          symbols: [],
+          diagnostics: [],
+          symbolPositions: new Map(),
+          symbolNames: new Map(),
+          dependencies: { includes: [], imports: [] },
+        };
+      },
+      entries() {
+        return [] as Array<
+          [string, { symbols: Array<{ name: string; kind: string; modifiers: string[] }> }]
+        >;
+      },
+    },
+    stdlibIndex: {
+      async getModule() {
+        return null;
+      },
+    },
+    includeResolver: null,
+    moduleContext: null,
+    typeDatabase: {},
+    workspaceIndex: {},
+    workspaceScanner: {
+      isReady: () => true,
+      getAllFiles: () => [],
+      getUncachedFiles: () => [],
+      getFile: () => undefined,
+      updateFileData() {},
+      invalidateFile() {},
+      upsertFile() {},
+      removeFile() {},
+      getStats: () => ({ fileCount: 0, rootCount: 0, cachedFiles: 0 }),
+    },
+    globalSettings: { pikePath: 'pike', maxNumberOfProblems: 100, diagnosticDelay: 0 },
+    includePaths: [],
+    pikeIntrospection: {
+      async searchImportableSymbols(symbol: string) {
+        return searchResults.filter(result =>
+          result.symbol.toLowerCase().startsWith(symbol.toLowerCase())
+        );
+      },
+    },
+  };
+
+  const documents = {
+    get(requestUri: string) {
+      return requestUri === uri ? document : undefined;
+    },
+  };
+
+  registerCompletionHandlers(connection as never, services as never, documents as never);
+
+  return {
+    uri,
+    async complete(line: number, character: number) {
+      return connection.complete({ textDocument: { uri }, position: { line, character } });
+    },
+    async resolve(item: CompletionItem) {
+      return connection.resolve(item);
+    },
+  };
+}
+
+function findItem(items: CompletionItem[], label: string): CompletionItem {
+  const found = items.find(item => item.label === label);
+  if (!found) {
+    throw new Error(`Missing completion item: ${label}`);
+  }
+  return found;
+}
+
+describe('Scenario: Auto-import completions', () => {
+  it('adds unresolved symbol auto-import candidate to completion list', async () => {
+    const test = setup('int main() { tok\n', [
+      createSearchResult('tokenize', 'Parser.Pike', 'import', 100),
+    ]);
+    const result = await test.complete(0, 16);
+
+    assert.ok(result.items.some((item: CompletionItem) => item.label === 'tokenize'));
+  });
+
+  it('marks auto-import completion with detail and origin metadata', async () => {
+    const test = setup('int main() { par\n', [
+      createSearchResult('parse', 'Parser', 'import', 100),
+    ]);
+    const result = await test.complete(0, 16);
+    const item = findItem(result.items, 'parse');
+
+    assert.ok(item.detail?.includes('Auto-import'));
+    assert.ok(item.data);
+  });
+
+  it('orders ambiguous auto-import completions deterministically', async () => {
+    const test = setup('int main() { par\n', [
+      createSearchResult('parse', 'Parser.XML', 'import', 90),
+      createSearchResult('parse', 'Parser.Pike', 'import', 90),
+      createSearchResult('parse', 'Parser', 'import', 95),
+    ]);
+    const result = await test.complete(0, 16);
+
+    const parseItems = result.items
+      .filter(
+        (item: CompletionItem) => item.label === 'parse' && item.detail?.includes('Auto-import')
+      )
+      .map((item: CompletionItem) => item.detail);
+
+    assert.deepStrictEqual(parseItems, [
+      'Auto-import from Parser',
+      'Auto-import from Parser.Pike',
+      'Auto-import from Parser.XML',
+    ]);
+  });
+
+  it('includes inherit-based candidates for class-style unresolved symbols', async () => {
+    const test = setup('class Child { int run() { Bas\n', [
+      createSearchResult('BaseClass', 'BaseClass', 'inherit', 100),
+    ]);
+    const result = await test.complete(0, 28);
+
+    assert.ok(
+      result.items.some(
+        (item: CompletionItem) => item.label === 'BaseClass' && item.detail?.includes('inherit')
+      )
+    );
+  });
+
+  it('filters auto-import candidates by typed prefix', async () => {
+    const test = setup('int main() { to\n', [
+      createSearchResult('tokenize', 'Parser.Pike', 'import', 100),
+      createSearchResult('parse', 'Parser', 'import', 100),
+    ]);
+    const result = await test.complete(0, 15);
+
+    assert.ok(result.items.some((item: CompletionItem) => item.label === 'tokenize'));
+    assert.ok(
+      !result.items.some(
+        (item: CompletionItem) => item.label === 'parse' && item.detail?.includes('Auto-import')
+      )
+    );
+  });
+
+  it('does not surface duplicate auto-import candidate for already imported module', async () => {
+    const test = setup('import Parser.Pike;\nint main() { tok\n', [
+      createSearchResult('tokenize', 'Parser.Pike', 'import', 100),
+    ]);
+    const result = await test.complete(1, 16);
+
+    assert.ok(
+      !result.items.some(
+        (item: CompletionItem) => item.label === 'tokenize' && item.detail?.includes('Auto-import')
+      )
+    );
+  });
+
+  it('resolves auto-import completion with additionalTextEdits', async () => {
+    const test = setup('int main() { tok\n', [
+      createSearchResult('tokenize', 'Parser.Pike', 'import', 100),
+    ]);
+    const result = await test.complete(0, 16);
+    const item = findItem(result.items, 'tokenize');
+    const resolved = await test.resolve(item);
+
+    assert.ok((resolved.additionalTextEdits?.length ?? 0) > 0);
+    assert.ok(resolved.additionalTextEdits?.[0]?.newText.includes('import Parser.Pike;'));
+  });
+
+  it('resolve uses inherit insertion when candidate import kind is inherit', async () => {
+    const test = setup('class Child { int run() { Bas\n', [
+      createSearchResult('BaseClass', 'BaseClass', 'inherit', 100),
+    ]);
+    const result = await test.complete(0, 28);
+    const item = findItem(result.items, 'BaseClass');
+    const resolved = await test.resolve(item);
+
+    assert.ok(resolved.additionalTextEdits?.[0]?.newText.includes('inherit BaseClass;'));
+  });
+});

--- a/packages/pike-lsp-server/src/server.ts
+++ b/packages/pike-lsp-server/src/server.ts
@@ -30,6 +30,7 @@ import { IncludeResolver } from './services/include-resolver.js';
 import { ModuleContext } from './services/module-context.js';
 import { WorkspaceScanner } from './services/workspace-scanner.js';
 import { FormattingService } from './services/formatting-service.js';
+import { PikeIntrospectionService } from './services/pike-introspection.js';
 import {
   Logger,
   anonymizeSensitivePaths,
@@ -103,6 +104,7 @@ const formattingService = new FormattingService();
 let stdlibIndex: StdlibIndexManager | null = null;
 let includeResolver: IncludeResolver | null = null;
 let bridgeManager: BridgeManager | null = null;
+let pikeIntrospection = new PikeIntrospectionService(workspaceIndex, stdlibIndex);
 
 let globalSettings: PikeSettings = defaultSettings;
 let includePaths: string[] = [];
@@ -157,6 +159,7 @@ function createServices(): features.Services {
     typeDatabase,
     workspaceIndex,
     stdlibIndex,
+    pikeIntrospection,
     includeResolver, // Will be null initially, updated after onInitialize
     workspaceScanner,
     globalSettings,
@@ -482,6 +485,8 @@ registerServerRuntimeHandlers({
   getClientSupportsWorkDoneProgress: () => clientSupportsWorkDoneProgress,
   setStdlibIndex: index => {
     stdlibIndex = index;
+    pikeIntrospection = new PikeIntrospectionService(workspaceIndex, stdlibIndex);
+    serviceRuntimeContext.update({ stdlibIndex, pikeIntrospection });
   },
   updateServices: patch => {
     serviceRuntimeContext.update(patch);

--- a/packages/pike-lsp-server/src/services/index.ts
+++ b/packages/pike-lsp-server/src/services/index.ts
@@ -16,6 +16,7 @@ import type { WorkspaceIndex } from '../workspace-index.js';
 import type { StdlibIndexManager } from '../stdlib-index.js';
 import type { PikeSettings } from '../core/types.js';
 import type { FormattingService } from './formatting-service.js';
+import type { PikeIntrospectionService } from './pike-introspection.js';
 
 /**
  * Services interface bundles all service dependencies.
@@ -48,6 +49,7 @@ export interface Services {
   includePaths: string[];
   formattingService?: FormattingService;
   documentSnapshots?: Map<string, string>;
+  pikeIntrospection?: PikeIntrospectionService;
 }
 
 // Re-export for convenience
@@ -56,6 +58,7 @@ export { BridgeManager, type HealthStatus } from './bridge-manager.js';
 export { WorkspaceScanner } from './workspace-scanner.js';
 export { ModuleContext } from './module-context.js';
 export { FormattingService } from './formatting-service.js';
+export { PikeIntrospectionService } from './pike-introspection.js';
 export { LRUCache, type LRUCacheOptions, type LRUCacheStats } from './lru-cache.js';
 export {
   CompilationCache,

--- a/packages/pike-lsp-server/src/services/pike-introspection.ts
+++ b/packages/pike-lsp-server/src/services/pike-introspection.ts
@@ -1,0 +1,108 @@
+import type { StdlibIndexManager } from '../stdlib-index.js';
+import type { WorkspaceIndex, ImportableSymbolSearchResult } from '../workspace-index.js';
+
+export interface ImportableSymbolCandidate {
+  symbol: string;
+  modulePath: string;
+  importKind: 'import' | 'inherit';
+  score: number;
+  source: 'workspace-index' | 'stdlib-index';
+}
+
+const DEFAULT_STDLIB_MODULES = [
+  'Parser',
+  'Parser.Pike',
+  'Stdio',
+  'String',
+  'Array',
+  'Math',
+] as const;
+
+export class PikeIntrospectionService {
+  constructor(
+    private readonly workspaceIndex: WorkspaceIndex,
+    private readonly stdlibIndex: StdlibIndexManager | null
+  ) {}
+
+  async searchImportableSymbols(
+    symbol: string,
+    options: { excludeUri?: string; limit?: number } = {}
+  ): Promise<ImportableSymbolCandidate[]> {
+    const query = symbol.trim();
+    if (!query) {
+      return [];
+    }
+
+    const workspaceCandidates = this.workspaceIndex.searchImportableSymbols(query, options);
+    const stdlibCandidates = await this.searchStdlibCandidates(query);
+    const merged = this.mergeCandidates(workspaceCandidates, stdlibCandidates);
+
+    const limit = Math.max(1, options.limit ?? 20);
+    return merged.slice(0, limit);
+  }
+
+  private async searchStdlibCandidates(query: string): Promise<ImportableSymbolCandidate[]> {
+    if (!this.stdlibIndex) {
+      return [];
+    }
+
+    const queryLower = query.toLowerCase();
+    const candidates: ImportableSymbolCandidate[] = [];
+
+    for (const modulePath of DEFAULT_STDLIB_MODULES) {
+      const moduleInfo = await this.stdlibIndex.getModule(modulePath);
+      if (!moduleInfo?.symbols) {
+        continue;
+      }
+
+      for (const [name, symbolInfo] of moduleInfo.symbols) {
+        if (!name.toLowerCase().startsWith(queryLower)) {
+          continue;
+        }
+
+        const importKind: 'import' | 'inherit' = symbolInfo.kind === 'class' ? 'inherit' : 'import';
+        const exactBoost = name.toLowerCase() === queryLower ? 130 : 0;
+        const kindBoost = importKind === 'inherit' ? 15 : 10;
+
+        candidates.push({
+          symbol: name,
+          modulePath,
+          importKind,
+          score: exactBoost + kindBoost + Math.max(0, 60 - modulePath.length),
+          source: 'stdlib-index',
+        });
+      }
+    }
+
+    return candidates;
+  }
+
+  private mergeCandidates(
+    workspaceCandidates: ImportableSymbolSearchResult[],
+    stdlibCandidates: ImportableSymbolCandidate[]
+  ): ImportableSymbolCandidate[] {
+    const merged = [...workspaceCandidates, ...stdlibCandidates];
+    const deduped = new Map<string, ImportableSymbolCandidate>();
+
+    for (const candidate of merged) {
+      const key = `${candidate.symbol}:${candidate.modulePath}:${candidate.importKind}`;
+      const existing = deduped.get(key);
+      if (!existing || candidate.score > existing.score) {
+        deduped.set(key, candidate);
+      }
+    }
+
+    return [...deduped.values()].sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      if (a.symbol !== b.symbol) {
+        return a.symbol.localeCompare(b.symbol);
+      }
+      if (a.modulePath !== b.modulePath) {
+        return a.modulePath.localeCompare(b.modulePath);
+      }
+      return a.importKind.localeCompare(b.importKind);
+    });
+  }
+}

--- a/packages/pike-lsp-server/src/services/protocol-mappers.ts
+++ b/packages/pike-lsp-server/src/services/protocol-mappers.ts
@@ -75,6 +75,9 @@ export function toCoreDiagnostic(diagnostic: Diagnostic): CoreDiagnostic {
   if (diagnostic.source !== undefined) {
     coreDiagnostic.source = diagnostic.source;
   }
+  if ('data' in diagnostic) {
+    coreDiagnostic.data = diagnostic.data;
+  }
   if (diagnostic.tags) {
     coreDiagnostic.tags = diagnostic.tags as CoreDiagnosticTag[];
   }
@@ -99,6 +102,9 @@ export function toProtocolDiagnostic(diagnostic: CoreDiagnostic): Diagnostic {
   }
   if (diagnostic.source !== undefined) {
     protocolDiagnostic.source = diagnostic.source;
+  }
+  if (diagnostic.data !== undefined) {
+    protocolDiagnostic.data = diagnostic.data;
   }
   if (diagnostic.tags) {
     protocolDiagnostic.tags = diagnostic.tags as Exclude<Diagnostic['tags'], undefined>;

--- a/packages/pike-lsp-server/src/workspace-index.ts
+++ b/packages/pike-lsp-server/src/workspace-index.ts
@@ -41,6 +41,14 @@ interface SymbolEntry {
   parentName?: string; // WS-001: Parent symbol name for containerName field
 }
 
+export interface ImportableSymbolSearchResult {
+  symbol: string;
+  modulePath: string;
+  importKind: 'import' | 'inherit';
+  score: number;
+  source: 'workspace-index';
+}
+
 /**
  * Error callback type for reporting indexing errors
  */
@@ -296,6 +304,70 @@ export class WorkspaceIndex {
   getDocumentSymbols(uri: string): PikeSymbol[] {
     const symbols = this.documents.get(uri)?.symbols ?? [];
     return symbols.map(symbol => this.toFlattenedSymbolEntry(symbol).symbol);
+  }
+
+  searchImportableSymbols(
+    query: string,
+    options: { excludeUri?: string; limit?: number } = {}
+  ): ImportableSymbolSearchResult[] {
+    const queryLower = query.trim().toLowerCase();
+    if (!queryLower) {
+      return [];
+    }
+
+    const candidates: ImportableSymbolSearchResult[] = [];
+    const seen = new Set<string>();
+    const limit = Math.max(1, options.limit ?? 20);
+
+    for (const [nameLower, entriesByUri] of this.symbolLookup) {
+      if (!nameLower.startsWith(queryLower)) {
+        continue;
+      }
+
+      for (const [uri, entry] of entriesByUri) {
+        if (options.excludeUri && uri === options.excludeUri) {
+          continue;
+        }
+
+        const modulePath = this.uriToModulePath(uri);
+        if (!modulePath) {
+          continue;
+        }
+
+        const importKind: 'import' | 'inherit' = entry.kind === 'class' ? 'inherit' : 'import';
+        const exactBoost = entry.name.toLowerCase() === queryLower ? 120 : 0;
+        const kindBoost = importKind === 'inherit' ? 15 : 5;
+        const score = exactBoost + kindBoost + Math.max(0, 60 - modulePath.length);
+        const dedupeKey = `${entry.name}:${modulePath}:${importKind}`;
+        if (seen.has(dedupeKey)) {
+          continue;
+        }
+        seen.add(dedupeKey);
+
+        candidates.push({
+          symbol: entry.name,
+          modulePath,
+          importKind,
+          score,
+          source: 'workspace-index',
+        });
+      }
+    }
+
+    candidates.sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      if (a.symbol !== b.symbol) {
+        return a.symbol.localeCompare(b.symbol);
+      }
+      if (a.importKind !== b.importKind) {
+        return a.importKind.localeCompare(b.importKind);
+      }
+      return a.modulePath.localeCompare(b.modulePath);
+    });
+
+    return candidates.slice(0, limit);
   }
 
   /**
@@ -877,6 +949,24 @@ export class WorkspaceIndex {
         this.searchCache.delete(cacheKey);
       }
     }
+  }
+
+  private uriToModulePath(uri: string): string | null {
+    const normalizedUri = decodeURIComponent(uri);
+    const withoutScheme = normalizedUri.startsWith('file://')
+      ? normalizedUri.slice('file://'.length)
+      : normalizedUri;
+    const basename = path.basename(withoutScheme);
+    if (!basename) {
+      return null;
+    }
+
+    const dotIndex = basename.lastIndexOf('.');
+    if (dotIndex <= 0) {
+      return basename;
+    }
+
+    return basename.slice(0, dotIndex);
   }
 
   /**


### PR DESCRIPTION
## Summary

Auto-import workflow: code actions to add imports and completion candidates with automatic import insertion.

## Linked Issue

closes #1205

## Changes

- `semantic-analyzer.ts`: Structured unresolved-symbol diagnostics with metadata
- `code-actions.ts`: Add import/inherit quick fixes
- `completion.ts`: Auto-import candidates with additionalTextEdits
- `pike-introspection.ts`: New searchImportableSymbols() method
- `workspace-index.ts`: Importable symbol search support
- 16 scenario tests (8 code actions + 8 completions)
- KB entry documenting pattern

## Knowledge Base

- [x] Added/updated KB entry

## Verification

```bash
bun test src/scenarios/
# 143 pass / 0 fail in changed areas
```

## Checklist

- [x] Code actions for Add import / Add inherit
- [x] Completion auto-import with additionalTextEdits
- [x] 16 scenario tests
- [x] No new regex patterns
- [x] KB entry added