### PR TITLE
test(#1690): Add tests for resolution cache validation and error recovery

### DIFF
--- a/packages/pike-lsp-server/src/scenarios/resolution-cache-persistence.test.ts
+++ b/packages/pike-lsp-server/src/scenarios/resolution-cache-persistence.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, beforeEach, afterEach } from 'bun:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  loadResolutionCache,
+  saveResolutionCache,
+  deleteResolutionCache,
+} from '../services/resolution-cache-persistence.js';
+
+describe('loadResolutionCache', () => {
+  let originalXdgCache: string | undefined;
+  let cacheDir: string;
+
+  beforeEach(() => {
+    originalXdgCache = process.env['XDG_CACHE_HOME'];
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pike-cache-test-'));
+    process.env['XDG_CACHE_HOME'] = cacheDir;
+  });
+
+  afterEach(() => {
+    process.env['XDG_CACHE_HOME'] = originalXdgCache;
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  function writeCacheFile(content: string): void {
+    const dir = path.join(cacheDir, 'pike-lsp');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'resolution-cache.json'), content, 'utf-8');
+  }
+
+  it('returns null for non-JSON content', async () => {
+    writeCacheFile('{{not json}}');
+    const result = await loadResolutionCache('1.0.0');
+    assert.strictEqual(result, null);
+  });
+
+  it('returns null when version field does not match', async () => {
+    writeCacheFile(JSON.stringify({ version: 999, timestamp: Date.now(), data: 'hello' }));
+    const result = await loadResolutionCache('1.0.0');
+    assert.strictEqual(result, null);
+  });
+
+  it('returns null when pike version mismatches', async () => {
+    writeCacheFile(
+      JSON.stringify({
+        version: 1,
+        pikeVersion: '0.9.0',
+        timestamp: Date.now(),
+        data: 'hello',
+      })
+    );
+    const result = await loadResolutionCache('1.0.0');
+    assert.strictEqual(result, null);
+  });
+
+  it('returns null when cache timestamp is expired', async () => {
+    const expiredTimestamp = Date.now() - 8 * 24 * 60 * 60 * 1000; // 8 days ago
+    writeCacheFile(
+      JSON.stringify({
+        version: 1,
+        pikeVersion: '1.0.0',
+        timestamp: expiredTimestamp,
+        data: 'hello',
+      })
+    );
+    const result = await loadResolutionCache('1.0.0');
+    assert.strictEqual(result, null);
+  });
+
+  it('returns null when data field is missing', async () => {
+    writeCacheFile(
+      JSON.stringify({
+        version: 1,
+        pikeVersion: '1.0.0',
+        timestamp: Date.now(),
+      })
+    );
+    const result = await loadResolutionCache('1.0.0');
+    assert.strictEqual(result, null);
+  });
+
+  it('returns null when data field is not a string', async () => {
+    writeCacheFile(
+      JSON.stringify({
+        version: 1,
+        pikeVersion: '1.0.0',
+        timestamp: Date.now(),
+        data: 42,
+      })
+    );
+    const result = await loadResolutionCache('1.0.0');
+    assert.strictEqual(result, null);
+  });
+
+  it('returns null when parsed value is a primitive (not object)', async () => {
+    writeCacheFile('"just a string"');
+    const result = await loadResolutionCache('1.0.0');
+    assert.strictEqual(result, null);
+  });
+
+  it('returns null when parsed value is null literal', async () => {
+    writeCacheFile('null');
+    const result = await loadResolutionCache('1.0.0');
+    assert.strictEqual(result, null);
+  });
+
+  it('returns null when parsed value is an array', async () => {
+    writeCacheFile('[1, 2, 3]');
+    const result = await loadResolutionCache('1.0.0');
+    assert.strictEqual(result, null);
+  });
+
+  it('returns null for ENOENT (file does not exist)', async () => {
+    const result = await loadResolutionCache('1.0.0');
+    assert.strictEqual(result, null);
+  });
+
+  it('returns data string for a valid cache', async () => {
+    writeCacheFile(
+      JSON.stringify({
+        version: 1,
+        pikeVersion: '1.0.0',
+        timestamp: Date.now(),
+        data: 'cached-resolution-data',
+      })
+    );
+    const result = await loadResolutionCache('1.0.0');
+    assert.strictEqual(result, 'cached-resolution-data');
+  });
+
+  it('accepts valid cache without pikeVersion when no currentPikeVersion provided', async () => {
+    writeCacheFile(
+      JSON.stringify({
+        version: 1,
+        timestamp: Date.now(),
+        data: 'no-pike-version',
+      })
+    );
+    const result = await loadResolutionCache();
+    assert.strictEqual(result, 'no-pike-version');
+  });
+
+  it('accepts valid cache with pikeVersion mismatch when no currentPikeVersion provided', async () => {
+    writeCacheFile(
+      JSON.stringify({
+        version: 1,
+        pikeVersion: '0.5.0',
+        timestamp: Date.now(),
+        data: 'mismatch-ok-without-current',
+      })
+    );
+    const result = await loadResolutionCache();
+    assert.strictEqual(result, 'mismatch-ok-without-current');
+  });
+});
+
+describe('saveResolutionCache and loadResolutionCache round-trip', () => {
+  let originalXdgCache: string | undefined;
+  let cacheDir: string;
+
+  beforeEach(() => {
+    originalXdgCache = process.env['XDG_CACHE_HOME'];
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pike-cache-test-'));
+    process.env['XDG_CACHE_HOME'] = cacheDir;
+  });
+
+  afterEach(() => {
+    process.env['XDG_CACHE_HOME'] = originalXdgCache;
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it('round-trips data through save and load', async () => {
+    await saveResolutionCache('test-data-123', '2.0.0');
+    const loaded = await loadResolutionCache('2.0.0');
+    assert.strictEqual(loaded, 'test-data-123');
+  });
+});
+
+describe('deleteResolutionCache', () => {
+  let originalXdgCache: string | undefined;
+  let cacheDir: string;
+
+  beforeEach(() => {
+    originalXdgCache = process.env['XDG_CACHE_HOME'];
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pike-cache-test-'));
+    process.env['XDG_CACHE_HOME'] = cacheDir;
+  });
+
+  afterEach(() => {
+    process.env['XDG_CACHE_HOME'] = originalXdgCache;
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it('removes the cache file after save', async () => {
+    await saveResolutionCache('to-be-deleted', '1.0.0');
+    const loaded = await loadResolutionCache('1.0.0');
+    assert.strictEqual(loaded, 'to-be-deleted');
+
+    await deleteResolutionCache();
+    const afterDelete = await loadResolutionCache('1.0.0');
+    assert.strictEqual(afterDelete, null);
+  });
+
+  it('does not throw when cache file does not exist', async () => {
+    await assert.doesNotReject(async () => {
+      await deleteResolutionCache();
+    });
+  });
+});


### PR DESCRIPTION
Closes #1690

## Summary

Now I have a clear understanding of the target function and the project patterns. Let me write the test file.All 16 tests pass. Now let me verify TypeScript compilation:Typecheck passes. Let me also run the full test to confirm no regressions:All green.Done. Created `packages/pike-lsp-server/src/scenarios/resolution-cache-persistence.test.ts` with 16 tests covering every validation branch in `loadResolutionCache()`: - Non-JSON content → null - Wrong `version` field → null

## Linked Issue

Closes #1690

## Root Cause

loadResolutionCache() contains multiple validation branches (schema version mismatch, pike version mismatch, expired cache, invalid data field type, non-object parse result) but has no dedicated test coverage. These branches handle cache corruption on disk — a common real-world scenario when the cache file is partially written or the format changes between server versions.

## Changes

- packages/pike-lsp-server/src/scenarios/resolution-cache-persistence.test.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1690

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].