### PR TITLE
refactor(#1877): Remove unused lastModified field from ResolvedInclude

### DIFF
--- a/.agent-knowledge/reference/KB-1876.md
+++ b/.agent-knowledge/reference/KB-1876.md
@@ -5,10 +5,13 @@ date: 2026-04-15
 authors: [dga-coder]
 summary: Fixed orphaned JSDoc and blank line inconsistency in workspace-index-scanner.ts from PR #1876 review
 ---
+
 # KB-1876: Fix orphaned JSDoc and style inconsistency in workspace-index-scanner
 
 ## Summary
+
 When `storeParsedDocument()` was extracted above `indexDirectory()`, the indexDirectory JSDoc was left in place above the new helper, making it orphaned. Moved the JSDoc to its correct position immediately before `indexDirectory()`. Also removed a spurious blank line in the sequential fallback path to match the batch path style.
 
 ## Key Files Changed
+
 - packages/pike-lsp-server/src/workspace-index-scanner.ts: Moved JSDoc from above storeParsedDocument to above indexDirectory; removed extra blank line in sequential fallback block

--- a/.agent-knowledge/reference/KB-1877.md
+++ b/.agent-knowledge/reference/KB-1877.md
@@ -1,0 +1,20 @@
+---
+id: KB-AUTO-1877
+domain: REFACTOR
+date: 2026-04-15
+authors: [dga-coder]
+summary: Removed unused lastModified field from ResolvedInclude interface and all assignment sites
+---
+
+# KB-1877: Remove unused lastModified from ResolvedInclude
+
+## Summary
+
+The `lastModified` field on `ResolvedInclude` was set to `Date.now()` during include resolution but never read by any consumer. Removed the field from the interface in `core/types.ts`, removed all assignments in `include-resolver.ts`, deleted the cache-timestamp test in `include-resolver.test.ts`, and removed `lastModified` properties from test fixture objects in `document-links.test.ts`.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/core/types.ts: Removed `lastModified: number` field from `ResolvedInclude` interface
+- packages/pike-lsp-server/src/services/include-resolver.ts: Removed `lastModified` from the internal return type of `resolveAndCache()`, removed `Date.now()` assignment, and removed `lastModified` from object literals in `resolveAndCache()` and `resolveSingleInclude()`
+- packages/pike-lsp-server/src/tests/services/include-resolver.test.ts: Deleted the `should return same lastModified timestamp from cache` test
+- packages/pike-lsp-server/src/scenarios/document-links.test.ts: Removed `lastModified: Date.now()` from three `ResolvedInclude` test fixture objects

--- a/packages/pike-lsp-server/src/core/types.ts
+++ b/packages/pike-lsp-server/src/core/types.ts
@@ -150,8 +150,6 @@ export interface ResolvedInclude {
   resolvedPath: string;
   /** Symbols from the included file (cached for completion) */
   symbols: PikeSymbol[];
-  /** Last modified time for cache invalidation */
-  lastModified: number;
 }
 
 /**

--- a/packages/pike-lsp-server/src/scenarios/document-links.test.ts
+++ b/packages/pike-lsp-server/src/scenarios/document-links.test.ts
@@ -216,7 +216,6 @@ describe('Document Links', () => {
         originalPath: '"utils.pike"',
         resolvedPath: includePath,
         symbols: [],
-        lastModified: Date.now(),
       },
     ]);
 
@@ -242,13 +241,11 @@ describe('Document Links', () => {
         originalPath: '"a.pike"',
         resolvedPath: '/project/a.pike',
         symbols: [],
-        lastModified: Date.now(),
       },
       {
         originalPath: '"b.pike"',
         resolvedPath: '/project/b.pike',
         symbols: [],
-        lastModified: Date.now(),
       },
     ]);
 
@@ -270,7 +267,6 @@ describe('Document Links', () => {
         originalPath: '"missing.pike"',
         resolvedPath: '',
         symbols: [],
-        lastModified: Date.now(),
       },
     ]);
 

--- a/packages/pike-lsp-server/src/services/include-resolver.ts
+++ b/packages/pike-lsp-server/src/services/include-resolver.ts
@@ -123,7 +123,6 @@ export class IncludeResolver {
     normalizedPath: string;
     originalPath: string;
     symbols: PikeSymbol[];
-    lastModified: number;
   } | null> {
     if (!this.bridge?.bridge) {
       return null;
@@ -144,18 +143,15 @@ export class IncludeResolver {
           normalizedPath,
           originalPath: cached.originalPath,
           symbols: cached.symbols,
-          lastModified: cached.lastModified,
         };
       }
 
       const symbols = await this.bridge.parseFileSymbols(normalizedPath);
-      const now = Date.now();
 
       const resolved: ResolvedInclude = {
         originalPath: result.originalPath,
         resolvedPath: normalizedPath,
         symbols,
-        lastModified: now,
       };
 
       this.includePathIndex.set(normalizedPath, resolved);
@@ -164,7 +160,6 @@ export class IncludeResolver {
         normalizedPath,
         originalPath: result.originalPath,
         symbols,
-        lastModified: now,
       };
     } catch (err) {
       this.logger.debug(`${logLabel} failed`, {
@@ -189,7 +184,6 @@ export class IncludeResolver {
       originalPath: result.originalPath,
       resolvedPath: result.normalizedPath,
       symbols: result.symbols,
-      lastModified: result.lastModified,
     };
   }
 

--- a/packages/pike-lsp-server/src/tests/services/include-resolver.test.ts
+++ b/packages/pike-lsp-server/src/tests/services/include-resolver.test.ts
@@ -739,33 +739,6 @@ describe('IncludeResolver - Cache hit behavior', () => {
     assert.equal(parseCallCount, 1);
   });
 
-  it('should return same lastModified timestamp from cache', async () => {
-    const bridge = {
-      bridge: {
-        resolveInclude: async () => ({
-          exists: true,
-          path: '/ts/header.h',
-          originalPath: '"header.h"',
-        }),
-        resolveStdlib: async () => ({ found: 0 }),
-      },
-      async parseFileSymbols(): Promise<PikeSymbol[]> {
-        return [{ name: 'x', kind: 'variable' as const }];
-      },
-    };
-    const resolver = new IncludeResolver(bridge as never, createMockLogger());
-
-    const deps1 = await resolver.resolveDependencies('file:///test.pike', [
-      includeSymbol('"header.h"'),
-    ]);
-    await new Promise(r => setTimeout(r, 10)); // small delay so Date.now() differs
-    const deps2 = await resolver.resolveDependencies('file:///test.pike', [
-      includeSymbol('"header.h"'),
-    ]);
-
-    assert.equal(deps1.includes[0]!.lastModified, deps2.includes[0]!.lastModified);
-  });
-
   it('should re-resolve after clear()', async () => {
     let parseCallCount = 0;
     const bridge = {


### PR DESCRIPTION
Closes #1877

## Summary

**Edit 1: Remove `lastModified` from `ResolvedInclude` interface in types.ts**Now update the test files.The first edit removed one but the offsets shifted. Let me re-read and fix the remaining ones.The edit tool keeps shifting IDs because each removal changes subsequent line numbers. Let me use ast_edit for this since it handles multiple removals atomically.Now let me also check the `setDependencies` helper to see if it types these objects as `ResolvedInclude` — if so, the type error from removing `lastModified` will already be caught by tsc.Good, the `setDependencies` is typed as `ResolvedInclude[]`, so tsc will catch any issues. Now let me also verify the include-resolver.ts edits are clean:I see the `resolved` object is missing `symbols` and the return on L158 is also missing `symbols`. Let me check what the original looked like more carefully — the edit removed lines incorrectly. The issue is that `symbols` was on the line _before_ `lastModified`, and my range edit removed both.The `symbols` field is missing from both the `resolved` object and the return statement. My edit removed too much. I need to add `symbols` back.The indentation is off — the inserted lines used wrong indentation. Let me fix:Let me check what the file uses for indentation:It uses 6 spaces for object properties inside `const resolved`. Let me fix the indentation:Now let me also check the `resolveSingleInclude` method:Same issue — `symbols` is missing from the return in `resolveSingleInclude`. Let me fix:Wait — the closing brace `};` got removed. Let me fix:Now let me run typecheck:Let me see the broader context to find the syntax issue:The error is at line 192 but the code around it looks fine. The issue might be earlier — perhaps a missing closing brace. Let me check from `resolveAndCache`:I see the indentation issue — lines 153-154 and 161-162 have only 6 spaces but should have 8 spaces (they're inside an object literal inside a function body). Let me fix:Wait, the file uses 6-space indentation for the object properties (matching the `originalPath:` line at 152). Let me look at the raw indentation more carefully. The `originalPath: result.originalPath,` at line 152 has 8 spaces of indentation (2 levels of 4). My additions need to match.That looks correct now — 8 spaces for object properties. Let me run typecheck again:Still the same error. Let me look at the full area around line 192 more carefully:Line 187 has `'  };'` — only 2 spaces of indentation, but it should be 4 (to match the `return {` on line 183). The closing `};` for the method is being parsed as a class-level statement.But wait — `resolveSingleInclude` is a method that needs a closing `}` for the method body. Let me check:The method body closes with `};` at line 187, but there's no closing `}` for the method itself. The `return { ... };` closes the object literal, but the method `resolveSingleInclude(` at line 176 needs its own `}`. Let me check what happened — my earlier edit removed the `}` when I replaced the range.Typecheck passes. Now run tests:All tests pass. Now write the KB entry:Done. Removed `lastModified` from `ResolvedInclude` across 4 source files. The field was dead data — written but never consumed. TypeScript compiles clean, all 57 affected tests pass.

## Linked Issue

Closes #1877

## Root Cause

The lastModified field on ResolvedInclude is set to Date.now() when resolving includes but is never read for cache invalidation or any other logic. The IncludeResolver.invalidate() method only removes entries by path, never by timestamp. All consumers of ResolvedInclude (document-links.ts, completion-qe.ts, completion-symbols.ts, definition-symbol-lookup.ts) only access originalPath, resolvedPath, and symbols — never lastModified.

## Changes

- .agent-knowledge/reference/KB-1876.md: (see commit diffs)
- .agent-knowledge/reference/KB-1877.md: (see commit diffs)
- packages/pike-lsp-server/src/core/types.ts: (see commit diffs)
- packages/pike-lsp-server/src/scenarios/document-links.test.ts: (see commit diffs)
- packages/pike-lsp-server/src/services/include-resolver.ts: (see commit diffs)
- packages/pike-lsp-server/src/tests/services/include-resolver.test.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1877

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].