### PR TITLE
fix(#1773): Fix formatRange() to clip edits instead of filtering by line

### DIFF
--- a/.agent-knowledge/reference/KB-1748.md
+++ b/.agent-knowledge/reference/KB-1748.md
@@ -13,5 +13,6 @@ summary: Added a second stopped guard after await realpath() in fetchVersionInfo
 PR #1759 replaced `fs.realpathSync()` with async `realpath()` from `node:fs/promises` in `fetchVersionInfoInternal()`. This introduced a second yield point where `stop()` could interleave, clear `cachedVersion`, and then the resumed async function would overwrite it with stale data. Added a `if (this.stopped) return;` guard after `await realpath(pikePath)`, mirroring the existing guard after `await getVersionInfo()`. Added a test using `spyOn` to intercept `realpath` and verify the guard works.
 
 ## Key Files Changed
+
 - packages/pike-lsp-server/src/services/bridge-manager.ts: Added `if (this.stopped) return;` after `await realpath(pikePath)` on line 157
 - packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts: Added test for second guard using spyOn on node:fs/promises.realpath

--- a/.agent-knowledge/reference/KB-1752.md
+++ b/.agent-knowledge/reference/KB-1752.md
@@ -9,8 +9,10 @@ summary: Added missing stopped guard after realpath() in fetchVersionInfoInterna
 # KB-1752: Add stopped guard after realpath() and missing test for PR #1752
 
 ## Summary
+
 PR #1752 replaced `fs.realpathSync` with `await realpath()` but did not add a `stopped` guard after the new await point, leaving a window where `cachedVersion` could be overwritten after `stop()`. Added `if (this.stopped) return;` after the `realpath()` call. Also added the test that was claimed to exist in the PR body but was missing from the diff — it uses `spyOn` on `node:fs/promises.realpath` to delay resolution, calls `stop()` during the delay, then asserts `cachedVersion` remains null.
 
 ## Key Files Changed
+
 - packages/pike-lsp-server/src/services/bridge-manager.ts: Added `if (this.stopped) return;` after `await realpath(pikePath)` to prevent stale writes after stop()
 - packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts: Added test 'does not overwrite cachedVersion when stop() is called during realpath() delay' using spyOn on node:fs/promises.realpath. Added spyOn to bun:test imports.

--- a/.agent-knowledge/reference/KB-1773.md
+++ b/.agent-knowledge/reference/KB-1773.md
@@ -1,0 +1,18 @@
+---
+id: KB-AUTO-1773
+domain: REFACTOR
+date: 2026-04-14
+authors: [dga-coder]
+summary: Fixed formatRange() to clip overlapping edits to range boundaries instead of silently discarding them
+---
+
+# KB-1773: Fix formatRange() to clip edits instead of filtering by line range
+
+## Summary
+
+`formatRange()` generated all edits for the full document then filtered by strict containment (`start >= rangeStart && end <= rangeEnd`), discarding edits that spanned outside the selection. This caused partial/inconsistent formatting when a user selected a range — e.g., an indentation edit on line 5 that also affected line 10 would be silently dropped if the range was lines 6-9. Fixed by changing to overlap detection and clipping partially overlapping edits to the requested range boundaries using a new `clipEditToRange()` helper.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/services/formatting-service.ts: Changed filter to overlap detection (`start.line <= endLine && end.line >= startLine`), added `clipEditToRange()` function that adjusts range and newText for partially overlapping edits. Added `Position` import.
+- packages/pike-lsp-server/src/tests/formatting.test.ts: Updated existing containment test to verify clipping behavior, added two new tests for overlap inclusion and full exclusion.

--- a/packages/pike-lsp-server/src/services/formatting-service.ts
+++ b/packages/pike-lsp-server/src/services/formatting-service.ts
@@ -1,4 +1,4 @@
-import { ErrorCodes, ResponseError, TextEdit } from 'vscode-languageserver/node.js';
+import { ErrorCodes, Position, ResponseError, TextEdit } from 'vscode-languageserver/node.js';
 
 // Re-export types and profiles
 export {
@@ -138,10 +138,49 @@ export class FormattingService {
     const profile = this.resolveProfile(options);
 
     const edits = formatPikeCodeWithProfile(text, indent, 0, profile);
-    return edits.filter(
-      edit => edit.range.start.line >= startLine && edit.range.end.line <= endLine
-    );
+    return edits
+      .filter(e => e.range.start.line <= endLine && e.range.end.line >= startLine)
+      .map(e => clipEditToRange(e, text, startLine, endLine));
   }
+}
+
+function clipEditToRange(
+  edit: TextEdit,
+  text: string,
+  startLine: number,
+  endLine: number
+): TextEdit {
+  // Fully contained — no clipping needed
+  if (edit.range.start.line >= startLine && edit.range.end.line <= endLine) {
+    return edit;
+  }
+
+  const lines = text.split('\n');
+  const startPos =
+    edit.range.start.line < startLine ? Position.create(startLine, 0) : edit.range.start;
+  const endLineLen = lines[endLine]?.length ?? 0;
+  const endPos =
+    edit.range.end.line > endLine ? Position.create(endLine, endLineLen) : edit.range.end;
+
+  // Compute the portion of newText that falls within the clipped range
+  const clippedStartCol = edit.range.start.line < startLine ? 0 : edit.range.start.character;
+  const clippedEndCol = edit.range.end.line > endLine ? endLineLen : edit.range.end.character;
+  const newTextLines = edit.newText.split('\n');
+  let clippedNewText: string;
+
+  if (edit.range.start.line === edit.range.end.line) {
+    // Single-line edit
+    clippedNewText = newTextLines[0]!.slice(clippedStartCol, clippedEndCol);
+  } else {
+    // Multi-line edit: take from the adjusted start column on the first line
+    // to the adjusted end column on the last line
+    const firstLine = newTextLines[0]!.slice(clippedStartCol);
+    const lastLine = newTextLines[newTextLines.length - 1]!.slice(0, clippedEndCol);
+    const middleLines = newTextLines.slice(1, -1);
+    clippedNewText = [firstLine, ...middleLines, lastLine].join('\n');
+  }
+
+  return TextEdit.replace({ start: startPos, end: endPos }, clippedNewText);
 }
 
 export function formatPikeCode(text: string, indent: string, startLine = 0): TextEdit[] {

--- a/packages/pike-lsp-server/src/tests/formatting.test.ts
+++ b/packages/pike-lsp-server/src/tests/formatting.test.ts
@@ -543,8 +543,8 @@ void test() {
     assert.equal(format(input), expected);
   });
 
-  describe('formatRange containment', () => {
-    it('excludes edits that start before or end after the requested range', () => {
+  describe('formatRange clipping', () => {
+    it('clips edits that extend beyond the requested range instead of discarding', () => {
       // 20-line document: lines 0-4 need no indent, lines 5-19 are inside a class
       const text = [
         'class Foo {', // 0
@@ -572,7 +572,7 @@ void test() {
       const svc = new FormattingService();
       const edits = svc.formatRange(text, 5, 8, { tabSize: 4, insertSpaces: true });
 
-      // Every edit must be fully within [5, 8]
+      // Every edit must be clipped to [5, 8]
       for (const edit of edits) {
         assert.ok(
           edit.range.start.line >= 5,
@@ -583,6 +583,30 @@ void test() {
           `Edit ends at line ${edit.range.end.line}, expected <= 8`
         );
       }
+    });
+
+    it('includes edits that overlap the range start or end', () => {
+      // A 3-line class where formatRange(1, 2) covers only line 1.
+      // Indentation edit on line 1 (the class body) must not be dropped.
+      const text = ['class X {', 'int y;', '}'].join('\n');
+
+      const svc = new FormattingService();
+      const edits = svc.formatRange(text, 1, 2, { tabSize: 2, insertSpaces: true });
+
+      const bodyEdit = edits.find(e => e.range.start.line === 1 && e.range.end.line === 1);
+      assert.ok(bodyEdit, 'Should include indent edit for line 1 (class body)');
+      assert.strictEqual(bodyEdit!.newText, '  ', '2-space indent for class body');
+    });
+
+    it('excludes edits fully outside the range', () => {
+      const text = ['class X {', 'int a;', 'int b;', '}'].join('\n');
+
+      const svc = new FormattingService();
+      const edits = svc.formatRange(text, 2, 2, { tabSize: 2, insertSpaces: true });
+
+      // Line 0 (class header) is outside [2, 2] — no edit for it
+      const line0Edit = edits.find(e => e.range.start.line === 0);
+      assert.ok(!line0Edit, 'Should exclude edits for line 0 which is outside range [2,2]');
     });
   });
 });

--- a/packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts
+++ b/packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts
@@ -281,7 +281,11 @@ describe('BridgeManager stop() guards against stale writes', () => {
         start: async () => undefined,
         stop: async () => undefined,
         getVersionInfo: async () => ({
-          major: 8, minor: 0, build: 1116, version: '8.0.1116', display: 8.01116,
+          major: 8,
+          minor: 0,
+          build: 1116,
+          version: '8.0.1116',
+          display: 8.01116,
         }),
         getDiagnostics: () => ({ options: { pikePath: '/usr/bin/pike' }, isRunning: true, pid: 1 }),
       } as unknown as PikeBridge,
@@ -302,9 +306,12 @@ describe('BridgeManager stop() guards against stale writes', () => {
     await new Promise(r => setTimeout(r, 0));
 
     const health = await manager.getHealth();
-    assert.equal(health.pikeVersion, null, 'cachedVersion should remain null after stop() during realpath delay');
+    assert.equal(
+      health.pikeVersion,
+      null,
+      'cachedVersion should remain null after stop() during realpath delay'
+    );
 
     realpathSpy.mockRestore();
   });
-
 });


### PR DESCRIPTION
Closes #1773

## Summary

1. Change filter to overlap detection: `edit.range.start.line <= endLine && edit.range.end.line >= startLine` 2. For partially overlapping edits, clip them to the range boundariesNow update the existing test to match the new behavior (overlapping edits are clipped, not excluded):Let me verify there's no duplicate closing brace:Good, no duplication. Now let me typecheck and run tests:The issue is `newTextLines[0]` and `newTextLines[newTextLines.length - 1]` being possibly undefined. The `.split('\n')` can't actually return an empty array, but TS doesn't know that. Fix with non-null assertions since `split` on a string always returns at least one element:TypeScript compiles clean. Now run the tests:All 25 tests pass. Now write the KB entry:The fix is complete. Here's a summary: **Root cause**: `formatRange()` used strict containment filtering (`start >= rangeStart && end <= rangeEnd`), which silently dropped edits spanning outside the selection — e.g., an indentation change on line 5 affecting line 10 would be discarded if the user selected lines 6-9.

## Linked Issue

Closes #1773

## Root Cause

formatRange() generates all edits for the full document then filters by line range, discarding edits that span outside the selection. An indentation edit on line 5 that affects line 10 is silently dropped if the range is lines 6-9. This causes partial/inconsistent formatting when a user selects a range.

## Changes

- .agent-knowledge/reference/KB-1748.md: (see commit diffs)
- .agent-knowledge/reference/KB-1752.md: (see commit diffs)
- .agent-knowledge/reference/KB-1773.md: (see commit diffs)
- packages/pike-lsp-server/src/services/formatting-service.ts: (see commit diffs)
- packages/pike-lsp-server/src/tests/formatting.test.ts: (see commit diffs)
- packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1773

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].