### PR TITLE
feat(#1809): Remove double as-unknown-as casts in getKnownUris()

### DIFF
--- a/.agent-knowledge/reference/KB-1809.md
+++ b/.agent-knowledge/reference/KB-1809.md
@@ -1,0 +1,19 @@
+---
+id: KB-AUTO-1809
+domain: REFACTOR
+date: 2026-04-14
+authors: [dga-coder]
+summary: Removed double as-unknown-as casts in getKnownUris() by using direct property access on the Services interface
+---
+
+# KB-1809: Remove double as-unknown-as casts in getKnownUris()
+
+## Summary
+
+`getKnownUris()` in `implementation.ts` used `services as unknown as { workspaceIndex?: { ... } }` double casts to access `workspaceIndex` and `workspaceScanner`, even though the `Services` interface already declared these properties with proper types. The double casts defeated TypeScript's type checking. Replaced with direct property access (`services.workspaceIndex.getAllDocumentUris()` and `services.workspaceScanner.getAllFiles()`). Also fixed test mocks that were missing `workspaceScanner` — the original casts masked this by treating missing properties as `undefined` via optional chaining.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/features/navigation/implementation.ts: Removed two double-cast blocks, replaced with direct typed property access on Services
+- packages/pike-lsp-server/src/tests/navigation/implementation-provider.test.ts: Added `workspaceIndex` and `workspaceScanner` to all 5 inline mock service objects
+- packages/pike-lsp-server/src/scenarios/implementation-parse-resilience.test.ts: Added `workspaceScanner` to inline mock service object

--- a/.agent-knowledge/reference/KB-1810.md
+++ b/.agent-knowledge/reference/KB-1810.md
@@ -1,0 +1,15 @@
+---
+id: KB-AUTO-1810
+domain: REFACTOR
+date: 2026-04-14
+authors: [dga-coder]
+summary: Restored accidentally deleted includeResolver: null in test mock and rewrote PR body to describe WHY not just WHAT
+---
+
+# KB-1810: Fix incomplete test mock and PR body quality on #1810
+
+## Summary
+The PR #1810 refactor accidentally deleted `includeResolver: null` from the Services mock in `implementation-parse-resilience.test.ts` when adding `workspaceScanner`. The `Services` interface requires `includeResolver: IncludeResolver | null` (non-optional), and while the mock uses `as unknown as Services` to bypass TypeScript, the incomplete mock could cause runtime errors. Also rewrote the PR body per reviewer feedback: Summary was agent scratchpad, Changes said "(see commit diffs)" instead of explaining rationale, Verification lacked actual command output.
+
+## Key Files Changed
+- packages/pike-lsp-server/src/scenarios/implementation-parse-resilience.test.ts: Added `includeResolver: null,` back to the mock object so it coexists with `workspaceScanner`.

--- a/packages/pike-lsp-server/src/features/navigation/implementation.ts
+++ b/packages/pike-lsp-server/src/features/navigation/implementation.ts
@@ -266,26 +266,12 @@ function getKnownUris(services: Services): string[] {
     uris.add(uri);
   }
 
-  const workspaceIndex = (
-    services as unknown as { workspaceIndex?: { getAllDocumentUris?: () => string[] } }
-  ).workspaceIndex as
-    | {
-        getAllDocumentUris?: () => string[];
-      }
-    | undefined;
-  const indexedUris = workspaceIndex?.getAllDocumentUris?.() ?? [];
+  const indexedUris = services.workspaceIndex.getAllDocumentUris();
   for (const uri of indexedUris) {
     uris.add(uri);
   }
 
-  const workspaceScanner = (
-    services as unknown as { workspaceScanner?: { getAllFiles?: () => Array<{ uri: string }> } }
-  ).workspaceScanner as
-    | {
-        getAllFiles?: () => Array<{ uri: string }>;
-      }
-    | undefined;
-  const files = workspaceScanner?.getAllFiles?.() ?? [];
+  const files = services.workspaceScanner.getAllFiles();
   for (const file of files) {
     if (file.uri) {
       uris.add(file.uri);

--- a/packages/pike-lsp-server/src/scenarios/implementation-parse-resilience.test.ts
+++ b/packages/pike-lsp-server/src/scenarios/implementation-parse-resilience.test.ts
@@ -96,7 +96,11 @@ function createImplementationHarness(bridge: FaultInjectableMockBridge) {
         return [...cache.keys()];
       },
     },
-    includeResolver: null,
+    workspaceScanner: {
+      getAllFiles() {
+        return [];
+      },
+    },
     stdlibIndex: null,
     globalSettings: { pikePath: 'pike', maxNumberOfProblems: 100, diagnosticDelay: 5 },
     documentSnapshots: new Map<string, string>(),

--- a/packages/pike-lsp-server/src/scenarios/implementation-parse-resilience.test.ts
+++ b/packages/pike-lsp-server/src/scenarios/implementation-parse-resilience.test.ts
@@ -101,6 +101,7 @@ function createImplementationHarness(bridge: FaultInjectableMockBridge) {
         return [];
       },
     },
+    includeResolver: null,
     stdlibIndex: null,
     globalSettings: { pikePath: 'pike', maxNumberOfProblems: 100, diagnosticDelay: 5 },
     documentSnapshots: new Map<string, string>(),

--- a/packages/pike-lsp-server/src/tests/navigation/implementation-provider.test.ts
+++ b/packages/pike-lsp-server/src/tests/navigation/implementation-provider.test.ts
@@ -111,6 +111,8 @@ describe('Implementation Provider', () => {
         bridge: null,
         logger: { debug: () => {}, error: () => {} },
         stdlibIndex: null,
+        workspaceIndex: { getAllDocumentUris: () => [] },
+        workspaceScanner: { getAllFiles: () => [] },
       };
 
       registerImplementationHandler(mockConnection, mockServices, mockDocuments);
@@ -147,6 +149,8 @@ describe('Implementation Provider', () => {
         bridge: null,
         logger: { debug: () => {}, error: () => {} },
         stdlibIndex: null,
+        workspaceIndex: { getAllDocumentUris: () => [] },
+        workspaceScanner: { getAllFiles: () => [] },
       };
 
       registerImplementationHandler(mockConnection, mockServices, mockDocuments);
@@ -188,6 +192,8 @@ describe('Implementation Provider', () => {
         bridge: null,
         logger: { debug: () => {}, error: () => {} },
         stdlibIndex: null,
+        workspaceIndex: { getAllDocumentUris: () => [] },
+        workspaceScanner: { getAllFiles: () => [] },
       };
 
       registerImplementationHandler(mockConnection, mockServices, mockDocuments);
@@ -217,6 +223,8 @@ describe('Implementation Provider', () => {
         bridge: null,
         logger: { debug: () => {}, error: () => {} },
         stdlibIndex: null,
+        workspaceIndex: { getAllDocumentUris: () => [] },
+        workspaceScanner: { getAllFiles: () => [] },
       };
 
       registerImplementationHandler(mockConnection, mockServices, mockDocuments);
@@ -238,6 +246,8 @@ describe('Implementation Provider', () => {
         bridge: null,
         logger: { debug: () => {}, error: () => {} },
         stdlibIndex: null,
+        workspaceIndex: { getAllDocumentUris: () => [] },
+        workspaceScanner: { getAllFiles: () => [] },
       };
 
       registerImplementationHandler(mockConnection, mockServices, mockDocuments);


### PR DESCRIPTION
Closes #1809

## Summary

Removes unnecessary double `as-unknown-as` casts in `getKnownUris()` by using direct typed property access on the `Services` interface, which already declares `workspaceIndex` and `workspaceScanner` with proper types. Updates test mocks that were incomplete after the change.

## Linked Issue

Closes #1809

## Root Cause

`getKnownUris()` accessed `services.workspaceIndex` and `services.workspaceScanner` via `as unknown as { workspaceIndex?: ... }` double casts because the original author did not realize the `Services` type already declares these properties. This defeated TypeScript type checking — any typo in property names or return types went undetected at compile time.

## Changes

- `packages/pike-lsp-server/src/features/navigation/implementation.ts`: Removed two `as unknown as` double-cast blocks in `getKnownUris()`, replaced with `services.workspaceIndex.getAllDocumentUris()` and `services.workspaceScanner.getAllFiles()` — the `Services` interface already declares these with proper types, so the casts were unnecessary and weakened type safety.
- `packages/pike-lsp-server/src/scenarios/implementation-parse-resilience.test.ts`: Added missing `workspaceScanner` mock and restored `includeResolver: null` that was accidentally deleted. The mock is cast via `as unknown as Services` so TypeScript does not catch missing properties, but the mock must still provide all required `Services` fields to avoid runtime errors.
- `packages/pike-lsp-server/src/tests/navigation/implementation-provider.test.ts`: Added missing `workspaceScanner` mock to the `Services` mock object, same rationale as above.
- `.agent-knowledge/reference/KB-1809.md`: Knowledge base entry documenting the change.

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1809

## Verification

```
$ bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json
(no output — clean pass)
```

```
$ bun test packages/pike-lsp-server/src/scenarios/implementation-parse-resilience.test.ts
bun test v1.3.12 (700fc117)

 6 pass
 0 fail
Ran 6 tests across 1 file. [148.00ms]
```

```
$ bun test packages/pike-lsp-server/src/tests/navigation/implementation-provider.test.ts
bun test v1.3.12 (700fc117)

 5 pass
 0 fail
Ran 5 tests across 1 file. [105.00ms]
```

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot]
