### PR TITLE
test(#1795): Add tests for searchStdlibCandidates fuzzy scoring and dedup

### DIFF
--- a/packages/pike-lsp-server/src/scenarios/stdlib-fuzzy-scoring.test.ts
+++ b/packages/pike-lsp-server/src/scenarios/stdlib-fuzzy-scoring.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, beforeEach } from 'bun:test';
+import assert from 'node:assert/strict';
+import { PikeIntrospectionService } from '../services/pike-introspection.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function noopLogger() {
+  return { debug() {}, info() {}, warn() {}, error() {} };
+}
+
+function makeServices() {
+  return {
+    bridge: null,
+    logger: noopLogger(),
+    documentCache: {
+      get() {
+        return undefined;
+      },
+      entries() {
+        return [];
+      },
+    },
+    moduleContext: null,
+    typeDatabase: {},
+    workspaceIndex: {},
+    stdlibIndex: null,
+    includeResolver: null,
+    workspaceScanner: {
+      isReady: () => true,
+      getAllFiles: () => [],
+      getUncachedFiles: () => [],
+      getFile: () => undefined,
+      updateFileData() {},
+      invalidateFile() {},
+      upsertFile() {},
+      removeFile() {},
+      getStats: () => ({ fileCount: 0, rootCount: 0, cachedFiles: 0 }),
+    },
+    globalSettings: { pikePath: 'pike', maxNumberOfProblems: 100, diagnosticDelay: 0 },
+    includePaths: [],
+  };
+}
+
+function makeStdlibIndex(modules: Map<string, Map<string, { kind: string }>>) {
+  return {
+    getAvailableModules: () => [...modules.keys()],
+    getModule: async (path: string) => {
+      const symbols = modules.get(path);
+      if (!symbols) return null;
+      return {
+        modulePath: path,
+        symbols,
+        lastAccessed: Date.now(),
+        accessCount: 0,
+        sizeBytes: 0,
+      };
+    },
+  };
+}
+
+function makeWorkspaceIndex(
+  results: Array<{
+    symbol: string;
+    modulePath: string;
+    importKind: 'import' | 'inherit';
+    score: number;
+  }> = []
+) {
+  return {
+    searchImportableSymbols: (_query: string, _opts?: { excludeUri?: string; limit?: number }) =>
+      results.map(r => ({ ...r, source: 'workspace-index' as const })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PikeIntrospectionService - stdlib fuzzy scoring and deduplication', () => {
+  let service: PikeIntrospectionService;
+
+  beforeEach(() => {
+    service = new PikeIntrospectionService(
+      makeServices() as never,
+      makeWorkspaceIndex() as never,
+      null
+    );
+  });
+
+  // ---- 1. Empty / whitespace query returns empty ----
+
+  describe('searchImportableSymbols - empty query', () => {
+    it('returns empty array for empty string', async () => {
+      const results = await service.searchImportableSymbols('');
+      assert.deepStrictEqual(results, []);
+    });
+
+    it('returns empty array for whitespace-only string', async () => {
+      const results = await service.searchImportableSymbols('   ');
+      assert.deepStrictEqual(results, []);
+    });
+  });
+
+  // ---- 2. Limit truncation ----
+
+  describe('searchImportableSymbols - limit', () => {
+    it('respects the limit parameter', async () => {
+      const stdlibModules = new Map<string, Map<string, { kind: string }>>();
+      const symbols = new Map<string, { kind: string }>();
+      for (let i = 0; i < 10; i++) {
+        symbols.set(`matchA${i}`, { kind: 'function' });
+      }
+      stdlibModules.set('Mod.A', symbols);
+
+      const svc = new PikeIntrospectionService(
+        makeServices() as never,
+        makeWorkspaceIndex() as never,
+        makeStdlibIndex(stdlibModules) as never
+      );
+
+      const results = await svc.searchImportableSymbols('matchA', { limit: 3 });
+      assert.equal(results.length, 3);
+      for (const r of results) {
+        assert.equal(r.source, 'stdlib-index');
+      }
+    });
+
+    it('enforces minimum limit of 1', async () => {
+      const stdlibModules = new Map<string, Map<string, { kind: string }>>();
+      stdlibModules.set('Mod.X', new Map([['foobar', { kind: 'function' }]]));
+
+      const svc = new PikeIntrospectionService(
+        makeServices() as never,
+        makeWorkspaceIndex() as never,
+        makeStdlibIndex(stdlibModules) as never
+      );
+
+      const results = await svc.searchImportableSymbols('foobar', { limit: 0 });
+      assert.ok(results.length >= 1, 'should return at least 1 result even with limit: 0');
+    });
+  });
+
+  // ---- 3. Scoring: exact > prefix > fuzzy ----
+
+  describe('searchStdlibCandidates - scoring order', () => {
+    it('exact match scores higher than prefix match', async () => {
+      const stdlibModules = new Map<string, Map<string, { kind: string }>>();
+      stdlibModules.set(
+        'Mod',
+        new Map([
+          ['Array', { kind: 'class' }],
+          ['ArrayIterator', { kind: 'class' }],
+        ])
+      );
+
+      const svc = new PikeIntrospectionService(
+        makeServices() as never,
+        makeWorkspaceIndex() as never,
+        makeStdlibIndex(stdlibModules) as never
+      );
+
+      const results = await svc.searchImportableSymbols('Array');
+      assert.ok(results.length >= 2);
+
+      const exact = results.find(r => r.symbol === 'Array');
+      const prefix = results.find(r => r.symbol === 'ArrayIterator');
+
+      assert.ok(exact, 'exact match "Array" should be present');
+      assert.ok(prefix, 'prefix match "ArrayIterator" should be present');
+      assert.ok(
+        exact!.score > prefix!.score,
+        `exact score (${exact!.score}) should exceed prefix score (${prefix!.score})`
+      );
+    });
+
+    it('prefix match scores higher than fuzzy match', async () => {
+      // Use two separate service instances to compare phase-1 (prefix) vs phase-2 (fuzzy)
+      // scores for the same symbol.
+      const stdlibModules = new Map<string, Map<string, { kind: string }>>();
+      stdlibModules.set('Mod', new Map([['String', { kind: 'class' }]]));
+
+      // Query "Str" triggers phase 1 (prefix match) — has exactBoost + prefix matchScore
+      const prefixSvc = new PikeIntrospectionService(
+        makeServices() as never,
+        makeWorkspaceIndex() as never,
+        makeStdlibIndex(stdlibModules) as never
+      );
+      const prefixResults = await prefixSvc.searchImportableSymbols('Str');
+      assert.equal(prefixResults.length, 1);
+      const prefixScore = prefixResults[0]!.score;
+
+      // Query "rng" triggers phase 2 (fuzzy subsequence match) — no exactBoost
+      // "rng" matches "String" via contiguous subsequence (s-t-r-i-n-g → r,n,g in order)
+      const fuzzySvc = new PikeIntrospectionService(
+        makeServices() as never,
+        makeWorkspaceIndex() as never,
+        makeStdlibIndex(stdlibModules) as never
+      );
+      const fuzzyResults = await fuzzySvc.searchImportableSymbols('rng');
+      assert.equal(fuzzyResults.length, 1);
+      const fuzzyScore = fuzzyResults[0]!.score;
+
+      assert.ok(
+        prefixScore > fuzzyScore,
+        `prefix score (${prefixScore}) should exceed fuzzy score (${fuzzyScore})`
+      );
+    });
+
+    it('fuzzy fallback is used when no prefix/exact match exists', async () => {
+      const stdlibModules = new Map<string, Map<string, { kind: string }>>();
+      stdlibModules.set('Mod', new Map([['internals', { kind: 'function' }]]));
+
+      const svc = new PikeIntrospectionService(
+        makeServices() as never,
+        makeWorkspaceIndex() as never,
+        makeStdlibIndex(stdlibModules) as never
+      );
+
+      const results = await svc.searchImportableSymbols('nrs');
+      assert.equal(results.length, 1, 'should find "internals" via fuzzy subsequence');
+      assert.equal(results[0]!.symbol, 'internals');
+      assert.equal(results[0]!.source, 'stdlib-index');
+    });
+
+    it('returns empty when no fuzzy match exists', async () => {
+      const stdlibModules = new Map<string, Map<string, { kind: string }>>();
+      stdlibModules.set('Mod', new Map([['String', { kind: 'class' }]]));
+
+      const svc = new PikeIntrospectionService(
+        makeServices() as never,
+        makeWorkspaceIndex() as never,
+        makeStdlibIndex(stdlibModules) as never
+      );
+
+      const results = await svc.searchImportableSymbols('zzz_no_match');
+      assert.deepStrictEqual(results, []);
+    });
+  });
+
+  // ---- 4. Deduplication: same symbol from workspace + stdlib ----
+
+  describe('mergeCandidates - deduplication', () => {
+    it('deduplicates candidates with same (symbol, modulePath, importKind) keeping highest score', async () => {
+      const stdlibModules = new Map<string, Map<string, { kind: string }>>();
+      stdlibModules.set('Mod', new Map([['Array', { kind: 'class' }]]));
+
+      const workspaceResults = [
+        { symbol: 'Array', modulePath: 'Mod', importKind: 'inherit' as const, score: 50 },
+      ];
+
+      const svc = new PikeIntrospectionService(
+        makeServices() as never,
+        makeWorkspaceIndex(workspaceResults) as never,
+        makeStdlibIndex(stdlibModules) as never
+      );
+
+      const results = await svc.searchImportableSymbols('Array');
+
+      const arrayMatches = results.filter(
+        r => r.symbol === 'Array' && r.modulePath === 'Mod' && r.importKind === 'inherit'
+      );
+      assert.equal(arrayMatches.length, 1, 'should deduplicate to a single entry');
+      assert.ok(
+        arrayMatches[0]!.score > 50,
+        `deduped score (${arrayMatches[0]!.score}) should keep the higher stdlib score`
+      );
+    });
+
+    it('keeps distinct candidates with different importKind for same symbol+module', async () => {
+      const workspaceResults = [
+        { symbol: 'Foo', modulePath: 'Mod', importKind: 'import' as const, score: 80 },
+        { symbol: 'Foo', modulePath: 'Mod', importKind: 'inherit' as const, score: 90 },
+      ];
+
+      const svc = new PikeIntrospectionService(
+        makeServices() as never,
+        makeWorkspaceIndex(workspaceResults) as never,
+        null
+      );
+
+      const results = await svc.searchImportableSymbols('Foo');
+      assert.equal(results.length, 2, 'different importKind should not deduplicate');
+
+      const kinds = results.map(r => r.importKind).sort();
+      assert.deepStrictEqual(kinds, ['import', 'inherit']);
+    });
+
+    it('merges and sorts candidates from both workspace and stdlib', async () => {
+      const stdlibModules = new Map<string, Map<string, { kind: string }>>();
+      stdlibModules.set('Lib', new Map([['Helper', { kind: 'function' }]]));
+
+      const workspaceResults = [
+        { symbol: 'Helper', modulePath: 'Lib', importKind: 'import' as const, score: 50 },
+        { symbol: 'Other', modulePath: 'Src', importKind: 'import' as const, score: 200 },
+      ];
+
+      const svc = new PikeIntrospectionService(
+        makeServices() as never,
+        makeWorkspaceIndex(workspaceResults) as never,
+        makeStdlibIndex(stdlibModules) as never
+      );
+
+      const results = await svc.searchImportableSymbols('Helper');
+
+      const other = results.find(r => r.symbol === 'Other');
+      assert.ok(other, '"Other" from workspace should be in merged results');
+      assert.equal(other!.source, 'workspace-index');
+
+      const helpers = results.filter(r => r.symbol === 'Helper' && r.modulePath === 'Lib');
+      assert.equal(helpers.length, 1, '"Helper" from "Lib" should be deduplicated');
+      assert.ok(helpers[0]!.score > 50, 'deduplicated score should be from stdlib (higher)');
+    });
+
+    it('sorts results by score descending, then symbol ascending', async () => {
+      const workspaceResults = [
+        { symbol: 'Beta', modulePath: 'M', importKind: 'import' as const, score: 100 },
+        { symbol: 'Alpha', modulePath: 'M', importKind: 'import' as const, score: 200 },
+        { symbol: 'Gamma', modulePath: 'M', importKind: 'import' as const, score: 50 },
+      ];
+
+      const svc = new PikeIntrospectionService(
+        makeServices() as never,
+        makeWorkspaceIndex(workspaceResults) as never,
+        null
+      );
+
+      const results = await svc.searchImportableSymbols('Alpha');
+      assert.equal(results.length, 3);
+      assert.equal(results[0]!.symbol, 'Alpha');
+      assert.equal(results[0]!.score, 200);
+      assert.equal(results[1]!.symbol, 'Beta');
+      assert.equal(results[1]!.score, 100);
+      assert.equal(results[2]!.symbol, 'Gamma');
+      assert.equal(results[2]!.score, 50);
+    });
+  });
+
+  // ---- 5. Class symbols get inherit kind ----
+
+  describe('searchStdlibCandidates - importKind assignment', () => {
+    it('assigns inherit to class-kind symbols, import to others', async () => {
+      const stdlibModules = new Map<string, Map<string, { kind: string }>>();
+      stdlibModules.set(
+        'Lib',
+        new Map([
+          ['MyClass', { kind: 'class' }],
+          ['myFunction', { kind: 'function' }],
+          ['MY_CONSTANT', { kind: 'variable' }],
+        ])
+      );
+
+      const svc = new PikeIntrospectionService(
+        makeServices() as never,
+        makeWorkspaceIndex() as never,
+        makeStdlibIndex(stdlibModules) as never
+      );
+
+      const results = await svc.searchImportableSymbols('My');
+
+      const cls = results.find(r => r.symbol === 'MyClass');
+      const fn = results.find(r => r.symbol === 'myFunction');
+      const variable = results.find(r => r.symbol === 'MY_CONSTANT');
+
+      assert.ok(cls, 'MyClass should be found');
+      assert.equal(cls!.importKind, 'inherit', 'class symbols should get inherit kind');
+
+      assert.ok(fn, 'myFunction should be found');
+      assert.equal(fn!.importKind, 'import', 'non-class symbols should get import kind');
+
+      assert.ok(variable, 'MY_CONSTANT should be found');
+      assert.equal(variable!.importKind, 'import', 'variable symbols should get import kind');
+    });
+  });
+});


### PR DESCRIPTION
Closes #1795

## Summary

1. Construct `PikeIntrospectionService` directly with mock `services`, `workspaceIndex`, and `stdlibIndex` 2. Test `searchImportableSymbols` (the public method) which exercises `searchStdlibCandidates`, `fuzzyScore`, and `mergeCandidates`Now run typecheck:I need to use `as never` casts for mock objects (like the existing test patterns do) and fix the Logger type. Let me check how the existing auto-import test handles this:The existing test uses `as never` casts at the call site (line 140). I need to use the same pattern. Let me rewrite the test file:Typecheck passes. Now run the tests:The "nrs" query doesn't match "String" — let me verify. "nrs" against "string" (lowercase): s-t-r-i-n-g. Looking for n-r-s in order: s(skip), t(skip), r(match n? no, r != n) — actually "nrs" = n, r, s. In "string" = s, t, r, i, n, g. The chars n, r, s appear in "string" but not in that order (s is at position 0, n at position 4, r at position 2 — so n, r, s is not a subsequence since r comes before n). Let me pick a better query:Wait, I see the issue - my edit was wrong. Let me re-read the file to see the current state:I see my edit didn't apply correctly - the "nrs" query is still there. Let me fix it:Now I also need to fix the "fuzzy fallback" test — "nrs" doesn't match "internals" either. Let me check: "internals" = i, n, t, e, r, n, a, l, s. Query "nrs": n(match at pos 1), r(match at pos 4), s(match at pos 8) — yes, "nrs" IS a subsequence of "internals". Wait, so the issue is that "nrs" doesn't match "String". Let me re-run the tests:All 13 tests pass. Now run the full test suite to check for regressions:All 386 tests pass (including the 13 new ones), zero failures.Done. Created `packages/pike-lsp-server/src/scenarios/stdlib-fuzzy-scoring.test.ts` with 13 tests covering all acceptance criteria. TypeScript compiles clean, all 386 tests pass.

## Linked Issue

Closes #1795

## Root Cause

searchStdlibCandidates() has a two-phase search strategy (exact/prefix via inverted index, then fuzzy fallback) with a scoring system that combines exactBoost, kindBoost, path-length penalty, and matchScore. The mergeCandidates() method deduplicates and sorts by composite score. Neither the scoring logic, the phase fallback behavior, nor the deduplication edge cases (same symbol from multiple sources) have dedicated unit tests. The only test coverage is indirect via integration tests.

## Changes

- packages/pike-lsp-server/src/scenarios/stdlib-fuzzy-scoring.test.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1795

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].
