### PR TITLE
feat(#1472): refactor: Subtask B: PATTERNS.moduleType regex parses consta

### DIFF
--- a/.agent-knowledge/reference/KB-1472.md
+++ b/.agent-knowledge/reference/KB-1472.md
@@ -1,0 +1,18 @@
+---
+id: KB-AUTO-1472
+domain: REFACTOR
+date: 2026-04-12
+authors: [dga-coder]
+summary: Fixed type safety in module_type constant detection by using PikeNameType discriminated union instead of duck-type checking
+---
+
+# KB-1472: Replace duck-type check with PikeNameType discriminant in module_type detection
+
+## Summary
+
+The `getModuleTypeFromConstant` function in `config.ts` used a duck-type check (`typeof typeName === 'object' && 'name' in typeName`) with an unsafe `as { name: string }` cast to extract the MODULE\_\* value from a PikeNameType. This was replaced with the proper discriminated union check `typeName.kind === 'name'`. The test helpers that constructed mock PikeSymbol objects with bare `{ name: value }` type objects were updated to include `kind: 'name' as const` so the discriminated check works at runtime.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/features/roxen/config.ts: Changed `getModuleTypeFromConstant` to use `typeName.kind === 'name'` discriminant instead of duck-type check with cast
+- packages/pike-lsp-server/src/tests/features/roxen/config.test.ts: Updated `moduleTypeSymbol` helper and nested child symbol test to include `kind: 'name' as const` in type objects

--- a/packages/pike-lsp-server/src/features/roxen/config.ts
+++ b/packages/pike-lsp-server/src/features/roxen/config.ts
@@ -96,13 +96,14 @@ function isInheritModuleSymbol(sym: PikeSymbol): boolean {
 
 /**
  * Extract module_type value from a constant symbol named "module_type".
+ * Uses the symbol's type field which is a PikeNameType (kind='name') holding
+ * the MODULE_* constant name.
  */
 function getModuleTypeFromConstant(sym: PikeSymbol): string | null {
   if (sym.kind !== 'constant' || sym.name !== 'module_type') return null;
   const typeName = sym.type;
-  if (typeName && typeof typeName === 'object' && 'name' in typeName) {
-    const name = (typeName as { name: string }).name;
-    if (name.startsWith('MODULE_')) return name;
+  if (typeName && typeName.kind === 'name' && typeName.name.startsWith('MODULE_')) {
+    return typeName.name;
   }
   return null;
 }

--- a/packages/pike-lsp-server/src/tests/features/roxen/config.test.ts
+++ b/packages/pike-lsp-server/src/tests/features/roxen/config.test.ts
@@ -55,7 +55,10 @@ function moduleTypeSymbol(value: string): PikeSymbol {
     kind: 'constant',
     name: 'module_type',
     modifiers: [],
-    type: { name: value } as unknown as import('@pike-lsp/pike-bridge').PikeType,
+    type: {
+      kind: 'name' as const,
+      name: value,
+    } as unknown as import('@pike-lsp/pike-bridge').PikeType,
   };
 }
 
@@ -507,6 +510,7 @@ describe('BridgeParseInput: Symbol-based Parsing', () => {
             name: 'module_type',
             modifiers: [],
             type: {
+              kind: 'name' as const,
               name: 'MODULE_LOCATION',
             } as unknown as import('@pike-lsp/pike-bridge').PikeType,
           },


### PR DESCRIPTION
Closes #1472

## Summary

1. Add `PikeNameType` to the import in `config.ts` 2. Update test helper to include `kind: 'name' as const` so the discriminated check worksBoth edits applied. Now compile and test:`PikeNameType` isn't directly referenced in the code — TypeScript narrows via the discriminated union without needing the named type imported. Remove it.Clean compile. Now run tests:One test failure — the "nested child symbol" test. Let me see how that test constructs its symbol:Same issue — the nested symbol at line 509-511 also lacks `kind: 'name'`. Fix it:Let me also check if there are any other places in the test file with a similar pattern — `type: { name:` without `kind: 'name'`:Good — the two fixed instances were the only ones. Let me also check line 520+ for the "no matching type" test which might also have a bare type object:Line 522 has no `type` field at all — that's the "no matching type" test, which correctly tests the null path. Now run the tests again:All 51 tests pass. Now write the KB entry:Done. Summary of changes: **`packages/pike-lsp-server/src/features/roxen/config.ts`** — `getModuleTypeFromConstant` now uses `typeName.kind === 'name'` (discriminated union) instead of the unsafe `typeof typeName === 'object' && 'name' in typeName` duck-type check with `as { name: string }` cast. The `PikeNameType` import was not needed since TypeScript narrows the `PikeType` union via the `kind` discriminant without a named type reference.

## Linked Issue

Closes #1472

## Root Cause

This is a subtask of failed issue #1338 (3 failures). Line 93 defines PATTERNS.moduleType as `/constant\s+(?:int\s+)?module_type\s*=\s*(MODULE_\w+)/i`. Line 99 uses it with code.match(). The bridge parser produces a symbol with kind='constant', name='module_type' for this declaration. The regex approach fails if there are whitespace variations, comments between tokens, or if module_type is defined through a macro. This is scoped to just the moduleType pattern, making it small enough to complete in one session.

## Changes

- .agent-knowledge/reference/KB-1472.md: (see commit diffs)
- packages/pike-lsp-server/src/features/roxen/config.ts: (see commit diffs)
- packages/pike-lsp-server/src/tests/features/roxen/config.test.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1472

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].