### PR TITLE
perf(#1229): Build overload symbol index for O(1) hover lookups

### DIFF
--- a/packages/pike-lsp-server/src/core/types.ts
+++ b/packages/pike-lsp-server/src/core/types.ts
@@ -200,6 +200,12 @@ export interface DocumentCacheEntry {
   callPositions?: Map<string, CorePosition[]>;
   /** Symbol name index for O(1) lookups: symbol_name -> PikeSymbol */
   symbolNames: Map<string, CoreSymbol>;
+  /**
+   * PERF-1229: Symbol overload index for O(1) lookups of all symbols by name.
+   * Maps symbol name to array of all symbols with that name (including overloads/variants).
+   * This enables O(1) hover lookups for overloaded methods instead of O(n) tree walk.
+   */
+  symbolsByName?: Map<string, CoreSymbol[]>;
   /** Include and import dependencies (optional, populated lazily) */
   dependencies?: DocumentDependencies;
   /** Inheritance information from introspection */

--- a/packages/pike-lsp-server/src/features/diagnostics/index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/index.ts
@@ -57,11 +57,14 @@ export {
 } from './utils.js';
 export {
   buildSymbolNameIndex,
+  buildSymbolsByNameIndex,
   buildSymbolPositionIndex,
   buildSymbolPositionIndexRegex,
   buildCallPositionIndex,
   flattenSymbols,
 } from './symbol-index.js';
+// Import for internal use
+import { buildSymbolsByNameIndex } from './symbol-index.js';
 export {
   classifyChange,
   stripLineComments,
@@ -958,6 +961,8 @@ export function registerDiagnosticsHandlers(
           callPositions,
           // PERF-005: Build symbol name index for O(1) hover lookups
           symbolNames: buildSymbolNameIndex(hierarchicalSymbols),
+          // PERF-1229: Build overload index from flattened symbols for O(1) method hover
+          symbolsByName: buildSymbolsByNameIndex(flatSymbols),
           // INC-002: Store hashes for incremental change detection
           contentHash,
           lineHashes,
@@ -1047,6 +1052,14 @@ export function registerDiagnosticsHandlers(
           return;
         }
 
+        // PERF-1229: Flatten symbols for overload index (if we don't have previous entry's index)
+        const symbolsByName: Map<string, PikeSymbol[]> | undefined =
+          analysisMode === 'typing' && previousEntry?.symbolsByName
+            ? previousEntry.symbolsByName
+            : symbolsWithDeprecated.length > 0
+              ? buildSymbolsByNameIndex(flattenSymbols(symbolsWithDeprecated))
+              : undefined;
+
         const cacheEntry: DocumentCacheEntry = {
           version,
           symbols: symbolsWithDeprecated,
@@ -1058,6 +1071,8 @@ export function registerDiagnosticsHandlers(
             analysisMode === 'typing' && previousEntry?.symbolNames
               ? previousEntry.symbolNames
               : buildSymbolNameIndex(symbolsWithDeprecated),
+          // PERF-1229: Build overload index from flattened symbols for O(1) method hover
+          symbolsByName,
           // INC-002: Store hashes for incremental change detection
           contentHash,
           lineHashes,

--- a/packages/pike-lsp-server/src/features/diagnostics/symbol-index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/symbol-index.ts
@@ -30,6 +30,31 @@ export function buildSymbolNameIndex(symbols: PikeSymbol[]): Map<string, PikeSym
 }
 
 /**
+ * PERF-1229: Build overload index for O(1) lookups of all symbols by name.
+ * Maps symbol name to array of ALL symbols with that name (including overloads/variants).
+ * This eliminates the need for recursive tree walks in hover to find method overloads.
+ *
+ * @param symbols - Array of symbols (typically flattened) to index
+ * @returns Map from symbol name to array of all symbols with that name
+ */
+export function buildSymbolsByNameIndex(symbols: PikeSymbol[]): Map<string, PikeSymbol[]> {
+  const index = new Map<string, PikeSymbol[]>();
+
+  for (const symbol of symbols) {
+    if (!symbol.name) continue;
+
+    const existing = index.get(symbol.name);
+    if (existing) {
+      existing.push(symbol);
+    } else {
+      index.set(symbol.name, [symbol]);
+    }
+  }
+
+  return index;
+}
+
+/**
  * Recursively index symbols into the map.
  * @param symbols - Array of symbols to index
  * @param index - Map to populate

--- a/packages/pike-lsp-server/src/features/navigation/hover.ts
+++ b/packages/pike-lsp-server/src/features/navigation/hover.ts
@@ -142,9 +142,11 @@ export function registerHoverHandler(
       }
 
       if (symbol.kind === 'method') {
-        const overloadCandidates = collectSymbolsByName(cached.symbols, symbol.name).filter(
-          s => s.kind === 'method'
-        );
+        // PERF-1229: Use pre-built symbolsByName index for O(1) overload lookup instead of O(n) recursive walk
+        const overloadCandidates =
+          cached.symbolsByName?.get(symbol.name)?.filter(s => s.kind === 'method') ??
+          // Fallback to recursive walk if index not available (shouldn't happen after validation)
+          collectSymbolsByName(cached.symbols, symbol.name).filter(s => s.kind === 'method');
 
         if (overloadCandidates.length > 0) {
           const mainSymbol = overloadCandidates.find(


### PR DESCRIPTION
## Summary

Adds a pre-built `symbolsByName` index (`Map<string, PikeSymbol[]>`) to `DocumentCacheEntry`, enabling O(1) overload/variant lookups in the hover handler instead of the previous O(n) recursive tree walk via `collectSymbolsByName()`.

## Changes

- **`core/types.ts`**: Added `symbolsByName?: Map<string, CoreSymbol[]>` field to `DocumentCacheEntry`
- **`diagnostics/symbol-index.ts`**: Added `buildSymbolsByNameIndex()` function that maps symbol names to arrays of all symbols with that name
- **`diagnostics/index.ts`**: Populates `symbolsByName` from flattened symbols in both cache entry build paths (introspection success + parse fallback)
- **`navigation/hover.ts`**: Uses `cached.symbolsByName` for O(1) overload lookup with fallback to recursive walk

## Performance Impact

Before: `collectSymbolsByName()` recursively walks the entire symbol tree on every method hover — O(n) where n is total symbols.

After: Single `Map.get()` lookup — O(1). The index is built once during validation and reused.

## Testing

- All 3783 existing tests pass
- Pre-commit hooks pass (formatting, fast regression, scenario tests, quality gate)

Refs: #1229