### PR TITLE
feat(#1737): Remove unused _getSettings parameter from WorkspaceScanner c

### DIFF
--- a/.agent-knowledge/reference/KB-1737.md
+++ b/.agent-knowledge/reference/KB-1737.md
@@ -1,0 +1,18 @@
+---
+id: KB-AUTO-1737
+domain: REFACTOR
+date: 2026-04-14
+authors: [dga-coder]
+summary: Removed unused _getSettings parameter and dead PikeSettings import from WorkspaceScanner
+---
+
+# KB-1737: Remove unused \_getSettings from WorkspaceScanner constructor
+
+## Summary
+
+The `WorkspaceScanner` constructor accepted a `_getSettings: () => PikeSettings` parameter that was never used — all scan behavior uses hardcoded `DEFAULT_OPTIONS`. Removed the parameter, the dead `PikeSettings` type import, and updated the sole callsite in `server.ts`.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/services/workspace-scanner.ts: Removed `_getSettings` constructor parameter and `PikeSettings` import
+- packages/pike-lsp-server/src/server.ts: Removed `() => globalSettings` argument from `new WorkspaceScanner(logger, ...)`

--- a/packages/pike-lsp-server/src/server.ts
+++ b/packages/pike-lsp-server/src/server.ts
@@ -98,7 +98,7 @@ const logger = new Logger('PikeLSPServer');
 const documentCache = new DocumentCache();
 const typeDatabase = new TypeDatabase();
 const workspaceIndex = new WorkspaceIndex();
-const workspaceScanner = new WorkspaceScanner(logger, () => globalSettings);
+const workspaceScanner = new WorkspaceScanner(logger);
 const moduleContext = new ModuleContext();
 const formattingService = new FormattingService();
 let pikeIntrospection: PikeIntrospectionService | null = null;

--- a/packages/pike-lsp-server/src/services/workspace-scanner.ts
+++ b/packages/pike-lsp-server/src/services/workspace-scanner.ts
@@ -18,7 +18,6 @@ function stripTrailingSlash(value: string): string {
 
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
-import type { PikeSettings } from '../core/types.js';
 import type { IntrospectedSymbol, PikeToken } from '@pike-lsp/pike-bridge';
 import { Logger } from '@pike-lsp/core';
 
@@ -72,10 +71,7 @@ export class WorkspaceScanner {
   private scanPending: boolean = false;
   private initialized: boolean = false;
 
-  constructor(
-    private readonly logger: Logger,
-    _getSettings: () => PikeSettings
-  ) {}
+  constructor(private readonly logger: Logger) {}
 
   /**
    * Initialize the workspace scanner with workspace folders.


### PR DESCRIPTION
Closes #1737

## Summary

The `_getSettings` parameter is unused in the constructor and the import of `PikeSettings` is also dead. Let me make both edits.TypeScript compiles clean. Now run tests.Now write the KB entry and submit.Done. Removed the unused `_getSettings` parameter from `WorkspaceScanner` constructor, deleted the dead `PikeSettings` import, and updated the callsite in `server.ts`. TypeScript compiles clean and tests pass.

## Linked Issue

Closes #1737

## Root Cause

The WorkspaceScanner constructor accepts a _getSettings: () => PikeSettings parameter but never uses it. All scan behavior uses hardcoded DEFAULT_OPTIONS. The underscore prefix indicates the author knew it was unused, but leaving it in the API is misleading — callers may believe settings are respected.

## Changes

- .agent-knowledge/reference/KB-1737.md: (see commit diffs)
- packages/pike-lsp-server/src/server.ts: (see commit diffs)
- packages/pike-lsp-server/src/services/workspace-scanner.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1737

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].