### PR TITLE
fix(#1683): Guard fetchVersionInfoInternal against stale writes after st

### DIFF
--- a/.agent-knowledge/reference/KB-1683.md
+++ b/.agent-knowledge/reference/KB-1683.md
@@ -1,0 +1,18 @@
+---
+id: KB-AUTO-1683
+domain: REFACTOR
+date: 2026-04-13
+authors: [dga-coder]
+summary: Added stopped flag to BridgeManager to prevent stale writes to cachedVersion/startupMetrics after stop() clears them
+---
+
+# KB-1683: Guard fetchVersionInfoInternal against stale writes after stop()
+
+## Summary
+
+`BridgeManager.start()` fires `fetchVersionInfoInternal()` as fire-and-forget. If `stop()` is called while the version RPC is in-flight, `stop()` clears `cachedVersion` and `startupMetrics`, but the async function resumes after the await and overwrites them with stale data. Added a `stopped` boolean flag, set synchronously in `stop()` before clearing fields, and checked after the `await` in `fetchVersionInfoInternal()` to bail out early.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/services/bridge-manager.ts: Added `private stopped = false` field. Set it in `stop()` before clearing cached state. Checked it after `await this.bridge.getVersionInfo()` in `fetchVersionInfoInternal()`.
+- packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts: Added test verifying that `cachedVersion` and `startupMetrics` remain null after `stop()` completes, even when the in-flight version fetch resolves afterward.

--- a/packages/pike-lsp-server/src/services/bridge-manager.ts
+++ b/packages/pike-lsp-server/src/services/bridge-manager.ts
@@ -67,6 +67,8 @@ export class BridgeManager {
   private startupMetrics: { [key: string]: number } | null = null;
   /** PERF-013: Promise tracking for async version fetch */
   private versionFetchPromise: Promise<void> | null = null;
+  /** Guard against stale writes after stop() */
+  private stopped = false;
 
   constructor(
     public readonly bridge: PikeBridge | null,
@@ -129,6 +131,7 @@ export class BridgeManager {
     try {
       const versionFetchStartTime = performance.now();
       const versionInfo = await this.bridge.getVersionInfo();
+      if (this.stopped) return;
       const versionFetchTime = performance.now();
 
       // PERF-013: Update startup metrics with version fetch timing
@@ -176,6 +179,7 @@ export class BridgeManager {
    * Stop the bridge subprocess.
    */
   async stop(): Promise<void> {
+    this.stopped = true;
     if (this.bridge) await this.bridge.stop();
     // Clear cached version on stop
     this.cachedVersion = null;

--- a/packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts
+++ b/packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts
@@ -117,11 +117,16 @@ describe('BridgeManager parseFileSymbols', () => {
     const mockLogger = {
       debug: () => undefined,
       info: () => undefined,
-      warn: (...args: unknown[]) => { warnCalls.push(args); },
+      warn: (...args: unknown[]) => {
+        warnCalls.push(args);
+      },
       error: () => undefined,
     } as unknown as Logger;
 
-    const manager = new BridgeManager(createBridge(true, 1234) as unknown as PikeBridge, mockLogger);
+    const manager = new BridgeManager(
+      createBridge(true, 1234) as unknown as PikeBridge,
+      mockLogger
+    );
 
     await assert.rejects(
       () => manager.parseFileSymbols('/nonexistent/path/file.pike'),
@@ -134,7 +139,10 @@ describe('BridgeManager parseFileSymbols', () => {
 
     assert.ok(warnCalls.length >= 1, 'warn should be called for readFile error');
     const warnArg = String(warnCalls[0][0]);
-    assert.ok(warnArg.includes('/nonexistent/path/file.pike'), `warn message should include filePath, got: ${warnArg}`);
+    assert.ok(
+      warnArg.includes('/nonexistent/path/file.pike'),
+      `warn message should include filePath, got: ${warnArg}`
+    );
   });
 
   it('throws on readFile EACCES and logs filePath', async () => {
@@ -142,11 +150,16 @@ describe('BridgeManager parseFileSymbols', () => {
     const mockLogger = {
       debug: () => undefined,
       info: () => undefined,
-      warn: (...args: unknown[]) => { warnCalls.push(args); },
+      warn: (...args: unknown[]) => {
+        warnCalls.push(args);
+      },
       error: () => undefined,
     } as unknown as Logger;
 
-    const manager = new BridgeManager(createBridge(true, 1234) as unknown as PikeBridge, mockLogger);
+    const manager = new BridgeManager(
+      createBridge(true, 1234) as unknown as PikeBridge,
+      mockLogger
+    );
 
     // Use /proc/kcore or another path that will trigger EACCES on Linux
     // If running as root, this won't trigger EACCES, so we skip
@@ -171,16 +184,23 @@ describe('BridgeManager parseFileSymbols', () => {
     const mockLogger = {
       debug: () => undefined,
       info: () => undefined,
-      warn: (...args: unknown[]) => { warnCalls.push(args); },
+      warn: (...args: unknown[]) => {
+        warnCalls.push(args);
+      },
       error: () => undefined,
     } as unknown as Logger;
 
-    const manager = new BridgeManager({
-      isRunning: () => true,
-      on: () => undefined,
-      getDiagnostics: () => ({ options: {}, isRunning: true, pid: 1 }),
-      analyze: () => { throw new Error('analyze failed'); },
-    } as unknown as PikeBridge, mockLogger);
+    const manager = new BridgeManager(
+      {
+        isRunning: () => true,
+        on: () => undefined,
+        getDiagnostics: () => ({ options: {}, isRunning: true, pid: 1 }),
+        analyze: () => {
+          throw new Error('analyze failed');
+        },
+      } as unknown as PikeBridge,
+      mockLogger
+    );
 
     // Write a temporary file with valid content so readFile succeeds
     const { writeFile, mkdtemp, rm } = await import('node:fs/promises');
@@ -204,5 +224,44 @@ describe('BridgeManager parseFileSymbols', () => {
     const manager = new BridgeManager(null, createMockLogger());
     const result = await manager.parseFileSymbols('/any/path.pike');
     assert.deepEqual(result, []);
+  });
+});
+
+describe('BridgeManager stop() guards against stale writes', () => {
+  it('does not overwrite cachedVersion after stop() clears it', async () => {
+    let resolveVersion: (v: unknown) => void;
+    const manager = new BridgeManager(
+      {
+        isRunning: () => true,
+        on: () => undefined,
+        start: async () => undefined,
+        stop: async () => undefined,
+        getVersionInfo: () =>
+          new Promise(r => {
+            resolveVersion = r;
+          }),
+        getDiagnostics: () => ({ options: { pikePath: '/usr/bin/pike' }, isRunning: true, pid: 1 }),
+      } as unknown as PikeBridge,
+      createMockLogger()
+    );
+
+    // start() fires fetchVersionInfoInternal as fire-and-forget
+    await manager.start();
+
+    // Resolve version AFTER stop() is called but BEFORE stop() returns
+    // We achieve this by calling stop() and resolving the promise in sequence.
+    // Since stop() is async but the flag is set synchronously, the in-flight
+    // await should see stopped=true.
+    await manager.stop();
+
+    // Now resolve the pending promise (if it hasn't already)
+    resolveVersion!({ major: 8, minor: 0, build: 1116, version: '8.0.1116', display: 8.01116 });
+
+    // Wait a tick for the promise microtask to run
+    await new Promise(r => setTimeout(r, 0));
+
+    const health = await manager.getHealth();
+    assert.equal(health.pikeVersion, null, 'cachedVersion should remain null after stop()');
+    assert.equal(health.startupMetrics, null, 'startupMetrics should remain null after stop()');
   });
 });


### PR DESCRIPTION
Closes #1683

## Summary

Now I have the full picture. The fix is clear: add a `stopped` flag, set it in `stop()` before clearing fields, check it after the await in `fetchVersionInfoInternal()`.Now I'll apply all three edits:Now compile and run tests:TypeScript compiles clean. Now run tests:All 8 existing tests pass. Now I need to add a test that verifies the stale-write guard. Let me read the existing test file:Now I need to add a test for the stale-write guard. I'll add a `describe` block that tests `start()` + `stop()` interaction where version fetch is in-flight:Wait — there's a timing issue. `stop()` sets `stopped = true` synchronously, but the `resolveVersion` promise callback runs after `stop()` fully completes. The `await` in `fetchVersionInfoInternal` resolves when `resolveVersion` is called, which is after `stop()` has returned. So `this.stopped` will be `true`. But actually, there's a subtlety: since `stop()` is awaited before `resolveVersion` is called, the promise chain in `fetchVersionInfoInternal` will see `stopped = true` on the next microtask. This test should work correctly. Let me run it:All 9 tests pass (8 existing + 1 new). Now write the KB entry and submit:Done. Three-line fix: 1. **`private stopped = false`** — new field on `BridgeManager` 2. **`if (this.stopped) return;`** — early exit after the `await` in `fetchVersionInfoInternal()`

## Linked Issue

Closes #1683

## Root Cause

BridgeManager.start() fires fetchVersionInfoInternal() as fire-and-forget (no await). If stop() is called while getVersionInfo() is in-flight, stop() clears cachedVersion and startupMetrics, but the async function resumes after the await and overwrites them with stale data from a now-stopped bridge. getHealth() then reports phantom version info.

## Changes

- .agent-knowledge/reference/KB-1683.md: (see commit diffs)
- packages/pike-lsp-server/src/services/bridge-manager.ts: (see commit diffs)
- packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1683

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].