### PR TITLE
fix(#1748): Guard fetchVersionInfoInternal against stale writes after st

### DIFF
--- a/.agent-knowledge/reference/KB-1748.md
+++ b/.agent-knowledge/reference/KB-1748.md
@@ -1,0 +1,17 @@
+---
+id: KB-AUTO-1748
+domain: FIX
+date: 2026-04-14
+authors: [dga-coder]
+summary: Added a second stopped guard after await realpath() in fetchVersionInfoInternal to prevent stale writes when stop() interleaves during the async path resolution
+---
+
+# KB-1748: Guard fetchVersionInfoInternal against stale writes after realpath
+
+## Summary
+
+PR #1759 replaced `fs.realpathSync()` with async `realpath()` from `node:fs/promises` in `fetchVersionInfoInternal()`. This introduced a second yield point where `stop()` could interleave, clear `cachedVersion`, and then the resumed async function would overwrite it with stale data. Added a `if (this.stopped) return;` guard after `await realpath(pikePath)`, mirroring the existing guard after `await getVersionInfo()`. Added a test using `spyOn` to intercept `realpath` and verify the guard works.
+
+## Key Files Changed
+- packages/pike-lsp-server/src/services/bridge-manager.ts: Added `if (this.stopped) return;` after `await realpath(pikePath)` on line 157
+- packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts: Added test for second guard using spyOn on node:fs/promises.realpath

--- a/.agent-knowledge/reference/KB-1752.md
+++ b/.agent-knowledge/reference/KB-1752.md
@@ -1,0 +1,16 @@
+---
+id: KB-AUTO-1752
+domain: REFACTOR
+date: 2026-04-14
+authors: [dga-coder]
+summary: Added missing stopped guard after realpath() in fetchVersionInfoInternal and added corresponding test
+---
+
+# KB-1752: Add stopped guard after realpath() and missing test for PR #1752
+
+## Summary
+PR #1752 replaced `fs.realpathSync` with `await realpath()` but did not add a `stopped` guard after the new await point, leaving a window where `cachedVersion` could be overwritten after `stop()`. Added `if (this.stopped) return;` after the `realpath()` call. Also added the test that was claimed to exist in the PR body but was missing from the diff — it uses `spyOn` on `node:fs/promises.realpath` to delay resolution, calls `stop()` during the delay, then asserts `cachedVersion` remains null.
+
+## Key Files Changed
+- packages/pike-lsp-server/src/services/bridge-manager.ts: Added `if (this.stopped) return;` after `await realpath(pikePath)` to prevent stale writes after stop()
+- packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts: Added test 'does not overwrite cachedVersion when stop() is called during realpath() delay' using spyOn on node:fs/promises.realpath. Added spyOn to bun:test imports.

--- a/packages/pike-lsp-server/src/services/bridge-manager.ts
+++ b/packages/pike-lsp-server/src/services/bridge-manager.ts
@@ -156,6 +156,8 @@ export class BridgeManager {
           resolvedPath = await realpath(pikePath);
         }
 
+        if (this.stopped) return;
+
         this.cachedVersion = {
           ...versionInfo,
           pikePath: resolvedPath,

--- a/packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts
+++ b/packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'bun:test';
+import { describe, it, spyOn } from 'bun:test';
 import type { PikeBridge } from '@pike-lsp/pike-bridge';
 import * as assert from 'node:assert/strict';
 import type { Logger } from '@pike-lsp/core';
@@ -264,4 +264,47 @@ describe('BridgeManager stop() guards against stale writes', () => {
     assert.equal(health.pikeVersion, null, 'cachedVersion should remain null after stop()');
     assert.equal(health.startupMetrics, null, 'startupMetrics should remain null after stop()');
   });
+
+  it('does not overwrite cachedVersion when stop() is called during realpath() delay', async () => {
+    let resolveRealpath: (v: string) => void;
+    const fsp = await import('node:fs/promises');
+    const realpathSpy = spyOn(fsp, 'realpath').mockImplementation(() => {
+      return new Promise(r => {
+        resolveRealpath = r;
+      });
+    });
+
+    const manager = new BridgeManager(
+      {
+        isRunning: () => true,
+        on: () => undefined,
+        start: async () => undefined,
+        stop: async () => undefined,
+        getVersionInfo: async () => ({
+          major: 8, minor: 0, build: 1116, version: '8.0.1116', display: 8.01116,
+        }),
+        getDiagnostics: () => ({ options: { pikePath: '/usr/bin/pike' }, isRunning: true, pid: 1 }),
+      } as unknown as PikeBridge,
+      createMockLogger()
+    );
+
+    // start() fires fetchVersionInfoInternal as fire-and-forget.
+    // getVersionInfo resolves immediately, but realpath() is delayed.
+    await manager.start();
+
+    // Call stop() while realpath() is still pending
+    await manager.stop();
+
+    // Now resolve the delayed realpath
+    resolveRealpath!('/usr/bin/pike');
+
+    // Wait for the promise microtask to run
+    await new Promise(r => setTimeout(r, 0));
+
+    const health = await manager.getHealth();
+    assert.equal(health.pikeVersion, null, 'cachedVersion should remain null after stop() during realpath delay');
+
+    realpathSpy.mockRestore();
+  });
+
 });


### PR DESCRIPTION
Closes #1748

## Summary

Adds a second `stopped` guard in `fetchVersionInfoInternal()` after `await realpath(pikePath)`. The existing guard after `await getVersionInfo()` was already correct, but after PR #1759 replaced `fs.realpathSync()` with async `realpath()`, a new yield point was introduced that could allow `stop()` to interleave and clear `cachedVersion`, only for the resumed function to overwrite it with stale data.

## Linked Issue

Closes #1748

## Root Cause

BridgeManager.start() fires fetchVersionInfoInternal() as fire-and-forget (no await). If stop() is called while realpath() is in-flight, stop() clears cachedVersion and startupMetrics, but the async function resumes after the await and overwrites them with stale data from a now-stopped bridge. getHealth() then reports phantom version info.

## Changes

- `packages/pike-lsp-server/src/services/bridge-manager.ts`: Added `if (this.stopped) return;` guard on line 157, immediately after `await realpath(pikePath)`. This mirrors the existing guard on line 133 after `await getVersionInfo()`.
- `packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts`: Added test "does not overwrite cachedVersion when stop() is called during realpath() delay" that uses `spyOn` to intercept `node:fs/promises.realpath`, delays its resolution, calls `stop()` during the delay, then asserts `cachedVersion` remains null.

## Knowledge Base

- [x] Added/updated KB entry
- KB ID: KB-AUTO-1748

## Verification

```
$ bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json
(no output — clean)

$ bun test packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts
bun test v1.3.12 (700fc117)

 10 pass
 0 fail
Ran 10 tests across 1 file. [108.00ms]
```

## Checklist

- [x] Automated tests included
- [x] No test coverage regression
- [x] Typecheck passes clean

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].
