### PR TITLE
refactor(#1871): Extract shared indexing logic from duplicate batch/sequentia

### DIFF
--- a/.agent-knowledge/reference/KB-1871.md
+++ b/.agent-knowledge/reference/KB-1871.md
@@ -1,0 +1,17 @@
+---
+id: KB-AUTO-1871
+domain: REFACTOR
+date: 2026-04-15
+authors: [dga-coder]
+summary: Extracted shared storeParsedDocument helper from duplicate batch/sequential indexing paths in workspace-index-scanner.ts
+---
+
+# KB-1871: Extract shared indexing logic from duplicate batch/sequential paths
+
+## Summary
+
+The `indexDirectory()` function in `workspace-index-scanner.ts` had two nearly identical code paths for storing indexed documents: the batch parsing path and the sequential fallback path. Both performed the same sequence (removeFromLookup, documents.set, addToLookup) with identical IndexedDocument construction. Extracted a `storeParsedDocument()` helper that encapsulates this shared logic, eliminating the duplication.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/workspace-index-scanner.ts: Added private `storeParsedDocument()` helper; replaced duplicated document-storage blocks in both batch and sequential parsing paths with single calls to the helper.

--- a/.agent-knowledge/reference/KB-1876.md
+++ b/.agent-knowledge/reference/KB-1876.md
@@ -1,0 +1,14 @@
+---
+id: KB-AUTO-1876
+domain: REFACTOR
+date: 2026-04-15
+authors: [dga-coder]
+summary: Fixed orphaned JSDoc and blank line inconsistency in workspace-index-scanner.ts from PR #1876 review
+---
+# KB-1876: Fix orphaned JSDoc and style inconsistency in workspace-index-scanner
+
+## Summary
+When `storeParsedDocument()` was extracted above `indexDirectory()`, the indexDirectory JSDoc was left in place above the new helper, making it orphaned. Moved the JSDoc to its correct position immediately before `indexDirectory()`. Also removed a spurious blank line in the sequential fallback path to match the batch path style.
+
+## Key Files Changed
+- packages/pike-lsp-server/src/workspace-index-scanner.ts: Moved JSDoc from above storeParsedDocument to above indexDirectory; removed extra blank line in sequential fallback block

--- a/packages/pike-lsp-server/src/workspace-index-scanner.ts
+++ b/packages/pike-lsp-server/src/workspace-index-scanner.ts
@@ -35,12 +35,6 @@ export interface IndexStorage {
 }
 
 /**
- * Index all Pike files in a directory.
- * PERF-002: Uses batch parsing for better performance
- * PERF-007: Adds performance instrumentation
- * PERF-008: Incremental indexing with progress callbacks and chunked processing
- */
-/**
  * Store a parsed document into the index, replacing any existing entry.
  */
 function storeParsedDocument(
@@ -66,6 +60,12 @@ function storeParsedDocument(
   storage.addToLookup(uri, symbols, lineCount);
 }
 
+/**
+ * Index all Pike files in a directory.
+ * PERF-002: Uses batch parsing for better performance
+ * PERF-007: Adds performance instrumentation
+ * PERF-008: Incremental indexing with progress callbacks and chunked processing
+ */
 export async function indexDirectory(
   storage: IndexStorage,
   dirPath: string,
@@ -252,7 +252,6 @@ export async function indexDirectory(
             fileData.filename
           );
           const parsedSymbols = analyzeResult.result?.parse?.symbols ?? [];
-
           const uri = `file://${fileData.filename}`;
           const symbols = storage.flattenSymbols(parsedSymbols);
 

--- a/packages/pike-lsp-server/src/workspace-index-scanner.ts
+++ b/packages/pike-lsp-server/src/workspace-index-scanner.ts
@@ -40,6 +40,32 @@ export interface IndexStorage {
  * PERF-007: Adds performance instrumentation
  * PERF-008: Incremental indexing with progress callbacks and chunked processing
  */
+/**
+ * Store a parsed document into the index, replacing any existing entry.
+ */
+function storeParsedDocument(
+  storage: IndexStorage,
+  uri: string,
+  symbols: FlattenedSymbolEntry[],
+  lastModified: number,
+  lineCount: number
+): void {
+  const existing = storage.documents.get(uri);
+  if (existing) {
+    storage.removeFromLookup(uri);
+  }
+
+  storage.documents.set(uri, {
+    uri,
+    symbols,
+    version: 1,
+    lastModified,
+    lineCount,
+  });
+
+  storage.addToLookup(uri, symbols, lineCount);
+}
+
 export async function indexDirectory(
   storage: IndexStorage,
   dirPath: string,
@@ -195,27 +221,10 @@ export async function indexDirectory(
 
         // Skip if either result or file info is undefined
         if (!result || !fileInfo) continue;
-
         const uri = `file://${result.filename}`;
-
-        // Remove old entries from lookup
-        const existing = storage.documents.get(uri);
-        if (existing) {
-          storage.removeFromLookup(uri);
-        }
-
-        // Store indexed document with filesystem mtime
         const symbols = storage.flattenSymbols(result.symbols);
-        storage.documents.set(uri, {
-          uri,
-          symbols,
-          version: 1,
-          lastModified: fileInfo.lastModified,
-          lineCount: fileInfo.lineCount,
-        });
 
-        // Add to lookup
-        storage.addToLookup(uri, symbols, fileInfo.lineCount);
+        storeParsedDocument(storage, uri, symbols, fileInfo.lastModified, fileInfo.lineCount);
         indexed++;
       }
 
@@ -243,26 +252,11 @@ export async function indexDirectory(
             fileData.filename
           );
           const parsedSymbols = analyzeResult.result?.parse?.symbols ?? [];
+
           const uri = `file://${fileData.filename}`;
-
-          // Remove old entries from lookup
-          const existing = storage.documents.get(uri);
-          if (existing) {
-            storage.removeFromLookup(uri);
-          }
-
-          // Store indexed document with filesystem mtime
           const symbols = storage.flattenSymbols(parsedSymbols);
-          storage.documents.set(uri, {
-            uri,
-            symbols,
-            version: 1,
-            lastModified: fileData.lastModified,
-            lineCount: fileData.lineCount,
-          });
 
-          // Add to lookup
-          storage.addToLookup(uri, symbols, fileData.lineCount);
+          storeParsedDocument(storage, uri, symbols, fileData.lastModified, fileData.lineCount);
           indexed++;
         } catch (error) {
           storage.log.debug('Sequential parse fallback failed for file', {


### PR DESCRIPTION
Closes #1871

## Summary

Now I have the full picture. Let me extract the shared `storeParsedDocument` helper.Let me check for the duplication issue:Duplicated `indexed++` lines. Fix both:Now clean up the blank line in the batch path:Now verify the changes look correct and run typecheck + tests:Typecheck passes. Run tests:All 9 tests pass. Now write the KB entry:Done. Extracted `storeParsedDocument()` — a private module-level function that consolidates the `removeFromLookup` → `documents.set` → `addToLookup` sequence that was duplicated across the batch and sequential parsing paths in `indexDirectory()`. Net change: +28 lines for the helper, -34 lines of duplication.

## Linked Issue

Closes #1871

## Root Cause

The indexDirectory() function has two nearly identical code paths for storing indexed documents: the main batch parsing path (lines 173-208) and the sequential fallback path (lines 220-258). Both perform the same sequence: removeFromLookup → documents.set → addToLookup with identical IndexedDocument construction. The only difference is how symbols are obtained (batch vs sequential). This duplication means a bug fix in one path can be missed in the other.

## Changes

- .agent-knowledge/reference/KB-1871.md: (see commit diffs)
- packages/pike-lsp-server/src/workspace-index-scanner.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1871

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].