### PR TITLE
feat(#1258): migrate code-actions to resilient query-engine pattern

### DIFF
--- a/packages/pike-lsp-server/src/features/advanced/code-actions.ts
+++ b/packages/pike-lsp-server/src/features/advanced/code-actions.ts
@@ -25,7 +25,7 @@ import type { Services } from '../../services/index.js';
 import { Logger } from '@pike-lsp/core';
 import { getGenerateGetterSetterActions } from './getters-setters.js';
 import { getExtractMethodAction } from './extract-method.js';
-import { RequestScheduler } from '../../services/request-scheduler.js';
+import { RequestScheduler, RequestSupersededError } from '../../services/request-scheduler.js';
 import { toSchedulerMetricsLogPayload } from '../utils/scheduler-metrics.js';
 
 interface ImportCandidate {
@@ -192,7 +192,8 @@ export function registerCodeActionsHandler(
 
   /**
    * Code Action handler - provide quick fixes and refactorings
-   * KB-1248: Parse-under-edit resilience with graceful error handling
+   * KB-1248: Parse-under-edit resilience with scheduler-based execution,
+   * cancellation support, and graceful error handling.
    */
   connection.onCodeAction(
     async (params: CodeActionParams, cancellationToken): Promise<CodeAction[]> => {
@@ -203,15 +204,15 @@ export function registerCodeActionsHandler(
         return [];
       }
 
+      const uri = params.textDocument.uri;
+
+      // CA-006, CA-007: Validate URI
+      if (!uri || typeof uri !== 'string' || uri.length === 0) {
+        log.warn('Invalid URI in code action request', { uri });
+        return [];
+      }
+
       try {
-        const uri = params.textDocument.uri;
-
-        // CA-006, CA-007: Validate URI
-        if (!uri || typeof uri !== 'string' || uri.length === 0) {
-          log.warn('Invalid URI in code action request', { uri });
-          return [];
-        }
-
         const document = documents.get(uri);
         const cached = documentCache.get(uri);
 
@@ -224,296 +225,321 @@ export function registerCodeActionsHandler(
           return [];
         }
 
-        // Filter by context.only if client specified kinds
-        const onlyKinds = params.context.only;
-        const filterByKind = onlyKinds && onlyKinds.length > 0;
+        // KB-1248: Schedule through RequestScheduler for cancellation and supersession
+        const actions = await codeActionsScheduler.schedule<CodeAction[]>({
+          requestClass: 'interactive',
+          key: `code-action:${uri}`,
+          run: async checkpoint => {
+            checkpoint();
 
-        /**
-         * Check if a CodeAction kind matches the filter.
-         * Supports hierarchical matching: 'refactor' matches 'refactor.extract' and 'refactor.rewrite'.
-         */
-        const matchesFilter = (kind: string): boolean => {
-          if (!filterByKind) return true;
-          return onlyKinds.some(only => {
-            // Exact match OR kind is a sub-kind of only (e.g., refactor.rewrite is a sub-kind of refactor)
-            return kind === only || kind.startsWith(only + '.');
-          });
-        };
-
-        const actions: CodeAction[] = [];
-        const text = document.getText();
-        const lines = text.split('\n');
-
-        // CA-008, CA-009: Validate and clamp range bounds
-        const startLine = params.range.start.line;
-        if (startLine < 0 || startLine >= lines.length) {
-          log.debug('Range start line out of bounds, clamping', {
-            startLine,
-            maxLine: lines.length - 1,
-          });
-          // Continue - will just return empty actions if nothing matches
-        }
-        // Organize Imports - only if filter allows
-        if (matchesFilter(CodeActionKind.SourceOrganizeImports)) {
-          const removeUnused = services.globalSettings.organizeImports?.removeUnused ?? true;
-          const importLines: { line: number; text: string; type: string; moduleName?: string }[] =
-            [];
-          for (let i = 0; i < lines.length; i++) {
-            const lt = (lines[i] ?? '').trim();
-            if (lt.startsWith('inherit ')) {
-              const match = lt.match(/^inherit\s+([A-Za-z_][A-Za-z0-9_]*)/);
-              const entry: { line: number; text: string; type: string; moduleName?: string } = {
-                line: i,
-                text: lines[i] ?? '',
-                type: 'inherit',
-              };
-              if (match?.[1]) entry.moduleName = match[1];
-              importLines.push(entry);
-            } else if (lt.startsWith('import ')) {
-              const match = lt.match(
-                /^import\s+([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)/
-              );
-              const entry: { line: number; text: string; type: string; moduleName?: string } = {
-                line: i,
-                text: lines[i] ?? '',
-                type: 'import',
-              };
-              if (match?.[1]) entry.moduleName = match[1];
-              importLines.push(entry);
-            } else if (lt.startsWith('#include ')) {
-              importLines.push({ line: i, text: lines[i] ?? '', type: 'include' });
-            }
-          }
-
-          const unusedImports = new Set<number>();
-          if (removeUnused) {
-            const importModuleNames = importLines
-              .filter(imp => imp.moduleName !== undefined)
-              .map(imp => imp.moduleName as string);
-
-            if (importModuleNames.length > 0) {
-              // Get code after the last import line to find actual symbol references
-              const lastImportLine = importLines[importLines.length - 1]!.line;
-              const codeOnlyLines = lines.slice(lastImportLine + 1).join('\n');
-              const allReferences = codeOnlyLines.match(/\b([A-Z][A-Za-z0-9_]*)\b/g) || [];
-              const referenceSet = new Set(allReferences);
-
-              for (const imp of importLines) {
-                const moduleName = imp.moduleName;
-                if (moduleName !== undefined && !referenceSet.has(moduleName)) {
-                  unusedImports.add(imp.line);
-                }
-              }
-            }
-          }
-
-          const usedImportLines = importLines.filter(imp => !unusedImports.has(imp.line));
-
-          if (importLines.length > 1 || unusedImports.size > 0) {
-            const sorted = [...usedImportLines].sort((a, b) => {
-              const typeOrder = { include: 0, import: 1, inherit: 2 };
-              const typeA = typeOrder[a.type as keyof typeof typeOrder] ?? 3;
-              const typeB = typeOrder[b.type as keyof typeof typeOrder] ?? 3;
-              if (typeA !== typeB) return typeA - typeB;
-              return a.text.localeCompare(b.text);
-            });
-
-            const needsSort = importLines.some((item, i) => item.text !== sorted[i]?.text);
-            const hasRemovals = unusedImports.size > 0;
-
-            if (needsSort || hasRemovals) {
-              const edits: TextEdit[] = [];
-
-              for (const unusedLine of unusedImports) {
-                const imp = importLines.find(i => i.line === unusedLine);
-                if (imp) {
-                  edits.push({
-                    range: {
-                      start: { line: imp.line, character: 0 },
-                      end: { line: imp.line, character: imp.text.length },
-                    },
-                    newText: '',
-                  });
-                }
-              }
-
-              for (let i = 0; i < usedImportLines.length; i++) {
-                const original = usedImportLines[i];
-                const replacement = sorted[i];
-                if (original && replacement && original.text !== replacement.text) {
-                  edits.push({
-                    range: {
-                      start: { line: original.line, character: 0 },
-                      end: { line: original.line, character: original.text.length },
-                    },
-                    newText: replacement.text,
-                  });
-                }
-              }
-
-              if (edits.length > 0) {
-                actions.push({
-                  title: 'Organize Imports',
-                  kind: CodeActionKind.SourceOrganizeImports,
-                  edit: {
-                    changes: {
-                      [uri]: edits,
-                    },
-                  },
-                });
-              }
-            }
-          }
-        }
-
-        // CA-010: Handle missing or empty diagnostics gracefully
-        const diagnostics = params.context.diagnostics ?? [];
-        if (!Array.isArray(diagnostics)) {
-          log.warn('Invalid diagnostics array in code action request');
-          return [];
-        }
-
-        // Quick Fixes - only if filter allows
-        if (matchesFilter(CodeActionKind.QuickFix)) {
-          for (const diag of diagnostics) {
-            if (diag.code !== 'undefined-symbol.unresolved-import') {
-              continue;
-            }
-
-            const unresolvedData = toUnresolvedDiagnosticData(diag.data);
-            if (!unresolvedData?.symbol) {
-              continue;
-            }
-
-            let candidates = unresolvedData.importCandidates ?? [];
-            if (candidates.length === 0 && services.pikeIntrospection) {
-              // KB-1248: Use resilient introspection call
-              candidates = await searchImportableSymbolsResilient(
-                unresolvedData.symbol,
-                {
-                  excludeUri: uri,
-                  limit: 8,
-                },
-                cancellationToken
-              );
-            }
-
-            // KB-1248: Check cancellation before processing candidates
             if (cancellationToken?.isCancellationRequested) {
-              continue;
+              throw new RequestSupersededError('Code action request cancelled');
             }
 
-            const sortedCandidates = sortImportCandidates(candidates);
-            const insertionLine = getImportInsertionLine(lines);
+            // Filter by context.only if client specified kinds
+            const onlyKinds = params.context.only;
+            const filterByKind = onlyKinds && onlyKinds.length > 0;
 
-            for (const candidate of sortedCandidates) {
-              if (hasImportStatement(lines, candidate)) {
-                continue;
+            /**
+             * Check if a CodeAction kind matches the filter.
+             * Supports hierarchical matching: 'refactor' matches 'refactor.extract' and 'refactor.rewrite'.
+             */
+            const matchesFilter = (kind: string): boolean => {
+              if (!filterByKind) return true;
+              return onlyKinds.some(only => {
+                // Exact match OR kind is a sub-kind of only (e.g., refactor.rewrite is a sub-kind of refactor)
+                return kind === only || kind.startsWith(only + '.');
+              });
+            };
+
+            const result: CodeAction[] = [];
+            const text = document.getText();
+            const lines = text.split('\n');
+
+            // CA-008, CA-009: Validate and clamp range bounds
+            const startLine = params.range.start.line;
+            if (startLine < 0 || startLine >= lines.length) {
+              log.debug('Range start line out of bounds, clamping', {
+                startLine,
+                maxLine: lines.length - 1,
+              });
+              // Continue - will just return empty actions if nothing matches
+            }
+
+            // Organize Imports - only if filter allows
+            if (matchesFilter(CodeActionKind.SourceOrganizeImports)) {
+              const removeUnused = services.globalSettings.organizeImports?.removeUnused ?? true;
+              const importLines: {
+                line: number;
+                text: string;
+                type: string;
+                moduleName?: string;
+              }[] = [];
+              for (let i = 0; i < lines.length; i++) {
+                const lt = (lines[i] ?? '').trim();
+                if (lt.startsWith('inherit ')) {
+                  const match = lt.match(/^inherit\s+([A-Za-z_][A-Za-z0-9_]*)/);
+                  const entry: { line: number; text: string; type: string; moduleName?: string } = {
+                    line: i,
+                    text: lines[i] ?? '',
+                    type: 'inherit',
+                  };
+                  if (match?.[1]) entry.moduleName = match[1];
+                  importLines.push(entry);
+                } else if (lt.startsWith('import ')) {
+                  const match = lt.match(
+                    /^import\s+([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)/
+                  );
+                  const entry: { line: number; text: string; type: string; moduleName?: string } = {
+                    line: i,
+                    text: lines[i] ?? '',
+                    type: 'import',
+                  };
+                  if (match?.[1]) entry.moduleName = match[1];
+                  importLines.push(entry);
+                } else if (lt.startsWith('#include ')) {
+                  importLines.push({ line: i, text: lines[i] ?? '', type: 'include' });
+                }
               }
 
-              const statement = buildImportStatement(candidate);
-              const verb = candidate.importKind === 'inherit' ? 'inherit' : 'import';
-              actions.push({
-                title: `Add ${verb} for ${unresolvedData.symbol} from ${candidate.modulePath}`,
-                kind: CodeActionKind.QuickFix,
-                diagnostics: [diag],
-                edit: {
-                  changes: {
-                    [uri]: [
-                      {
+              const unusedImports = new Set<number>();
+              if (removeUnused) {
+                const importModuleNames = importLines
+                  .filter(imp => imp.moduleName !== undefined)
+                  .map(imp => imp.moduleName as string);
+
+                if (importModuleNames.length > 0) {
+                  // Get code after the last import line to find actual symbol references
+                  const lastImportLine = importLines[importLines.length - 1]!.line;
+                  const codeOnlyLines = lines.slice(lastImportLine + 1).join('\n');
+                  const allReferences = codeOnlyLines.match(/\b([A-Z][A-Za-z0-9_]*)\b/g) || [];
+                  const referenceSet = new Set(allReferences);
+
+                  for (const imp of importLines) {
+                    const moduleName = imp.moduleName;
+                    if (moduleName !== undefined && !referenceSet.has(moduleName)) {
+                      unusedImports.add(imp.line);
+                    }
+                  }
+                }
+              }
+
+              const usedImportLines = importLines.filter(imp => !unusedImports.has(imp.line));
+
+              if (importLines.length > 1 || unusedImports.size > 0) {
+                const sorted = [...usedImportLines].sort((a, b) => {
+                  const typeOrder = { include: 0, import: 1, inherit: 2 };
+                  const typeA = typeOrder[a.type as keyof typeof typeOrder] ?? 3;
+                  const typeB = typeOrder[b.type as keyof typeof typeOrder] ?? 3;
+                  if (typeA !== typeB) return typeA - typeB;
+                  return a.text.localeCompare(b.text);
+                });
+
+                const needsSort = importLines.some((item, i) => item.text !== sorted[i]?.text);
+                const hasRemovals = unusedImports.size > 0;
+
+                if (needsSort || hasRemovals) {
+                  const edits: TextEdit[] = [];
+
+                  for (const unusedLine of unusedImports) {
+                    const imp = importLines.find(i => i.line === unusedLine);
+                    if (imp) {
+                      edits.push({
                         range: {
-                          start: { line: insertionLine, character: 0 },
-                          end: { line: insertionLine, character: 0 },
+                          start: { line: imp.line, character: 0 },
+                          end: { line: imp.line, character: imp.text.length },
                         },
-                        newText: statement,
+                        newText: '',
+                      });
+                    }
+                  }
+
+                  for (let i = 0; i < usedImportLines.length; i++) {
+                    const original = usedImportLines[i];
+                    const replacement = sorted[i];
+                    if (original && replacement && original.text !== replacement.text) {
+                      edits.push({
+                        range: {
+                          start: { line: original.line, character: 0 },
+                          end: { line: original.line, character: original.text.length },
+                        },
+                        newText: replacement.text,
+                      });
+                    }
+                  }
+
+                  if (edits.length > 0) {
+                    result.push({
+                      title: 'Organize Imports',
+                      kind: CodeActionKind.SourceOrganizeImports,
+                      edit: {
+                        changes: {
+                          [uri]: edits,
+                        },
                       },
-                    ],
-                  },
-                },
+                    });
+                  }
+                }
+              }
+            }
+
+            // CA-010: Handle missing or empty diagnostics gracefully
+            const diagnostics = params.context.diagnostics ?? [];
+            if (!Array.isArray(diagnostics)) {
+              log.warn('Invalid diagnostics array in code action request');
+              return result;
+            }
+
+            // Quick Fixes - only if filter allows
+            if (matchesFilter(CodeActionKind.QuickFix)) {
+              for (const diag of diagnostics) {
+                if (diag.code !== 'undefined-symbol.unresolved-import') {
+                  continue;
+                }
+
+                const unresolvedData = toUnresolvedDiagnosticData(diag.data);
+                if (!unresolvedData?.symbol) {
+                  continue;
+                }
+
+                let candidates = unresolvedData.importCandidates ?? [];
+                if (candidates.length === 0 && services.pikeIntrospection) {
+                  // KB-1248: Use resilient introspection call
+                  candidates = await searchImportableSymbolsResilient(
+                    unresolvedData.symbol,
+                    {
+                      excludeUri: uri,
+                      limit: 8,
+                    },
+                    cancellationToken
+                  );
+                }
+
+                // KB-1248: Check cancellation before processing candidates
+                if (cancellationToken?.isCancellationRequested) {
+                  return result;
+                }
+
+                const sortedCandidates = sortImportCandidates(candidates);
+                const insertionLine = getImportInsertionLine(lines);
+
+                for (const candidate of sortedCandidates) {
+                  if (hasImportStatement(lines, candidate)) {
+                    continue;
+                  }
+
+                  const statement = buildImportStatement(candidate);
+                  const verb = candidate.importKind === 'inherit' ? 'inherit' : 'import';
+                  result.push({
+                    title: `Add ${verb} for ${unresolvedData.symbol} from ${candidate.modulePath}`,
+                    kind: CodeActionKind.QuickFix,
+                    diagnostics: [diag],
+                    edit: {
+                      changes: {
+                        [uri]: [
+                          {
+                            range: {
+                              start: { line: insertionLine, character: 0 },
+                              end: { line: insertionLine, character: 0 },
+                            },
+                            newText: statement,
+                          },
+                        ],
+                      },
+                    },
+                  });
+                }
+              }
+
+              for (const diag of diagnostics) {
+                if (diag.message.includes('syntax error') || diag.message.includes('expected')) {
+                  const diagLine = lines[diag.range.start.line] ?? '';
+                  if (
+                    !diagLine.trim().endsWith(';') &&
+                    !diagLine.trim().endsWith('{') &&
+                    !diagLine.trim().endsWith('}')
+                  ) {
+                    result.push({
+                      title: 'Add missing semicolon',
+                      kind: CodeActionKind.QuickFix,
+                      diagnostics: [diag],
+                      edit: {
+                        changes: {
+                          [uri]: [
+                            {
+                              range: {
+                                start: { line: diag.range.start.line, character: diagLine.length },
+                                end: { line: diag.range.start.line, character: diagLine.length },
+                              },
+                              newText: ';',
+                            },
+                          ],
+                        },
+                      },
+                    });
+                  }
+                }
+              }
+            }
+
+            // KB-1248: Check cancellation before expensive refactoring operations
+            if (cancellationToken?.isCancellationRequested) {
+              return result;
+            }
+
+            // CA-011: Getter/Setter Generation - pass filter for consistency
+            // KB-1248: Wrap in try-catch for resilience
+            try {
+              const getterSetterActions = getGenerateGetterSetterActions(
+                document,
+                uri,
+                params.range,
+                cached.symbols,
+                onlyKinds // Pass filter to getter/setter generator
+              );
+              result.push(...getterSetterActions);
+            } catch (err) {
+              // KB-1248: Gracefully handle getter/setter generation failures
+              log.debug('Getter/setter generation failed (handled gracefully)', {
+                uri,
+                error: err instanceof Error ? err.message : String(err),
               });
             }
-          }
 
-          for (const diag of diagnostics) {
-            if (diag.message.includes('syntax error') || diag.message.includes('expected')) {
-              const diagLine = lines[diag.range.start.line] ?? '';
-              if (
-                !diagLine.trim().endsWith(';') &&
-                !diagLine.trim().endsWith('{') &&
-                !diagLine.trim().endsWith('}')
-              ) {
-                actions.push({
-                  title: 'Add missing semicolon',
-                  kind: CodeActionKind.QuickFix,
-                  diagnostics: [diag],
-                  edit: {
-                    changes: {
-                      [uri]: [
-                        {
-                          range: {
-                            start: { line: diag.range.start.line, character: diagLine.length },
-                            end: { line: diag.range.start.line, character: diagLine.length },
-                          },
-                          newText: ';',
-                        },
-                      ],
-                    },
-                  },
-                });
+            // Extract Method Refactoring
+            // KB-1248: Wrap in try-catch for resilience
+            try {
+              const extractMethodAction = getExtractMethodAction(
+                document,
+                uri,
+                params.range,
+                text,
+                onlyKinds // Pass filter for consistency
+              );
+              if (extractMethodAction) {
+                result.push(extractMethodAction);
               }
+            } catch (err) {
+              // KB-1248: Gracefully handle extract method failures
+              log.debug('Extract method generation failed (handled gracefully)', {
+                uri,
+                error: err instanceof Error ? err.message : String(err),
+              });
             }
-          }
-        }
 
-        // KB-1248: Check cancellation before expensive refactoring operations
-        if (cancellationToken?.isCancellationRequested) {
-          maybeLogCodeActionsSchedulerMetrics(uri, 'cancelled_before_refactor');
-          return actions;
-        }
-
-        // CA-011: Getter/Setter Generation - pass filter for consistency
-        // KB-1248: Wrap in try-catch for resilience
-        try {
-          const getterSetterActions = getGenerateGetterSetterActions(
-            document,
-            uri,
-            params.range,
-            cached.symbols,
-            onlyKinds // Pass filter to getter/setter generator
-          );
-          actions.push(...getterSetterActions);
-        } catch (err) {
-          // KB-1248: Gracefully handle getter/setter generation failures
-          log.debug('Getter/setter generation failed (handled gracefully)', {
-            uri,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-
-        // Extract Method Refactoring
-        // KB-1248: Wrap in try-catch for resilience
-        try {
-          const extractMethodAction = getExtractMethodAction(
-            document,
-            uri,
-            params.range,
-            text,
-            onlyKinds // Pass filter for consistency
-          );
-          if (extractMethodAction) {
-            actions.push(extractMethodAction);
-          }
-        } catch (err) {
-          // KB-1248: Gracefully handle extract method failures
-          log.debug('Extract method generation failed (handled gracefully)', {
-            uri,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
+            return result;
+          },
+        });
 
         maybeLogCodeActionsSchedulerMetrics(uri, actions.length > 0 ? 'success' : 'empty');
         return actions;
       } catch (err) {
+        // RequestSupersededError means a newer request superseded this one
+        if (err instanceof RequestSupersededError) {
+          maybeLogCodeActionsSchedulerMetrics(uri, 'superseded');
+          return [];
+        }
+
         // KB-1248: Log at debug level for parse-under-edit scenarios, error only for unexpected
         const errorMessage = err instanceof Error ? err.message : String(err);
         const isParseError = errorMessage.includes('parse') || errorMessage.includes('syntax');

--- a/packages/pike-lsp-server/src/scenarios/code-actions-parse-resilience.test.ts
+++ b/packages/pike-lsp-server/src/scenarios/code-actions-parse-resilience.test.ts
@@ -451,4 +451,72 @@ describe('Code Actions: parse-under-edit resilience', () => {
     // Should return array without throwing
     assert.ok(Array.isArray(result), 'Getter/setter generation should complete gracefully');
   });
+
+  it('handles request supersession for same URI without crashing', async () => {
+    const bridge = new FaultInjectableMockBridge();
+
+    const { setDocumentWithSymbol, triggerCodeActions } = createCodeActionsHarness(bridge);
+    const uri = 'file:///code-actions-supersede.pike';
+
+    setDocumentWithSymbol(uri, 'int x = 1;\n', 'x');
+
+    // Fire two concurrent requests for the same URI — second should supersede first
+    const promise1 = triggerCodeActions(uri, 0, 0);
+    const promise2 = triggerCodeActions(uri, 0, 0);
+
+    const [result1, result2] = await Promise.allSettled([promise1, promise2]);
+
+    // Both should settle without unhandled rejection
+    assert.ok(result1.status === 'fulfilled', 'First request should settle');
+    assert.ok(result2.status === 'fulfilled', 'Second request should settle');
+
+    // At least one should return an array (possibly empty due to supersession)
+    if (result1.status === 'fulfilled') {
+      assert.ok(Array.isArray(result1.value), 'First result should be an array');
+    }
+    if (result2.status === 'fulfilled') {
+      assert.ok(Array.isArray(result2.value), 'Second result should be an array');
+    }
+  });
+
+  it('handles concurrent requests for different URIs', async () => {
+    const bridge = new FaultInjectableMockBridge();
+
+    const { setDocumentWithSymbol, triggerCodeActions } = createCodeActionsHarness(bridge);
+    const uri1 = 'file:///code-actions-concurrent-a.pike';
+    const uri2 = 'file:///code-actions-concurrent-b.pike';
+
+    setDocumentWithSymbol(uri1, 'int a = 1;\n', 'a');
+    setDocumentWithSymbol(uri2, 'int b = 2;\n', 'b');
+
+    // Fire concurrent requests for different URIs — neither should be superseded
+    const [result1, result2] = await Promise.all([
+      triggerCodeActions(uri1, 0, 0),
+      triggerCodeActions(uri2, 0, 0),
+    ]);
+
+    assert.ok(Array.isArray(result1), 'First URI result should be an array');
+    assert.ok(Array.isArray(result2), 'Second URI result should be an array');
+  });
+
+  it('handles rapid sequential requests for same URI without memory leak', async () => {
+    const bridge = new FaultInjectableMockBridge();
+
+    const { setDocumentWithSymbol, triggerCodeActions } = createCodeActionsHarness(bridge);
+    const uri = 'file:///code-actions-rapid-seq.pike';
+
+    setDocumentWithSymbol(uri, 'int rapid = 1;\n', 'rapid');
+
+    // Fire many sequential requests — each supersedes the previous
+    const results: unknown[] = [];
+    for (let i = 0; i < 20; i++) {
+      const result = await triggerCodeActions(uri, 0, 0);
+      results.push(result);
+    }
+
+    assert.equal(results.length, 20, 'All sequential requests should complete');
+    for (let i = 0; i < results.length; i++) {
+      assert.ok(Array.isArray(results[i]), `Request ${i} should return an array`);
+    }
+  });
 });


### PR DESCRIPTION
Addresses #1258 (completes remaining work)

## Changes
Migrates code-actions to the resilient query-engine pattern with:
- **RequestScheduler.schedule()** wrapping — main handler body now scheduled through the request scheduler with key-based supersession (`code-action:${uri}`), so rapid edits to the same URI don't queue redundant work
- **RequestSupersededError handling** — superseded requests return `[]` gracefully instead of propagating errors
- **Cancellation support** — CancellationToken checks at entry, before heavy processing, and inside the scheduled work
- **Parse-error classification** — debug-level logging for parse-under-edit scenarios, error-level for unexpected failures
- **3 new resilience tests** — request supersession for same URI, concurrent different URIs, rapid sequential requests

Combined with PR #1259, this completes all three MEDIUM-risk migrations from #1258.

## Verification
- `npx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json` passes clean
- 201 scenario tests pass (12 code-actions resilience tests including 3 new)
- Prettier formatting passes

---
Implemented by DGA Coder agent
