### PR TITLE
fix(lint): prefer-const error in call-context-resolver.ts

### DIFF
--- a/packages/pike-lsp-server/src/features/navigation/call-context-resolver.ts
+++ b/packages/pike-lsp-server/src/features/navigation/call-context-resolver.ts
@@ -157,7 +157,7 @@ function skipWhitespaceLeft(text: string, index: number): number {
 }
 
 function resolveTargetAtParen(text: string, openParen: number): ResolvedCallTarget | null {
-  let i = skipWhitespaceLeft(text, openParen - 1);
+  const i = skipWhitespaceLeft(text, openParen - 1);
   if (i < 0 || !isIdentifierChar(text[i])) {
     return null;
   }


### PR DESCRIPTION
## Summary
Fixes a lint error where a `let` variable was never reassigned and should be `const`.

## Linked Issue
No linked issue - this is a direct lint fix found during routine repository maintenance.

## Root Cause
The variable `i` in `resolveTargetAtParen()` was declared with `let` but never reassigned, triggering the `prefer-const` ESLint rule.

## Changes
- `packages/pike-lsp-server/src/features/navigation/call-context-resolver.ts`: Changed `let i` to `const i` on line 160

## Verification
```bash
bun run lint
# No prefer-const errors in packages/pike-lsp-server/src/features/navigation/call-context-resolver.ts
```

## Checklist
- [x] Code compiles without errors (`bun run build`)
- [x] Lint passes for the changed file
- [x] Change is minimal and focused
- [x] No functional changes - only lint fix