### PR TITLE
perf(#1800): Consolidate duplicate FNV-1a hash implementations into singl

### DIFF
--- a/.agent-knowledge/reference/KB-1800.md
+++ b/.agent-knowledge/reference/KB-1800.md
@@ -1,0 +1,17 @@
+---
+id: KB-AUTO-1800
+domain: REFACTOR
+date: 2026-04-14
+authors: [dga-coder]
+summary: Extracted duplicate FNV-1a hash implementations in document-cache.ts into a single shared fnv1a() function
+---
+
+# KB-1800: Consolidate duplicate FNV-1a hash implementations
+
+## Summary
+
+`document-cache.ts` had two identical FNV-1a hash loops: one in `computeContentHash()` (lines 21-27) returning a hex string, and one in `simpleHash()` (lines 72-78) returning an unsigned int. Extracted a private `fnv1a(str): number` function and had both callers delegate to it. `computeContentHash` now returns `fnv1a(content).toString(16).padStart(8, '0')`, and `computeSemanticLineHash` returns `fnv1a(semantic)` directly. The `simpleHash` wrapper was inlined away.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/services/document-cache.ts: Extracted `fnv1a()` as the single canonical FNV-1a implementation; simplified `computeContentHash()` and `computeSemanticLineHash()` to delegate to it; removed redundant `simpleHash()`.

--- a/packages/pike-lsp-server/src/services/document-cache.ts
+++ b/packages/pike-lsp-server/src/services/document-cache.ts
@@ -12,6 +12,18 @@ import { Logger } from '@pike-lsp/core';
 const log = new Logger('DocumentCache');
 
 /**
+ * FNV-1a 32-bit hash — single canonical implementation.
+ */
+function fnv1a(str: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+/**
  * PERF-1229: Compute FNV-1a hash of document content.
  * Non-cryptographic but sufficient for change detection and ~5× faster than SHA-256.
  *
@@ -19,12 +31,7 @@ const log = new Logger('DocumentCache');
  * @returns Hex-encoded FNV-1a hash
  */
 export function computeContentHash(content: string): string {
-  let hash = 2166136261; // FNV offset basis (32-bit)
-  for (let i = 0; i < content.length; i++) {
-    hash ^= content.charCodeAt(i);
-    hash = Math.imul(hash, 16777619); // FNV prime
-  }
-  return (hash >>> 0).toString(16).padStart(8, '0');
+  return fnv1a(content).toString(16).padStart(8, '0');
 }
 
 /**
@@ -59,20 +66,7 @@ export function stripLineComments(line: string): string {
 
 export function computeSemanticLineHash(line: string): number {
   const semantic = stripLineComments(line.trim());
-  return simpleHash(semantic);
-}
-
-/**
- * INC-002: Simple string hash for quick line comparison.
- * Uses FNV-1a algorithm for fast hashing.
- */
-function simpleHash(str: string): number {
-  let hash = 2166136261; // FNV offset basis
-  for (let i = 0; i < str.length; i++) {
-    hash ^= str.charCodeAt(i);
-    hash = Math.imul(hash, 16777619); // FNV prime
-  }
-  return hash >>> 0; // Convert to unsigned 32-bit
+  return fnv1a(semantic);
 }
 
 /**


### PR DESCRIPTION
Closes #1800

## Summary

Clear. Two identical FNV-1a loops at lines 21-28 and 69-76. I'll extract a shared `fnv1a` function and have both callers delegate to it.All 31 tests pass. Now write the KB entry.Done. The two duplicate FNV-1a loops in `document-cache.ts` are now consolidated into a single `fnv1a()` private function. Both `computeContentHash()` and `computeSemanticLineHash()` delegate to it, differing only in output format. TypeScript compiles clean, 31/31 tests pass.

## Linked Issue

Closes #1800

## Root Cause

document-cache.ts contains two nearly identical FNV-1a hash implementations: computeContentHash() (lines 21-27, returns hex string) and simpleHash() (lines 72-78, returns unsigned int). Both use the same offset basis (2166136261), the same prime (16777619), and the same Math.imul + XOR loop. This is a DRY violation — if the algorithm needs fixing, both copies must be updated.

## Changes

- .agent-knowledge/reference/KB-1800.md: (see commit diffs)
- packages/pike-lsp-server/src/services/document-cache.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1800

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].