### PR TITLE
feat: performance: Single-char workspace search falls back to O(n) scan — no prefix in

### DIFF
--- a/packages/pike-lsp-server/src/tests/symbols/workspace-prefix-index-single-char.test.ts
+++ b/packages/pike-lsp-server/src/tests/symbols/workspace-prefix-index-single-char.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Tests for single-character prefix index optimization (PERF-1285).
+ *
+ * Before the fix, single-char workspace symbol searches fell back to O(n)
+ * scan of symbolLookup because the prefix index only stored prefixes of
+ * length >= 2. Now single-char prefixes are indexed too.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { WorkspaceIndex } from '../../workspace-index.js';
+
+/**
+ * Helper: access private prefixIndex for assertions.
+ */
+function getPrefixIndex(idx: WorkspaceIndex): Map<string, Set<string>> {
+  return (idx as unknown as { prefixIndex: Map<string, Set<string>> }).prefixIndex;
+}
+
+/**
+ * Helper: access private symbolLookup.
+ */
+function getSymbolLookup(idx: WorkspaceIndex): Map<string, Map<string, unknown>> {
+  return (idx as unknown as { symbolLookup: Map<string, Map<string, unknown>> }).symbolLookup;
+}
+
+describe('Single-char prefix index (PERF-1285)', () => {
+  let index: WorkspaceIndex;
+
+  beforeEach(() => {
+    index = new WorkspaceIndex();
+  });
+
+  describe('prefix index population', () => {
+    it('indexes single-character prefixes into prefixIndex', () => {
+      // Use internal lookup to add a symbol named 'myFunction'
+      const symbols = [{ name: 'myFunction', kind: 'method', position: { line: 1 }, children: [] }];
+      const docs = (index as unknown as { documents: Map<string, unknown> }).documents;
+      docs.set('file:///test.pike', {
+        uri: 'file:///test.pike',
+        symbols,
+        version: 1,
+        lastModified: Date.now(),
+      });
+
+      // Use the private addToLookup
+      const flatSymbols = symbols.map(s => ({ symbol: s }));
+      (
+        index as unknown as { addToLookup: (uri: string, syms: unknown[], lc?: number) => void }
+      ).addToLookup('file:///test.pike', flatSymbols);
+
+      const prefixIndex = getPrefixIndex(index);
+      expect(prefixIndex.has('m')).toBe(true);
+      expect(prefixIndex.has('my')).toBe(true);
+      expect(prefixIndex.has('myf')).toBe(true);
+      expect(prefixIndex.has('myfu')).toBe(true);
+      // 'myfun' is length 5 > MAX_DEPTH=4, so not stored separately
+      expect(prefixIndex.has('myfun')).toBe(false);
+
+      // 'm' set should contain 'myfunction' (lowercase)
+      const mSet = prefixIndex.get('m');
+      expect(mSet).toBeDefined();
+      expect(mSet!.has('myfunction')).toBe(true);
+    });
+
+    it('indexes single-char symbol names into prefixIndex', () => {
+      const symbols = [{ name: 'x', kind: 'variable', position: { line: 1 }, children: [] }];
+      const docs = (index as unknown as { documents: Map<string, unknown> }).documents;
+      docs.set('file:///test.pike', {
+        uri: 'file:///test.pike',
+        symbols,
+        version: 1,
+        lastModified: Date.now(),
+      });
+
+      (
+        index as unknown as { addToLookup: (uri: string, syms: unknown[], lc?: number) => void }
+      ).addToLookup(
+        'file:///test.pike',
+        symbols.map(s => ({ symbol: s }))
+      );
+
+      const prefixIndex = getPrefixIndex(index);
+      expect(prefixIndex.has('x')).toBe(true);
+      expect(prefixIndex.get('x')!.has('x')).toBe(true);
+    });
+  });
+
+  describe('single-char search uses prefix index', () => {
+    it('finds symbols with single-char prefix query', () => {
+      const symbols = [
+        { name: 'alpha', kind: 'method', position: { line: 1 }, children: [] },
+        { name: 'app', kind: 'class', position: { line: 5 }, children: [] },
+        { name: 'beta', kind: 'method', position: { line: 10 }, children: [] },
+      ];
+      const docs = (index as unknown as { documents: Map<string, unknown> }).documents;
+      docs.set('file:///test.pike', {
+        uri: 'file:///test.pike',
+        symbols,
+        version: 1,
+        lastModified: Date.now(),
+        lineCount: 15,
+      });
+
+      (
+        index as unknown as { addToLookup: (uri: string, syms: unknown[], lc?: number) => void }
+      ).addToLookup(
+        'file:///test.pike',
+        symbols.map(s => ({ symbol: s })),
+        15
+      );
+
+      // Single-char query 'a' should find 'alpha' and 'app' but not 'beta'
+      const results = index.searchSymbols('a');
+      expect(results.length).toBe(2);
+      const names = results.map(r => r.name);
+      expect(names).toContain('alpha');
+      expect(names).toContain('app');
+      expect(names).not.toContain('beta');
+    });
+
+    it('finds exact single-char symbol name', () => {
+      const symbols = [
+        { name: 'm', kind: 'method', position: { line: 1 }, children: [] },
+        { name: 'myFunction', kind: 'method', position: { line: 5 }, children: [] },
+      ];
+      const docs = (index as unknown as { documents: Map<string, unknown> }).documents;
+      docs.set('file:///test.pike', {
+        uri: 'file:///test.pike',
+        symbols,
+        version: 1,
+        lastModified: Date.now(),
+        lineCount: 10,
+      });
+
+      (
+        index as unknown as { addToLookup: (uri: string, syms: unknown[], lc?: number) => void }
+      ).addToLookup(
+        'file:///test.pike',
+        symbols.map(s => ({ symbol: s })),
+        10
+      );
+
+      const results = index.searchSymbols('m');
+      expect(results.length).toBe(2);
+      // Exact match should be ranked first
+      expect(results[0].name).toBe('m');
+    });
+
+    it('returns empty when no symbols match single-char query', () => {
+      const symbols = [{ name: 'alpha', kind: 'method', position: { line: 1 }, children: [] }];
+      const docs = (index as unknown as { documents: Map<string, unknown> }).documents;
+      docs.set('file:///test.pike', {
+        uri: 'file:///test.pike',
+        symbols,
+        version: 1,
+        lastModified: Date.now(),
+        lineCount: 5,
+      });
+
+      (
+        index as unknown as { addToLookup: (uri: string, syms: unknown[], lc?: number) => void }
+      ).addToLookup(
+        'file:///test.pike',
+        symbols.map(s => ({ symbol: s })),
+        5
+      );
+
+      const results = index.searchSymbols('z');
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('prefix index cleanup on removal', () => {
+    it('removes single-char prefix entries when last symbol using them is removed', () => {
+      // Add symbol starting with 'z'
+      const symbols = [{ name: 'zebra', kind: 'class', position: { line: 1 }, children: [] }];
+      const docs = (index as unknown as { documents: Map<string, unknown> }).documents;
+      docs.set('file:///test.pike', {
+        uri: 'file:///test.pike',
+        symbols,
+        version: 1,
+        lastModified: Date.now(),
+        lineCount: 5,
+      });
+
+      (
+        index as unknown as { addToLookup: (uri: string, syms: unknown[], lc?: number) => void }
+      ).addToLookup(
+        'file:///test.pike',
+        symbols.map(s => ({ symbol: s })),
+        5
+      );
+
+      const prefixIndex = getPrefixIndex(index);
+      expect(prefixIndex.has('z')).toBe(true);
+
+      // Remove the document
+      index.removeDocument('file:///test.pike');
+
+      // Single-char prefix 'z' should be cleaned up
+      expect(prefixIndex.has('z')).toBe(false);
+      // searchSymbols should find nothing
+      expect(index.searchSymbols('z')).toEqual([]);
+    });
+
+    it('keeps single-char prefix entry when other symbols still use it', () => {
+      const symbolsA = [{ name: 'alpha', kind: 'method', position: { line: 1 }, children: [] }];
+      const symbolsB = [{ name: 'app', kind: 'class', position: { line: 1 }, children: [] }];
+      const docs = (index as unknown as { documents: Map<string, unknown> }).documents;
+
+      docs.set('file:///a.pike', {
+        uri: 'file:///a.pike',
+        symbols: symbolsA,
+        version: 1,
+        lastModified: Date.now(),
+        lineCount: 5,
+      });
+      docs.set('file:///b.pike', {
+        uri: 'file:///b.pike',
+        symbols: symbolsB,
+        version: 1,
+        lastModified: Date.now(),
+        lineCount: 5,
+      });
+
+      (
+        index as unknown as { addToLookup: (uri: string, syms: unknown[], lc?: number) => void }
+      ).addToLookup(
+        'file:///a.pike',
+        symbolsA.map(s => ({ symbol: s })),
+        5
+      );
+      (
+        index as unknown as { addToLookup: (uri: string, syms: unknown[], lc?: number) => void }
+      ).addToLookup(
+        'file:///b.pike',
+        symbolsB.map(s => ({ symbol: s })),
+        5
+      );
+
+      const prefixIndex = getPrefixIndex(index);
+      expect(prefixIndex.get('a')!.has('alpha')).toBe(true);
+      expect(prefixIndex.get('a')!.has('app')).toBe(true);
+
+      // Remove one document
+      index.removeDocument('file:///a.pike');
+
+      // 'a' prefix still exists because 'app' uses it
+      expect(prefixIndex.has('a')).toBe(true);
+      expect(prefixIndex.get('a')!.has('alpha')).toBe(false);
+      expect(prefixIndex.get('a')!.has('app')).toBe(true);
+
+      // Searching for 'a' should still find 'app'
+      const results = index.searchSymbols('a');
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe('app');
+    });
+  });
+
+  describe('searchImportableSymbols single-char', () => {
+    it('finds importable symbols with single-char prefix via prefix index', () => {
+      const symbols = [
+        { name: 'Alpha', kind: 'class', position: { line: 1 }, children: [] },
+        { name: 'alphaMethod', kind: 'method', position: { line: 5 }, children: [] },
+      ];
+      const docs = (index as unknown as { documents: Map<string, unknown> }).documents;
+      docs.set('file:///src/Alpha.pike', {
+        uri: 'file:///src/Alpha.pike',
+        symbols,
+        version: 1,
+        lastModified: Date.now(),
+        lineCount: 10,
+      });
+
+      (
+        index as unknown as { addToLookup: (uri: string, syms: unknown[], lc?: number) => void }
+      ).addToLookup(
+        'file:///src/Alpha.pike',
+        symbols.map(s => ({ symbol: s })),
+        10
+      );
+
+      const results = index.searchImportableSymbols('a');
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      // Should find symbols starting with 'a'
+      expect(results.every(r => r.symbol.toLowerCase().startsWith('a'))).toBe(true);
+    });
+  });
+
+  describe('clear removes single-char prefixes', () => {
+    it('clears all single-char prefix entries', () => {
+      const symbols = [{ name: 'foo', kind: 'method', position: { line: 1 }, children: [] }];
+      const docs = (index as unknown as { documents: Map<string, unknown> }).documents;
+      docs.set('file:///test.pike', {
+        uri: 'file:///test.pike',
+        symbols,
+        version: 1,
+        lastModified: Date.now(),
+      });
+
+      (
+        index as unknown as { addToLookup: (uri: string, syms: unknown[], lc?: number) => void }
+      ).addToLookup(
+        'file:///test.pike',
+        symbols.map(s => ({ symbol: s }))
+      );
+
+      expect(getPrefixIndex(index).has('f')).toBe(true);
+      index.clear();
+      expect(getPrefixIndex(index).has('f')).toBe(false);
+      expect(getPrefixIndex(index).size).toBe(0);
+    });
+  });
+});

--- a/packages/pike-lsp-server/src/workspace-index.ts
+++ b/packages/pike-lsp-server/src/workspace-index.ts
@@ -113,7 +113,7 @@ export class WorkspaceIndex {
   private uriToSymbols = new Map<string, Set<string>>();
 
   // PERF-XXX: Prefix index for O(1) prefix matching
-  // Maps each prefix (2+ chars) to set of symbol names that have that prefix
+  // Maps each prefix (1+ chars) to set of symbol names that have that prefix
   private prefixIndex = new Map<string, Set<string>>();
 
   // PERF-430: LRU cache for search results
@@ -328,11 +328,34 @@ export class WorkspaceIndex {
     const seen = new Set<string>();
     const limit = Math.max(1, options.limit ?? 20);
 
-    for (const [nameLower, entriesByUri] of this.symbolLookup) {
-      if (!nameLower.startsWith(queryLower)) {
-        continue;
+    // PERF-1285: Use prefix index for O(1) lookup instead of O(n) scan
+    const matchingNames = new Set<string>();
+    if (queryLower.length >= 1) {
+      const lookupKey =
+        queryLower.length <= WorkspaceIndex.PREFIX_INDEX_MAX_DEPTH
+          ? queryLower
+          : queryLower.slice(0, WorkspaceIndex.PREFIX_INDEX_MAX_DEPTH);
+      const prefixSet = this.prefixIndex.get(lookupKey);
+      if (prefixSet) {
+        for (const name of prefixSet) {
+          if (name.startsWith(queryLower)) {
+            matchingNames.add(name);
+          }
+        }
       }
+    }
+    // Fall back to scanning when prefix index misses
+    if (matchingNames.size === 0) {
+      for (const nameLower of this.symbolLookup.keys()) {
+        if (nameLower.startsWith(queryLower)) {
+          matchingNames.add(nameLower);
+        }
+      }
+    }
 
+    for (const nameLower of matchingNames) {
+      const entriesByUri = this.symbolLookup.get(nameLower);
+      if (!entriesByUri) continue;
       for (const [uri, entry] of entriesByUri) {
         if (options.excludeUri && uri === options.excludeUri) {
           continue;
@@ -426,7 +449,7 @@ export class WorkspaceIndex {
     // Collect unique symbol names that match the query
     const matchingNames = new Set<string>();
 
-    if (queryLower.length >= 2) {
+    if (queryLower.length >= 1) {
       // PERF-1273: Use truncated prefix index for O(1) lookup.
       // For queries within MAX_DEPTH, look up directly.
       // For longer queries, look up the truncated prefix then filter.
@@ -445,10 +468,8 @@ export class WorkspaceIndex {
       }
     }
 
-    // Also check for exact/substring matches in symbolLookup (for shorter queries)
-    // This handles the case where query is 1 character
-    if (queryLower.length < 2 || matchingNames.size === 0) {
-      // Fall back to scanning for short queries or when prefix index misses
+    // Fall back to scanning when prefix index misses (eviction or no results)
+    if (matchingNames.size === 0) {
       for (const name of this.symbolLookup.keys()) {
         if (name.startsWith(queryLower) || name.includes(queryLower)) {
           matchingNames.add(name);
@@ -902,9 +923,9 @@ export class WorkspaceIndex {
       if (!symbolNames.has(nameLower)) {
         symbolNames.add(nameLower);
 
-        if (nameLower.length >= 2) {
+        if (nameLower.length >= 1) {
           const maxPrefix = Math.min(nameLower.length, WorkspaceIndex.PREFIX_INDEX_MAX_DEPTH);
-          for (let i = 2; i <= maxPrefix; i++) {
+          for (let i = 1; i <= maxPrefix; i++) {
             const prefix = nameLower.slice(0, i);
             let prefixSet = this.prefixIndex.get(prefix);
             if (!prefixSet) {
@@ -951,9 +972,9 @@ export class WorkspaceIndex {
         }
       }
 
-      if (removeNameFromPrefixIndex && nameLower.length >= 2) {
+      if (removeNameFromPrefixIndex && nameLower.length >= 1) {
         for (
-          let i = 2;
+          let i = 1;
           i <= Math.min(nameLower.length, WorkspaceIndex.PREFIX_INDEX_MAX_DEPTH);
           i++
         ) {


### PR DESCRIPTION
Closes #1285

## Summary

Now I have a clear picture of the problem. The `addToLookup` method only indexes prefixes of length >= 2 (line 905: `if (nameLower.length >= 2)`), meaning single-character queries always fall back to an O(n) full scan of `symbolLookup` (line 450-456). The fix is to add single-character prefixes to the prefix index.

Let me check existing tests for the workspace index:Now I understand the full picture. The fix is clear:

1. **Problem**: `addToLookup` only indexes prefixes of length >= 2 (line 905

## Linked Issue

Closes #1285

## Root Cause

Found at packages/pike-lsp-server/src/workspace-index.ts:425. Auto-discovered by DGA Architect agent.

## Changes

- packages/pike-lsp-server/src/tests/symbols/workspace-prefix-index-single-char.test.ts: see summary
- packages/pike-lsp-server/src/workspace-index.ts: see summary

## Knowledge Base

- [ ] Added/updated KB entry (see `.agent-knowledge/`)
- KB IDs touched: 
- [x] Exempt: automated agent PR

## Verification

- `bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json` passes clean

## Checklist

- [ ] Tests added/updated for changed behavior
- [ ] `bun run test:packages` passes

## Notes for Reviewer

Implemented by DGA coder agent via omp + glm-5.1.