### PR TITLE
perf(#1672): Replace queue.shift() BFS with index-based iteration in inva

### DIFF
--- a/.agent-knowledge/reference/KB-1672.md
+++ b/.agent-knowledge/reference/KB-1672.md
@@ -1,0 +1,17 @@
+---
+id: KB-AUTO-1672
+domain: REFACTOR
+date: 2026-04-13
+authors: [dga-coder]
+summary: Replaced O(n) queue.shift() BFS with O(1) index-based iteration in CompilationCache.invalidate()
+---
+
+# KB-1672: Replace queue.shift() BFS with index-based iteration in invalidate()
+
+## Summary
+
+The transitive invalidation BFS in `CompilationCache.invalidate()` used `Array.shift()` to dequeue nodes, which is O(n) per call due to re-indexing. For a dependency graph with n files, this made BFS O(n^2). Replaced the `while` + `queue.shift()` pattern with a `for` loop using an index variable, maintaining FIFO order while making each dequeue O(1). The `!` non-null assertion is safe because the loop guard `i < queue.length` guarantees the index is in bounds.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/services/compilation-cache.ts: Replaced `while (queue.length > 0) { queue.shift() }` with `for (let i = 0; i < queue.length; i++) { queue[i]! }` in the `invalidate()` method's transitive BFS loop.

--- a/packages/pike-lsp-server/src/services/compilation-cache.ts
+++ b/packages/pike-lsp-server/src/services/compilation-cache.ts
@@ -102,11 +102,8 @@ export class CompilationCache<TResult> {
     const visited = new Set<string>([uri]);
     const invalidated: string[] = [];
 
-    while (queue.length > 0) {
-      const current = queue.shift();
-      if (!current) {
-        continue;
-      }
+    for (let i = 0; i < queue.length; i++) {
+      const current = queue[i]!;
 
       const dependents = this.dependentsByFile.get(current);
       if (dependents) {


### PR DESCRIPTION
Closes #1672

## Summary

The issue is on lines 105-107. Replace `while` + `queue.shift()` with a `for` loop using index-based iteration.Array index access is `string | undefined` in strict TS. Fix by asserting the index bounds (guaranteed by the loop condition).TypeScript compiles clean. Now run tests.All tests pass. Now write the KB entry.Done. The change replaces 4 lines (`while` + `shift` + null check + `continue`) with 2 lines (`for` + indexed access with `!` assertion). The BFS semantics are identical — FIFO order is preserved since we still push to the end and iterate from the front — but the dequeue cost drops from O(n) to O(1), making total transitive invalidation O(n) instead of O(n^2).

## Linked Issue

Closes #1672

## Root Cause

The transitive invalidation BFS in CompilationCache.invalidate() uses Array.shift() to dequeue nodes. Array.shift() is O(n) because it re-indexes all remaining elements. For a dependency graph with n files, this makes the BFS O(n^2) instead of O(n). Large workspaces with many inter-file dependencies will hit this.

## Changes

- .agent-knowledge/reference/KB-1672.md: (see commit diffs)
- packages/pike-lsp-server/src/services/compilation-cache.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1672

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].