### PR TITLE
fix(#1695): Fix formatRange() filter to exclude edits spanning outside r

### DIFF
--- a/.agent-knowledge/reference/KB-1695.md
+++ b/.agent-knowledge/reference/KB-1695.md
@@ -1,0 +1,18 @@
+---
+id: KB-AUTO-1695
+domain: REFACTOR
+date: 2026-04-13
+authors: [dga-coder]
+summary: Fixed formatRange() filter from inclusive overlap to strict containment, preventing edits from being applied outside the requested range
+---
+
+# KB-1695: Fix formatRange() filter to use strict containment
+
+## Summary
+
+`formatRange()` in `formatting-service.ts` filtered edits using inclusive overlap (`start <= endLine && end >= startLine`), which allowed edits spanning outside the requested range to leak through. This violated the LSP spec for range formatting. Changed to strict containment (`start >= startLine && end <= endLine`). Added a regression test.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/services/formatting-service.ts: Changed filter condition from inclusive overlap to strict containment
+- packages/pike-lsp-server/src/tests/formatting.test.ts: Added test verifying formatRange excludes edits outside [5,8] on a 20-line document

--- a/packages/pike-lsp-server/src/services/formatting-service.ts
+++ b/packages/pike-lsp-server/src/services/formatting-service.ts
@@ -143,7 +143,7 @@ export class FormattingService {
 
     const edits = formatPikeCodeWithProfile(text, indent, 0, profile);
     return edits.filter(
-      edit => edit.range.start.line <= endLine && edit.range.end.line >= startLine
+      edit => edit.range.start.line >= startLine && edit.range.end.line <= endLine
     );
   }
 }

--- a/packages/pike-lsp-server/src/tests/formatting.test.ts
+++ b/packages/pike-lsp-server/src/tests/formatting.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'bun:test';
 import assert from 'node:assert/strict';
+import { FormattingService } from '../services/formatting-service.js';
 import { formatPikeCode } from '../features/advanced/formatting.js';
 import { TextEdit } from 'vscode-languageserver/node.js';
 
@@ -540,5 +541,48 @@ void test() {
 }`.trim();
 
     assert.equal(format(input), expected);
+  });
+
+  describe('formatRange containment', () => {
+    it('excludes edits that start before or end after the requested range', () => {
+      // 20-line document: lines 0-4 need no indent, lines 5-19 are inside a class
+      const text = [
+        'class Foo {', // 0
+        '  int a;', // 1
+        '  int b;', // 2
+        '  int c;', // 3
+        '  int d;', // 4
+        'void bar() {', // 5
+        'int x;', // 6
+        '}', // 7
+        '}', // 8
+        '// padding', // 9
+        '// padding', // 10
+        '// padding', // 11
+        '// padding', // 12
+        '// padding', // 13
+        '// padding', // 14
+        '// padding', // 15
+        '// padding', // 16
+        '// padding', // 17
+        '// padding', // 18
+        '// padding', // 19
+      ].join('\n');
+
+      const svc = new FormattingService();
+      const edits = svc.formatRange(text, 5, 8, { tabSize: 4, insertSpaces: true });
+
+      // Every edit must be fully within [5, 8]
+      for (const edit of edits) {
+        assert.ok(
+          edit.range.start.line >= 5,
+          `Edit starts at line ${edit.range.start.line}, expected >= 5`
+        );
+        assert.ok(
+          edit.range.end.line <= 8,
+          `Edit ends at line ${edit.range.end.line}, expected <= 8`
+        );
+      }
+    });
   });
 });


### PR DESCRIPTION
Closes #1695

## Summary

Now I'll fix the filter and find the test file to add the test case.Now I need to add a test for `formatRange` containment. The existing tests use `formatPikeCode`, not the `FormattingService` class. I'll add a focused test at the end of the file.Wait — I just replaced the `formatPikeCode` import with `FormattingService`, breaking all existing tests. Let me fix that.Now let me run the typecheck and tests.Typecheck passes. Now run the tests:All 23 tests pass (22 existing + 1 new). Now write the KB entry:Done. The fix is a one-line filter change in `formatRange()` at line 146 of `formatting-service.ts`, switching from inclusive overlap to strict containment. The regression test verifies that edits on a 20-line document with range `[5,8]` never touch lines outside that range.

## Linked Issue

Closes #1695

## Root Cause

formatRange() computes edits for the entire document then filters with `edit.range.start.line <= endLine && edit.range.end.line >= startLine`. This includes edits that start before or end after the requested range. Per the LSP spec, range formatting must only return edits that modify lines within the requested range. An indentation edit on lines 0-10 would be returned even when the range is 5-10, causing the client to apply changes outside the user's selection.

## Changes

- .agent-knowledge/reference/KB-1695.md: (see commit diffs)
- packages/pike-lsp-server/src/services/formatting-service.ts: (see commit diffs)
- packages/pike-lsp-server/src/tests/formatting.test.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1695

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].