### PR TITLE
refactor(#1853): Remove redundant filter after processedUris.clear() in onInd

### DIFF
--- a/.agent-knowledge/reference/KB-1853.md
+++ b/.agent-knowledge/reference/KB-1853.md
@@ -1,0 +1,17 @@
+---
+id: KB-AUTO-1853
+domain: REFACTOR
+date: 2026-04-15
+authors: [dga-coder]
+summary: Removed redundant filter after processedUris.clear() in onIndexingComplete()
+---
+
+# KB-1853: Remove redundant filter after processedUris.clear()
+
+## Summary
+
+`onIndexingComplete()` called `this.processedUris.clear()` then immediately filtered `allUris` against the now-empty set. Since the set was just cleared, every URI passes the filter, making the `.filter()` call dead logic. Replaced with a direct spread assignment.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/services/workspace-diagnostics.ts: Replaced `allUris.filter(uri => !this.processedUris.has(uri))` with `[...allUris]` after `processedUris.clear()`.

--- a/packages/pike-lsp-server/src/services/workspace-diagnostics.ts
+++ b/packages/pike-lsp-server/src/services/workspace-diagnostics.ts
@@ -100,7 +100,7 @@ export class WorkspaceDiagnosticsManager {
     log.debug('Workspace indexing complete, scheduling idle diagnostics');
     this.processedUris.clear();
     const allUris = this.workspaceIndex.getAllDocumentUris();
-    this.remainingUris = allUris.filter(uri => !this.processedUris.has(uri));
+    this.remainingUris = [...allUris];
     this.scheduleIdleCheck();
   }
 


### PR DESCRIPTION
Closes #1853

## Summary

The lines shown don't match the issue description. Let me search for the `onIndexingComplete` method and `processedUris.clear()`.Confirmed: line 101 clears `processedUris`, line 103 filters against the now-empty set. The filter is dead logic.Now I need to check if `allUris` is typed as an array (so spread works) or an iterable. Let me check.The method returns an array (used in `for...of`, `.filter()`, spread context). The spread `[...allUris]` is safe. Let me verify compilation and run tests.Compilation clean. Now run the tests:All 14 tests pass. Now write the KB entry.Done. Replaced the dead `.filter()` call on line 103 with `[...allUris]` since `processedUris` was cleared on the line immediately prior. Compilation clean, 14/14 tests pass.

## Linked Issue

Closes #1853

## Root Cause

onIndexingComplete() calls this.processedUris.clear() on line 163, then immediately filters allUris against the now-empty set on line 165. Since the set was just cleared, every URI passes the filter, making the .filter() call dead logic that performs N unnecessary Set.has() lookups.

## Changes

- .agent-knowledge/reference/KB-1853.md: (see commit diffs)
- packages/pike-lsp-server/src/services/workspace-diagnostics.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1853

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].