### PR TITLE
feat(#1653): feat: Sub-issue of #1638: searchStdlibCandidates() re-reads 

### DIFF
--- a/.agent-knowledge/reference/KB-1653.md
+++ b/.agent-knowledge/reference/KB-1653.md
@@ -1,0 +1,18 @@
+---
+id: KB-AUTO-1653
+domain: REFACTOR
+date: 2026-04-13
+authors: [dga-coder]
+summary: Cached stdlib module symbol lists and added fuzzy matching to searchStdlibCandidates() for better IntelliSense completions
+---
+
+# KB-1653: Cache stdlib symbols and add fuzzy matching to searchStdlibCandidates
+
+## Summary
+
+`searchStdlibCandidates()` previously re-read every stdlib module's symbols on each call (via `getModule()`) and only supported prefix matching (`startsWith`). Two changes: (A) Added `stdlibSymbolCache` Map that is populated on first access and cleared via `invalidateStdlibCache()`. (B) Added `fuzzyScore()` static method supporting exact, prefix, substring, and contiguous subsequence matching, replacing the old `startsWith` check. Results are ranked by match quality.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/services/pike-introspection.ts: Added `stdlibSymbolCache` field, `fuzzyScore` static method, `invalidateStdlibCache()` public method, rewrote `searchStdlibCandidates()` to use cache and fuzzy scoring
+- packages/pike-lsp-server/src/tests/services/pike-introspection.test.ts: New test file with 15 tests covering fuzzy match types, ranking order, caching behavior, cache invalidation, case insensitivity, and import kind classification

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,41 +5,41 @@ or `utils/pike-token-utils.ts`. No regex, no indexOf/charAt scanning loops.
 
 ## Shared Infrastructure
 
-| File | Status | Notes |
-|------|--------|-------|
-| `src/utils/pike-token-utils.ts` | DONE | Shared findIdentifierOccurrences, tokenizeOrFallback, findPositionForIndex, isIdentifierToken |
-| `src/utils/regex-patterns.ts` | DEPRECATED | Marked deprecated. Functions migrated to pike-token-utils or inlined. |
+| File                            | Status     | Notes                                                                                         |
+| ------------------------------- | ---------- | --------------------------------------------------------------------------------------------- |
+| `src/utils/pike-token-utils.ts` | DONE       | Shared findIdentifierOccurrences, tokenizeOrFallback, findPositionForIndex, isIdentifierToken |
+| `src/utils/regex-patterns.ts`   | DEPRECATED | Marked deprecated. Functions migrated to pike-token-utils or inlined.                         |
 
 ## Done
 
-| File | What | PR |
-|------|------|----|
-| `features/advanced/extract-method-utils.ts` | Removed `stripCodeContent()` (85 lines) + `isIdentPresent()` (25 lines). Replaced with token kind filtering. | #1644 |
-| `features/advanced/semantic-tokens-builder.ts` | Token-based symbol matching via identifierIndex when bridge available. Regex as fallback. | #1645 |
-| `features/rxml/definition-provider.ts` | Deduplicated `findPositionForIndex` → shared import | #1643 |
-| `features/rxml/references-provider.ts` | Deduplicated `findPositionForIndex` → shared import | #1643 |
-| `features/rxml/rename-provider.ts` | Deduplicated `findPositionForIndex` → shared import | #1643 |
+| File                                           | What                                                                                                         | PR    |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ----- |
+| `features/advanced/extract-method-utils.ts`    | Removed `stripCodeContent()` (85 lines) + `isIdentPresent()` (25 lines). Replaced with token kind filtering. | #1644 |
+| `features/advanced/semantic-tokens-builder.ts` | Token-based symbol matching via identifierIndex when bridge available. Regex as fallback.                    | #1645 |
+| `features/rxml/definition-provider.ts`         | Deduplicated `findPositionForIndex` → shared import                                                          | #1643 |
+| `features/rxml/references-provider.ts`         | Deduplicated `findPositionForIndex` → shared import                                                          | #1643 |
+| `features/rxml/rename-provider.ts`             | Deduplicated `findPositionForIndex` → shared import                                                          | #1643 |
 
 ## Triage: Not Anti-patterns (verified)
 
-| File | Why regex/string-scan is correct here |
-|------|----------------------------------------|
-| `features/rxml/rename-provider.ts` L112-121 | Reads `.pike` files from disk (not open LSP documents). Bridge only operates on open documents. Regex via `buildTagPattern()` is the only viable method. Also: exported functions are dead code (never imported). |
-| `features/rxml/module-scanner.ts` L93-145 | String scan fallback is used by `definition-provider.ts:73` and `references-provider.ts:102`, which read files from disk via `readFileCached()`. Bridge requires open documents. Symbol-based path exists and is used when symbols are available. |
-| `features/advanced/folding.ts` | Brace-matching scanner is generic document-structure analysis, not Pike parsing |
-| `features/editing/autodoc.ts` | Single-line text extraction for completion snippets, not Pike source parsing |
-| `features/advanced/ignored-ranges.ts` | Necessary fallback for when bridge is unavailable (tests, parse-under-edit) |
-| `features/editing/completion-qe.ts` | Single-line regex heuristic for completion ranking. Bridge's CompletionContext solves a different problem |
-| `features/navigation/references.ts` | PikeToken lacks operator metadata; regex is only viable method for write-detection |
+| File                                        | Why regex/string-scan is correct here                                                                                                                                                                                                             |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `features/rxml/rename-provider.ts` L112-121 | Reads `.pike` files from disk (not open LSP documents). Bridge only operates on open documents. Regex via `buildTagPattern()` is the only viable method. Also: exported functions are dead code (never imported).                                 |
+| `features/rxml/module-scanner.ts` L93-145   | String scan fallback is used by `definition-provider.ts:73` and `references-provider.ts:102`, which read files from disk via `readFileCached()`. Bridge requires open documents. Symbol-based path exists and is used when symbols are available. |
+| `features/advanced/folding.ts`              | Brace-matching scanner is generic document-structure analysis, not Pike parsing                                                                                                                                                                   |
+| `features/editing/autodoc.ts`               | Single-line text extraction for completion snippets, not Pike source parsing                                                                                                                                                                      |
+| `features/advanced/ignored-ranges.ts`       | Necessary fallback for when bridge is unavailable (tests, parse-under-edit)                                                                                                                                                                       |
+| `features/editing/completion-qe.ts`         | Single-line regex heuristic for completion ranking. Bridge's CompletionContext solves a different problem                                                                                                                                         |
+| `features/navigation/references.ts`         | PikeToken lacks operator metadata; regex is only viable method for write-detection                                                                                                                                                                |
 
 ## Already Fixed (reference implementations)
 
-| File | Function | How |
-|------|----------|-----|
-| `features/roxen/defvar-scanner.ts` | `extractDefvarsFromTokens()` | Token-based defvar extraction via PikeToken[] |
-| `features/roxen/config.ts` | defvar extraction orchestration | 3-tier: roxenDetect > extractDefvarsFromTokens > parse symbols |
-| `features/rxml/references-provider.ts` | `findDefvarReferences()` | tokenizeFn parameter, RXML entity regex kept (not Pike) |
-| `features/rxml/definition-provider.ts` | `getDefvarDefinitionIndex()` | tokenizeFn + extractDefvarsFromTokens (partial) |
+| File                                   | Function                        | How                                                            |
+| -------------------------------------- | ------------------------------- | -------------------------------------------------------------- |
+| `features/roxen/defvar-scanner.ts`     | `extractDefvarsFromTokens()`    | Token-based defvar extraction via PikeToken[]                  |
+| `features/roxen/config.ts`             | defvar extraction orchestration | 3-tier: roxenDetect > extractDefvarsFromTokens > parse symbols |
+| `features/rxml/references-provider.ts` | `findDefvarReferences()`        | tokenizeFn parameter, RXML entity regex kept (not Pike)        |
+| `features/rxml/definition-provider.ts` | `getDefvarDefinitionIndex()`    | tokenizeFn + extractDefvarsFromTokens (partial)                |
 
 ## DGA Orchestrator Integration
 

--- a/packages/pike-lsp-server/src/features/advanced/semantic-tokens-builder.ts
+++ b/packages/pike-lsp-server/src/features/advanced/semantic-tokens-builder.ts
@@ -265,4 +265,3 @@ export async function buildTokens(
 
   return builder.build();
 }
-

--- a/packages/pike-lsp-server/src/services/pike-introspection.ts
+++ b/packages/pike-lsp-server/src/services/pike-introspection.ts
@@ -30,6 +30,9 @@ interface CachedIntrospectionDocument {
 export class PikeIntrospectionService {
   private readonly cache = new Map<string, CachedIntrospectionDocument>();
 
+  /** Cached symbol lists per stdlib module, populated on first search. */
+  private stdlibSymbolCache = new Map<string, Map<string, IntrospectedSymbol>>();
+
   constructor(
     private readonly services: Services,
     private readonly workspaceIndex?: WorkspaceIndex,
@@ -303,36 +306,83 @@ export class PikeIntrospectionService {
 
   // === Auto-import private methods ===
 
+  /**
+   * Score how well `name` matches `query`.
+   * Returns 0 for no match, or a positive score where higher = better.
+   * Prefix match scores higher than substring; contiguous subsequence gets a bonus.
+   */
+  private static fuzzyScore(query: string, name: string): number {
+    const q = query.toLowerCase();
+    const n = name.toLowerCase();
+
+    // Exact match
+    if (n === q) return 100;
+    // Prefix match
+    if (n.startsWith(q)) return 80 + q.length;
+    // Substring match
+    const subIdx = n.indexOf(q);
+    if (subIdx >= 0) return 40 + q.length;
+
+    // Contiguous subsequence match (characters appear in order)
+    let qi = 0;
+    let contiguous = 0;
+    let bestContiguous = 0;
+    for (let ni = 0; ni < n.length && qi < q.length; ni++) {
+      if (n[ni] === q[qi]) {
+        qi++;
+        contiguous++;
+        if (contiguous > bestContiguous) bestContiguous = contiguous;
+      } else {
+        contiguous = 0;
+      }
+    }
+    if (qi < q.length) return 0; // not all query chars found
+    return 20 + bestContiguous + q.length;
+  }
+
+  /**
+   * Clear the cached stdlib symbol lists. Should be called when
+   * the workspace index changes.
+   */
+  invalidateStdlibCache(): void {
+    this.stdlibSymbolCache.clear();
+  }
+
   private async searchStdlibCandidates(query: string): Promise<ImportableSymbolCandidate[]> {
-    if (!this.stdlibIndex) {
+    if (!this.stdlibIndex || query.length === 0) {
       return [];
     }
 
-    const queryLower = query.toLowerCase();
-    const candidates: ImportableSymbolCandidate[] = [];
-
     const searchPaths = this.stdlibIndex.getAvailableModules();
 
+    // Populate cache for any modules not yet loaded
     for (const modulePath of searchPaths) {
+      if (this.stdlibSymbolCache.has(modulePath)) continue;
       const moduleInfo = await this.stdlibIndex.getModule(modulePath);
-      if (!moduleInfo?.symbols) {
-        continue;
+      if (moduleInfo?.symbols) {
+        this.stdlibSymbolCache.set(modulePath, moduleInfo.symbols);
       }
+    }
 
-      for (const [name, symbolInfo] of moduleInfo.symbols) {
-        if (!name.toLowerCase().startsWith(queryLower)) {
-          continue;
-        }
+    const candidates: ImportableSymbolCandidate[] = [];
+
+    for (const modulePath of searchPaths) {
+      const symbols = this.stdlibSymbolCache.get(modulePath);
+      if (!symbols) continue;
+
+      for (const [name, symbolInfo] of symbols) {
+        const matchScore = PikeIntrospectionService.fuzzyScore(query, name);
+        if (matchScore === 0) continue;
 
         const importKind: 'import' | 'inherit' = symbolInfo.kind === 'class' ? 'inherit' : 'import';
-        const exactBoost = name.toLowerCase() === queryLower ? 130 : 0;
+        const exactBoost = name.toLowerCase() === query.toLowerCase() ? 130 : 0;
         const kindBoost = importKind === 'inherit' ? 15 : 10;
 
         candidates.push({
           symbol: name,
           modulePath,
           importKind,
-          score: exactBoost + kindBoost + Math.max(0, 60 - modulePath.length),
+          score: exactBoost + kindBoost + Math.max(0, 60 - modulePath.length) + matchScore,
           source: 'stdlib-index',
         });
       }

--- a/packages/pike-lsp-server/src/tests/services/pike-introspection.test.ts
+++ b/packages/pike-lsp-server/src/tests/services/pike-introspection.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'bun:test';
+import type { IntrospectedSymbol } from '@pike-lsp/pike-bridge';
+import { PikeIntrospectionService } from '../../services/pike-introspection.js';
+import { createMockServices } from '../helpers/mock-services.js';
+
+/** Create a mock StdlibIndexManager with known modules and symbols. */
+function createMockStdlibIndex(
+  modules: {
+    path: string;
+    symbols: Map<string, IntrospectedSymbol>;
+  }[]
+) {
+  let getModuleCallCount = 0;
+  return {
+    getAvailableModules: () => modules.map(m => m.path),
+    getModule: async (modulePath: string) => {
+      getModuleCallCount++;
+      const mod = modules.find(m => m.path === modulePath);
+      return mod ? { symbols: mod.symbols, path: modulePath } : null;
+    },
+    _getModuleCallCount: () => getModuleCallCount,
+  };
+}
+
+function makeSymbol(
+  name: string,
+  kind: IntrospectedSymbol['kind'] = 'function'
+): IntrospectedSymbol {
+  return { name, kind };
+}
+
+describe('PikeIntrospectionService - searchImportableSymbols', () => {
+  const modules = [
+    {
+      path: 'Stream',
+      symbols: new Map<string, IntrospectedSymbol>([
+        ['read', makeSymbol('read', 'function')],
+        ['readBytes', makeSymbol('readBytes', 'function')],
+        ['write', makeSymbol('write', 'function')],
+      ]),
+    },
+    {
+      path: 'String',
+      symbols: new Map<string, IntrospectedSymbol>([
+        ['trim', makeSymbol('trim', 'function')],
+        ['trimAllWhites', makeSymbol('trimAllWhites', 'function')],
+        ['strlen', makeSymbol('strlen', 'function')],
+      ]),
+    },
+    {
+      path: 'Array',
+      symbols: new Map<string, IntrospectedSymbol>([
+        ['sort', makeSymbol('sort', 'function')],
+        ['ArrayIterator', makeSymbol('ArrayIterator', 'class')],
+      ]),
+    },
+  ];
+
+  function createService() {
+    const stdlibIndex = createMockStdlibIndex(modules);
+    const services = createMockServices();
+    const svc = new PikeIntrospectionService(services, undefined, stdlibIndex as never);
+    return { svc, stdlibIndex };
+  }
+
+  it('returns empty for empty query', async () => {
+    const { svc } = createService();
+    const results = await svc.searchImportableSymbols('');
+    expect(results).toEqual([]);
+  });
+
+  it('returns empty for whitespace-only query', async () => {
+    const { svc } = createService();
+    const results = await svc.searchImportableSymbols('   ');
+    expect(results).toEqual([]);
+  });
+
+  it('matches exact symbol name', async () => {
+    const { svc } = createService();
+    const results = await svc.searchImportableSymbols('read');
+    const symbols = results.map(r => r.symbol);
+    expect(symbols).toContain('read');
+  });
+
+  it('matches prefix (starts with query)', async () => {
+    const { svc } = createService();
+    const results = await svc.searchImportableSymbols('read');
+    const symbols = results.map(r => r.symbol);
+    expect(symbols).toContain('readBytes');
+  });
+
+  it('matches substring (query found inside name)', async () => {
+    const { svc } = createService();
+    const results = await svc.searchImportableSymbols('trim');
+    const symbols = results.map(r => r.symbol);
+    expect(symbols).toContain('trimAllWhites');
+  });
+
+  it('matches contiguous subsequence', async () => {
+    const { svc } = createService();
+    const results = await svc.searchImportableSymbols('rBy');
+    const symbols = results.map(r => r.symbol);
+    expect(symbols).toContain('readBytes');
+  });
+
+  it('ranks exact match higher than prefix match', async () => {
+    const { svc } = createService();
+    const results = await svc.searchImportableSymbols('read');
+    const readResult = results.find(r => r.symbol === 'read');
+    const readBytesResult = results.find(r => r.symbol === 'readBytes');
+    expect(readResult).toBeDefined();
+    expect(readBytesResult).toBeDefined();
+    expect(readResult!.score).toBeGreaterThan(readBytesResult!.score);
+  });
+
+  it('ranks prefix match higher than substring match', async () => {
+    const { svc } = createService();
+    const results = await svc.searchImportableSymbols('trim');
+    const trimResult = results.find(r => r.symbol === 'trim');
+    const trimAllResult = results.find(r => r.symbol === 'trimAllWhites');
+    expect(trimResult).toBeDefined();
+    expect(trimAllResult).toBeDefined();
+    expect(trimResult!.score).toBeGreaterThan(trimAllResult!.score);
+  });
+
+  it('does not match unrelated symbols', async () => {
+    const { svc } = createService();
+    const results = await svc.searchImportableSymbols('xyz');
+    expect(results).toEqual([]);
+  });
+
+  it('sets importKind to inherit for class symbols', async () => {
+    const { svc } = createService();
+    const results = await svc.searchImportableSymbols('ArrayIterator');
+    const match = results.find(r => r.symbol === 'ArrayIterator');
+    expect(match).toBeDefined();
+    expect(match!.importKind).toBe('inherit');
+  });
+
+  it('sets importKind to import for function symbols', async () => {
+    const { svc } = createService();
+    const results = await svc.searchImportableSymbols('sort');
+    const match = results.find(r => r.symbol === 'sort');
+    expect(match).toBeDefined();
+    expect(match!.importKind).toBe('import');
+  });
+
+  it('caches module symbols and does not re-fetch on second call', async () => {
+    const { svc, stdlibIndex } = createService();
+    // First call populates cache
+    await svc.searchImportableSymbols('read');
+    const countAfterFirst = stdlibIndex._getModuleCallCount();
+
+    // Second call should use cache, not re-fetch
+    await svc.searchImportableSymbols('write');
+    const countAfterSecond = stdlibIndex._getModuleCallCount();
+
+    expect(countAfterSecond).toBe(countAfterFirst);
+  });
+
+  it('invalidateStdlibCache clears cache and forces re-fetch', async () => {
+    const { svc, stdlibIndex } = createService();
+    // First call populates cache
+    await svc.searchImportableSymbols('read');
+    const countAfterFirst = stdlibIndex._getModuleCallCount();
+
+    // Invalidate cache
+    svc.invalidateStdlibCache();
+
+    // Second call must re-fetch from stdlibIndex
+    await svc.searchImportableSymbols('write');
+    const countAfterSecond = stdlibIndex._getModuleCallCount();
+
+    expect(countAfterSecond).toBeGreaterThan(countAfterFirst);
+  });
+
+  it('is case-insensitive', async () => {
+    const { svc } = createService();
+    const resultsLower = await svc.searchImportableSymbols('read');
+    const resultsUpper = await svc.searchImportableSymbols('READ');
+    expect(resultsLower.map(r => r.symbol).sort()).toEqual(resultsUpper.map(r => r.symbol).sort());
+  });
+
+  it('all candidates have source stdlib-index', async () => {
+    const { svc } = createService();
+    const results = await svc.searchImportableSymbols('r');
+    for (const r of results) {
+      expect(r.source).toBe('stdlib-index');
+    }
+  });
+});


### PR DESCRIPTION
Closes #1653

## Summary

1. **`pike-introspection.ts`** — Added `stdlibSymbolCache` Map (populated on first search, cleared via `invalidateStdlibCache()`), `fuzzyScore()` static method (exact/prefix/substring/contiguous-subsequence scoring), and rewrote `searchStdlibCandidates()` to use both. 2. **`pike-introspection.test.ts`** (new) — 15 tests covering all match types, ranking order, caching behavior, invalidation, case insensitivity, and import kind classification. 3. **`KB-1653.md`** — Knowledge base entry documenting the change.

## Linked Issue

Closes #1653

## Root Cause

searchStdlibCandidates() iterates over all stdlib modules (via getAvailableModules()), calls getModule() for each one, then iterates over all symbols doing toLowerCase().startsWith(queryLower). This is called on every auto-import completion request. Two issues: (A) getModule() results are not cached between calls — the same module's symbol list is re-read on every keystroke. (B) Only exact prefix matching is supported, missing substring and fuzzy matches that users expect from IntelliSense.

## Changes

- .agent-knowledge/reference/KB-1653.md: (see commit diffs)
- PROGRESS.md: (see commit diffs)
- packages/pike-lsp-server/src/features/advanced/semantic-tokens-builder.ts: (see commit diffs)
- packages/pike-lsp-server/src/services/pike-introspection.ts: (see commit diffs)
- packages/pike-lsp-server/src/tests/services/pike-introspection.test.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1653

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].