### PR TITLE
refactor(#1818): Remove as-unknown-as casts for workspaceIndex method access

### DIFF
--- a/.agent-knowledge/reference/KB-1818.md
+++ b/.agent-knowledge/reference/KB-1818.md
@@ -1,0 +1,19 @@
+---
+id: KB-AUTO-1818
+domain: REFACTOR
+date: 2026-04-14
+authors: [dga-coder]
+summary: Removed as-unknown-as casts for workspaceIndex method access in hierarchy.ts, calling getDocumentSymbols and getAllDocumentUris directly
+---
+
+# KB-1818: Remove as-unknown-as casts for workspaceIndex method access
+
+## Summary
+
+`hierarchy.ts` had two `as unknown as` casts on `services.workspaceIndex` to access `getDocumentSymbols()` and `getAllDocumentUris()`. These methods already exist on the `WorkspaceIndex` class with matching signatures, so the casts were unnecessary. Removed both casts and updated the mock workspace index in test helpers and cross-file-hierarchy tests to include the missing methods.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/features/hierarchy.ts: Removed two `as unknown as` casts, replaced with direct method calls on `services.workspaceIndex`
+- packages/pike-lsp-server/src/tests/helpers/mock-services.ts: Added `getDocumentSymbols` and `getAllDocumentUris` to default mock workspace index
+- packages/pike-lsp-server/src/tests/hierarchy/cross-file-hierarchy.test.ts: Added `getAllDocumentUris` to all four custom mock workspace index objects

--- a/packages/pike-lsp-server/src/features/hierarchy.ts
+++ b/packages/pike-lsp-server/src/features/hierarchy.ts
@@ -93,14 +93,9 @@ export function registerHierarchyHandlers(
       return cached.symbols;
     }
 
-    const workspaceIndex = services.workspaceIndex as unknown as {
-      getDocumentSymbols?: (documentUri: string) => PikeSymbol[];
-    };
-    if (workspaceIndex?.getDocumentSymbols) {
-      const indexedSymbols = workspaceIndex.getDocumentSymbols(uri);
-      if (indexedSymbols && indexedSymbols.length > 0) {
-        return indexedSymbols;
-      }
+    const indexedSymbols = services.workspaceIndex.getDocumentSymbols(uri);
+    if (indexedSymbols && indexedSymbols.length > 0) {
+      return indexedSymbols;
     }
 
     return [];
@@ -112,13 +107,8 @@ export function registerHierarchyHandlers(
       uris.add(uri);
     }
 
-    const workspaceIndex = services.workspaceIndex as unknown as {
-      getAllDocumentUris?: () => string[];
-    };
-    if (workspaceIndex?.getAllDocumentUris) {
-      for (const uri of workspaceIndex.getAllDocumentUris()) {
-        uris.add(uri);
-      }
+    for (const uri of services.workspaceIndex.getAllDocumentUris()) {
+      uris.add(uri);
     }
 
     // Include uncached files from workspace scanner

--- a/packages/pike-lsp-server/src/tests/helpers/mock-services.ts
+++ b/packages/pike-lsp-server/src/tests/helpers/mock-services.ts
@@ -503,7 +503,11 @@ export function createMockServices(overrides?: MockServicesOverrides) {
     stdlibIndex: overrides?.stdlibIndex ?? null,
     includeResolver: null,
     typeDatabase: {},
-    workspaceIndex: overrides?.workspaceIndex ?? { searchSymbols: () => [] },
+    workspaceIndex: overrides?.workspaceIndex ?? {
+      searchSymbols: () => [],
+      getDocumentSymbols: () => [],
+      getAllDocumentUris: () => [],
+    },
     workspaceScanner: overrides?.workspaceScanner ?? createMockWorkspaceScanner([]),
     globalSettings: { pikePath: 'pike', maxNumberOfProblems: 100, diagnosticDelay: 300 },
     includePaths: [],

--- a/packages/pike-lsp-server/src/tests/hierarchy/cross-file-hierarchy.test.ts
+++ b/packages/pike-lsp-server/src/tests/hierarchy/cross-file-hierarchy.test.ts
@@ -86,6 +86,7 @@ describe('Cross-File Type Hierarchy', () => {
           if (uri === derivedUri) return derivedSymbols;
           return [];
         },
+        getAllDocumentUris: () => [baseUri, derivedUri],
       };
 
       const services = createMockServices({
@@ -194,6 +195,7 @@ describe('Cross-File Type Hierarchy', () => {
           if (uri === derivedUri) return derivedSymbols;
           return [];
         },
+        getAllDocumentUris: () => [baseUri, derivedUri],
       };
 
       const services = createMockServices({
@@ -327,6 +329,7 @@ describe('Cross-File Type Hierarchy', () => {
           if (uri === childUri) return childSymbols;
           return [];
         },
+        getAllDocumentUris: () => [grandParentUri, parentUri, childUri],
       };
 
       const services = createMockServices({
@@ -450,6 +453,7 @@ describe('Cross-File Type Hierarchy', () => {
           if (uri === file2Uri) return file2Symbols;
           return [];
         },
+        getAllDocumentUris: () => [file1Uri, file2Uri],
       };
 
       const services = createMockServices({


### PR DESCRIPTION
Closes #1818

## Summary

Remove two unnecessary `as unknown as` casts on `services.workspaceIndex` in hierarchy.ts. Both `getDocumentSymbols()` and `getAllDocumentUris()` already exist on the WorkspaceIndex class with matching signatures. Update mock services and test mocks to include the previously-optional methods.

## Linked Issue

Closes #1818

## Root Cause

getSymbolsForUri() casts services.workspaceIndex as unknown as { getDocumentSymbols?: (documentUri: string) => PikeSymbol[] } to access a method that may not be on the WorkspaceIndex type. Similarly, getKnownUris() casts it to access getAllDocumentUris(). These casts bypass TypeScript checking — if WorkspaceIndex is refactored, these call sites won't produce compile errors. The same pattern was cleaned up in implementation.ts via PR #1810 but hierarchy.ts was missed.

## Changes

- packages/pike-lsp-server/src/features/hierarchy.ts: Removed two `as unknown as` casts — both methods already exist on WorkspaceIndex
- packages/pike-lsp-server/src/tests/helpers/mock-services.ts: Added `getDocumentSymbols` and `getAllDocumentUris` stubs to default mock workspaceIndex
- packages/pike-lsp-server/src/tests/hierarchy/cross-file-hierarchy.test.ts: Added `getAllDocumentUris` to 4 custom mock workspaceIndex objects that were missing it
- .agent-knowledge/reference/KB-1818.md: Added knowledge base entry

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1818

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json: passes clean (0 errors)
- bun test packages/pike-lsp-server/src/tests/hierarchy/: 133 pass, 0 fail

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].
