### PR TITLE
chore: bump version to 0.1.0-alpha.44

### DIFF
--- a/packages/vscode-pike/package.json
+++ b/packages/vscode-pike/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-pike",
   "displayName": "Pike Language Support",
   "description": "Complete language support for Pike including IntelliSense, go-to-definition, find references, diagnostics, hover, signature help, code completion, semantic tokens, call hierarchy, and workspace symbols.",
-  "version": "0.1.0-alpha.43",
+  "version": "0.1.0-alpha.44",
   "publisher": "pike-lsp",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
## Summary
Bump vscode-pike package version from 0.1.0-alpha.43 to 0.1.0-alpha.44 for the next release.

## Changes
- Updated `version` field in `packages/vscode-pike/package.json`

## Verification
- No code changes — version bump only
- CI will validate the version matches the expected format

## Acceptance Criteria
- [x] Version in package.json is `0.1.0-alpha.44`

Closes #1888

## Knowledge Base
- [x] Exempt: trivial version bump, no functional change