### PR TITLE
feat(#1255): migrate hover & signature-help to resilient query-engine pattern

### DIFF
--- a/packages/pike-bridge/src/query-engine-hover-signature-resilience.test.ts
+++ b/packages/pike-bridge/src/query-engine-hover-signature-resilience.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeAll, describe, it } from 'bun:test';
+import assert from 'node:assert/strict';
+import { PikeBridge } from './bridge.js';
+
+describe('Query engine parse-under-edit resilience (hover, signature-help)', () => {
+  let bridge: PikeBridge;
+
+  beforeAll(async () => {
+    bridge = new PikeBridge();
+    const available = await bridge.checkPike();
+    if (!available) {
+      throw new Error('Pike executable not found. Parse-under-edit tests require Pike.');
+    }
+    await bridge.start();
+  });
+
+  afterAll(async () => {
+    await bridge.stop();
+  });
+
+  it('keeps hover query path alive for broken intermediate edits', async () => {
+    const uri = 'file:///tmp/qe2-hover-edit.pike';
+    const filename = '/tmp/qe2-hover-edit.pike';
+    const texts = [
+      'int stable = 1;\n',
+      'int stable = ;\n',
+      'class C {\n  int x\n',
+      'class C {\n  int x = 1;\n  void run() {\n    if (x\n  }\n}\n',
+      'int repaired = 2;\n',
+    ];
+
+    const opened = await bridge.engineOpenDocument({
+      uri,
+      languageId: 'pike',
+      version: 1,
+      text: texts[0] ?? '',
+    });
+    assert.ok(typeof opened.snapshotId === 'string' && opened.snapshotId.length > 0);
+
+    for (let i = 0; i < texts.length; i++) {
+      const text = texts[i] ?? '';
+      const version = i + 2;
+
+      const changed = await bridge.engineChangeDocument({
+        uri,
+        version,
+        changes: [{ text }],
+      });
+
+      assert.ok(typeof changed.snapshotId === 'string' && changed.snapshotId.length > 0);
+
+      // Hover query should never hard-fail, even on malformed text
+      const hoverResult = await bridge.engineQuery({
+        feature: 'hover',
+        requestId: `qe2-hover-edit-${version}`,
+        snapshot: { mode: 'latest' },
+        queryParams: {
+          uri,
+          filename,
+          version,
+          text,
+          position: { line: 0, character: 1 },
+          word: 'stable',
+        },
+      });
+
+      assert.ok(
+        typeof hoverResult.snapshotIdUsed === 'string' && hoverResult.snapshotIdUsed.length > 0
+      );
+      assert.ok(typeof hoverResult.metrics?.durationMs === 'number');
+
+      // The result must be a structured response (not a thrown error).
+      // It may contain a hover object or be empty — both are valid for broken text.
+      const rawResult = hoverResult.result;
+      assert.ok(typeof rawResult === 'object' && rawResult !== null);
+    }
+  });
+
+  it('keeps signature-help query path alive for broken intermediate edits', async () => {
+    const uri = 'file:///tmp/qe2-sigedit.pike';
+    const filename = '/tmp/qe2-sigedit.pike';
+    const texts = [
+      'int x = abs(1);\n',
+      'int x = abs(\n',
+      'int x = abs(,\n',
+      'class C {\n  void run() {\n    write(\n  }\n}\n',
+      'int repaired = abs(42);\n',
+    ];
+
+    const opened = await bridge.engineOpenDocument({
+      uri,
+      languageId: 'pike',
+      version: 1,
+      text: texts[0] ?? '',
+    });
+    assert.ok(typeof opened.snapshotId === 'string' && opened.snapshotId.length > 0);
+
+    for (let i = 0; i < texts.length; i++) {
+      const text = texts[i] ?? '';
+      const version = i + 2;
+
+      const changed = await bridge.engineChangeDocument({
+        uri,
+        version,
+        changes: [{ text }],
+      });
+
+      assert.ok(typeof changed.snapshotId === 'string' && changed.snapshotId.length > 0);
+
+      // Signature-help query should never hard-fail, even on malformed text
+      const sigResult = await bridge.engineQuery({
+        feature: 'signatureHelp',
+        requestId: `qe2-sigedit-${version}`,
+        snapshot: { mode: 'latest' },
+        queryParams: {
+          uri,
+          filename,
+          version,
+          text,
+          position: { line: 0, character: text.indexOf('(') + 1 || 1 },
+          offset: text.indexOf('(') + 1 || 1,
+        },
+      });
+
+      assert.ok(
+        typeof sigResult.snapshotIdUsed === 'string' && sigResult.snapshotIdUsed.length > 0
+      );
+      assert.ok(typeof sigResult.metrics?.durationMs === 'number');
+
+      // The result must be a structured response (not a thrown error).
+      const rawResult = sigResult.result;
+      assert.ok(typeof rawResult === 'object' && rawResult !== null);
+    }
+  });
+});

--- a/packages/pike-lsp-server/src/features/editing/signature-help.ts
+++ b/packages/pike-lsp-server/src/features/editing/signature-help.ts
@@ -24,8 +24,72 @@ import type { Services } from '../../services/index.js';
 import { formatPikeType } from '../utils/pike-type-formatter.js';
 import { uriToFsPath } from '../../utils/uri-path.js';
 import { resolveCallContextAtOffset } from '../navigation/call-context-resolver.js';
-import { RequestScheduler } from '../../services/request-scheduler.js';
+import { RequestScheduler, RequestSupersededError } from '../../services/request-scheduler.js';
 import { toSchedulerMetricsLogPayload } from '../utils/scheduler-metrics.js';
+
+const useQueryEngineSignatureHelp = process.env['PIKE_LSP_QE2_SIGNATURE_HELP'] !== '0';
+const inFlightSignatureHelpRequests = new Map<string, string>();
+const signatureHelpRequestSequence = new Map<string, number>();
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Parse a SignatureHelp object from query engine response.
+ * Handles both structured and minimally-shaped responses.
+ */
+function parseSignatureHelpResponse(raw: Record<string, unknown>): SignatureHelp | null {
+  try {
+    const signatures = raw['signatures'];
+    if (!Array.isArray(signatures) || signatures.length === 0) {
+      return null;
+    }
+
+    const parsed: SignatureInformation[] = [];
+    for (const sig of signatures) {
+      if (!sig || typeof sig !== 'object') continue;
+      const s = sig as Record<string, unknown>;
+      if (typeof s['label'] !== 'string') continue;
+
+      const parameters = Array.isArray(s['parameters'])
+        ? (s['parameters'] as Array<Record<string, unknown>>).map(p => {
+            if (typeof p['label'] === 'string') {
+              return { label: p['label'] as string };
+            }
+            if (Array.isArray(p['label']) && p['label'].length === 2) {
+              return { label: p['label'] as [number, number] };
+            }
+            return { label: '' };
+          })
+        : [];
+
+      const info: SignatureInformation = {
+        label: s['label'] as string,
+        parameters,
+      };
+      if (typeof s['documentation'] === 'string') {
+        info.documentation = s['documentation'];
+      }
+      parsed.push(info);
+    }
+
+    if (parsed.length === 0) return null;
+
+    return {
+      signatures: parsed,
+      activeSignature:
+        typeof raw['activeSignature'] === 'number' ? (raw['activeSignature'] as number) : 0,
+      activeParameter:
+        typeof raw['activeParameter'] === 'number' ? (raw['activeParameter'] as number) : 0,
+    };
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Register signature help handler.
@@ -199,6 +263,119 @@ export function registerSignatureHelpHandler(
     const funcName = callContext.target.name;
     const paramIndex = callContext.activeParameter;
 
+    // KB-1248: Try query engine signature-help path with snapshot isolation
+    if (useQueryEngineSignatureHelp) {
+      const bridge = services.bridge;
+      if (bridge?.isRunning?.()) {
+        const nextSequence = (signatureHelpRequestSequence.get(uri) ?? 0) + 1;
+        signatureHelpRequestSequence.set(uri, nextSequence);
+        const requestId = `signatureHelp:${uri}:${document.version ?? 0}:${Date.now()}:${nextSequence}`;
+        const filename = decodeURIComponent(uri.replace(/^file:\/\//, ''));
+
+        let cancelledByToken = false;
+        const cancellationDisposable = cancellationToken?.onCancellationRequested(() => {
+          cancelledByToken = true;
+          void bridge.engineCancelRequest({ requestId }).catch(error => {
+            logger.warn('Signature help cancellation request failed', {
+              uri,
+              requestId,
+              error,
+            });
+          });
+        });
+
+        const clearInFlight = (): void => {
+          if (inFlightSignatureHelpRequests.get(uri) === requestId) {
+            inFlightSignatureHelpRequests.delete(uri);
+          }
+        };
+
+        try {
+          const qeSignatureResult = await signatureHelpScheduler.schedule<SignatureHelp | null>({
+            requestClass: 'interactive',
+            key: `signatureHelp:${uri}`,
+            run: async checkpoint => {
+              checkpoint();
+              if (cancelledByToken || cancellationToken?.isCancellationRequested) {
+                throw new RequestSupersededError('Signature help request cancelled by LSP token');
+              }
+
+              // Cancel previous in-flight request for same URI
+              const previousRequestId = inFlightSignatureHelpRequests.get(uri);
+              if (previousRequestId && previousRequestId !== requestId) {
+                try {
+                  await bridge.engineCancelRequest({ requestId: previousRequestId });
+                } catch (err) {
+                  logger.debug('Signature help cancellation for superseded request failed', {
+                    uri,
+                    requestId: previousRequestId,
+                    error: err instanceof Error ? err.message : String(err),
+                  });
+                }
+              }
+              inFlightSignatureHelpRequests.set(uri, requestId);
+
+              const snapshotId = services.documentSnapshots?.get(uri);
+              const qeResponse = await bridge.engineQuery({
+                feature: 'signatureHelp',
+                requestId,
+                snapshot: snapshotId ? { mode: 'fixed', snapshotId } : { mode: 'latest' },
+                queryParams: {
+                  uri,
+                  filename,
+                  position: params.position,
+                  text,
+                  offset,
+                },
+              });
+              checkpoint();
+
+              if (cancelledByToken || cancellationToken?.isCancellationRequested) {
+                throw new RequestSupersededError('Signature help request cancelled by LSP token');
+              }
+
+              // Parse direct signature help result
+              const directSig = asRecord(qeResponse.result['signatureHelp']);
+              if (directSig) {
+                return parseSignatureHelpResponse(directSig);
+              }
+
+              // Parse nested result
+              const nested = asRecord(qeResponse.result['result']);
+              if (nested && nested['status'] !== 'stub') {
+                const nestedSig = asRecord(nested['signatureHelp']);
+                if (nestedSig) {
+                  return parseSignatureHelpResponse(nestedSig);
+                }
+              }
+
+              return null;
+            },
+          });
+
+          clearInFlight();
+          cancellationDisposable?.dispose();
+          if (qeSignatureResult) {
+            maybeLogSignatureHelpSchedulerMetrics(uri, 'qe_success');
+            return qeSignatureResult;
+          }
+        } catch (err) {
+          clearInFlight();
+          cancellationDisposable?.dispose();
+          if (err instanceof RequestSupersededError) {
+            maybeLogSignatureHelpSchedulerMetrics(uri, 'superseded');
+            return null;
+          }
+          maybeLogSignatureHelpSchedulerMetrics(uri, 'qe_fallback');
+          logger.debug('Signature help query engine fallback', {
+            uri,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }
+
+    // Fallback: local signature resolution
     // KB-1248: Find function symbol with resilience wrapper
     let funcSymbol: PikeSymbol | null = null;
 

--- a/packages/pike-lsp-server/src/features/navigation/hover.ts
+++ b/packages/pike-lsp-server/src/features/navigation/hover.ts
@@ -21,8 +21,19 @@ import { getWordRangeAtPosition } from '../utils/pike-identifier.js';
 import { Logger } from '@pike-lsp/core';
 import { getKeywordInfo, getMacroInfo } from './keywords.js';
 import { LRUCache } from '../../utils/lru-cache.js';
-import { RequestScheduler } from '../../services/request-scheduler.js';
+import { RequestScheduler, RequestSupersededError } from '../../services/request-scheduler.js';
 import { toSchedulerMetricsLogPayload } from '../utils/scheduler-metrics.js';
+
+const useQueryEngineHover = process.env['PIKE_LSP_QE2_HOVER'] !== '0';
+const inFlightHoverRequests = new Map<string, string>();
+const hoverRequestSequence = new Map<string, number>();
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
 
 /**
  * Generate cache key from hover request parameters.
@@ -126,6 +137,40 @@ export function registerHoverHandler(
   }
 
   /**
+   * Parse a Hover object from query engine response.
+   */
+  function parseHoverResponse(raw: Record<string, unknown>): Hover | null {
+    const contents = raw['contents'];
+    if (!contents) {
+      return null;
+    }
+
+    // Structured contents: { kind, value }
+    if (typeof contents === 'object' && contents !== null) {
+      const c = contents as Record<string, unknown>;
+      if (typeof c['kind'] === 'string' && typeof c['value'] === 'string') {
+        return {
+          contents: {
+            kind: c['kind'] as (typeof MarkupKind)[keyof typeof MarkupKind],
+            value: c['value'],
+          },
+          range: raw['range'] ?? undefined,
+        } as Hover;
+      }
+    }
+
+    // Plain text contents
+    if (typeof contents === 'string') {
+      return {
+        contents: { kind: MarkupKind.PlainText, value: contents },
+        range: raw['range'] ?? undefined,
+      } as Hover;
+    }
+
+    return null;
+  }
+
+  /**
    * Hover handler - show type info and documentation
    * KB-1248: Parse-under-edit resilience with snapshot-based queries
    */
@@ -199,15 +244,126 @@ export function registerHoverHandler(
       }
     }
 
-    // 1. Try to find symbol in local document (O(1) lookup using symbolNames index)
-    // Only do symbol lookup if we don't have a keyword/macro result
+    // 1. Try query engine hover path with snapshot isolation
+    if (!hoverResult && useQueryEngineHover) {
+      const bridge = services.bridge;
+      if (bridge?.isRunning?.()) {
+        const nextSequence = (hoverRequestSequence.get(uri) ?? 0) + 1;
+        hoverRequestSequence.set(uri, nextSequence);
+        const requestId = `hover:${uri}:${document.version ?? 0}:${Date.now()}:${nextSequence}`;
+        const filename = decodeURIComponent(uri.replace(/^file:\/\//, ''));
+
+        let cancelledByToken = false;
+        const cancellationDisposable = cancellationToken?.onCancellationRequested(() => {
+          cancelledByToken = true;
+          void bridge.engineCancelRequest({ requestId }).catch(error => {
+            log.warn('Hover cancellation request failed', {
+              uri,
+              requestId,
+              error,
+            });
+          });
+        });
+
+        const clearInFlight = (): void => {
+          if (inFlightHoverRequests.get(uri) === requestId) {
+            inFlightHoverRequests.delete(uri);
+          }
+        };
+
+        try {
+          const qeHoverResult = await hoverScheduler.schedule<Hover | null>({
+            requestClass: 'interactive',
+            key: `hover:${uri}`,
+            run: async checkpoint => {
+              checkpoint();
+              if (cancelledByToken || cancellationToken?.isCancellationRequested) {
+                throw new RequestSupersededError('Hover request cancelled by LSP token');
+              }
+
+              // Cancel previous in-flight request for same URI
+              const previousRequestId = inFlightHoverRequests.get(uri);
+              if (previousRequestId && previousRequestId !== requestId) {
+                try {
+                  await bridge.engineCancelRequest({ requestId: previousRequestId });
+                } catch (err) {
+                  log.debug('Hover query cancellation for superseded request failed', {
+                    uri,
+                    requestId: previousRequestId,
+                    error: err instanceof Error ? err.message : String(err),
+                  });
+                }
+              }
+              inFlightHoverRequests.set(uri, requestId);
+
+              const snapshotId = services.documentSnapshots?.get(uri);
+              const qeResponse = await bridge.engineQuery({
+                feature: 'hover',
+                requestId,
+                snapshot: snapshotId ? { mode: 'fixed', snapshotId } : { mode: 'latest' },
+                queryParams: {
+                  uri,
+                  filename,
+                  position: params.position,
+                  word,
+                },
+              });
+              checkpoint();
+
+              if (cancelledByToken || cancellationToken?.isCancellationRequested) {
+                throw new RequestSupersededError('Hover request cancelled by LSP token');
+              }
+
+              // Parse direct hover result
+              const directHover = asRecord(qeResponse.result['hover']);
+              if (directHover) {
+                return parseHoverResponse(directHover);
+              }
+
+              // Parse nested result
+              const nested = asRecord(qeResponse.result['result']);
+              if (nested && nested['status'] !== 'stub') {
+                const nestedHover = asRecord(nested['hover']);
+                if (nestedHover) {
+                  return parseHoverResponse(nestedHover);
+                }
+              }
+
+              return null;
+            },
+          });
+
+          clearInFlight();
+          cancellationDisposable?.dispose();
+          if (qeHoverResult) {
+            hoverResult = qeHoverResult;
+            maybeLogHoverSchedulerMetrics(uri, 'qe_success');
+          }
+        } catch (err) {
+          clearInFlight();
+          cancellationDisposable?.dispose();
+          if (err instanceof RequestSupersededError) {
+            maybeLogHoverSchedulerMetrics(uri, 'superseded');
+            return null;
+          }
+          maybeLogHoverSchedulerMetrics(uri, 'qe_fallback');
+          log.debug('Hover query engine fallback', {
+            uri,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }
+
+    // 2. Fallback: try to find symbol in local document (O(1) lookup using symbolNames index)
+    // Only do symbol lookup if we don't have a keyword/macro/query-engine result
     let symbol: PikeSymbol | null = null;
     let parentScope: string | undefined;
 
     if (!hoverResult) {
       symbol = cached.symbolNames?.get(word) ?? null;
 
-      // 1a. For variables, check for scope-aware type with parse-under-edit resilience
+      // 2a. For variables, check for scope-aware type with parse-under-edit resilience
       if (symbol && symbol.kind === 'variable' && services.bridge?.bridge) {
         try {
           const text = document.getText();
@@ -239,9 +395,9 @@ export function registerHoverHandler(
       }
     }
 
-    // 2. If not found, try to find in stdlib
+    // 3. If not found, try to find in stdlib
     let isStdlib = false;
-    if (!symbol && stdlibIndex) {
+    if (!hoverResult && !symbol && stdlibIndex) {
       // Check if it's a known module
       try {
         const moduleInfo = await stdlibIndex.getModule(word);
@@ -297,7 +453,7 @@ export function registerHoverHandler(
       }
     }
 
-    // Build hover content if not already set (keyword/macro case)
+    // Build hover content if not already set (keyword/macro/query-engine case)
     if (!hoverResult && symbol) {
       const content = buildHoverContent(symbol, parentScope);
       if (!content) {


### PR DESCRIPTION
Addresses #1255

Migrates hover and signature-help to the resilient query-engine pattern with try-catch wrappers, CancellationToken support, and graceful fallbacks. Includes resilience tests for rapid edit sequences.

## Changes

### hover.ts
- Add engineQuery path with snapshot isolation via `RequestScheduler.schedule()`
- CancellationToken triggers `engineCancelRequest` for in-flight engine queries
- `RequestSupersededError` handling returns null gracefully
- In-flight request tracking with auto-cancellation of superseded requests
- Existing local computation (symbol lookup, getTypeAtPosition, stdlib) remains as fallback
- Feature flag: `PIKE_LSP_QE2_HOVER` (default: enabled)

### signature-help.ts
- Add engineQuery path with same resilience pattern
- `parseSignatureHelpResponse` helper parses engine response into LSP SignatureHelp
- In-flight request tracking and cancellation
- Existing call-context resolution and symbol lookup remain as fallback
- Feature flag: `PIKE_LSP_QE2_SIGNATURE_HELP` (default: enabled)

### query-engine-hover-signature-resilience.test.ts (new)
- Hover resilience test: rapid edits with broken syntax (missing semicolons, incomplete classes)
- Signature-help resilience test: broken intermediate call expressions
- Both verify the engine never hard-fails and returns structured responses

## Pattern
Follows the exact same pattern as the already-migrated completion handler (`useQueryEngineCompletions`):
1. Check feature flag and bridge availability
2. Generate requestId with version + sequence
3. Set up CancellationToken disposal with engineCancelRequest
4. Wrap in RequestScheduler.schedule() for deduplication
5. engineQuery with snapshot isolation
6. Parse response (direct + nested formats)
7. On failure: fall through to existing local computation

## Verification
- `npx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json` passes cleanly