### PR TITLE
fix: suppress transient syntax errors and undefined-symbol false positives during typing

### DIFF
--- a/.agent-knowledge/reference/KB-1911.md
+++ b/.agent-knowledge/reference/KB-1911.md
@@ -1,0 +1,15 @@
+---
+id: KB-AUTO-1911
+domain: REFACTOR
+date: 2026-04-15
+authors: [dga-coder]
+summary: PR review cleanup: removed redundant type cast, unrelated files, and added missing Linked Issue section
+---
+
+# KB-1911: PR #1911 review fixes — redundant cast, unrelated files, missing linked issue
+
+## Summary
+Reviewer requested three fixes on PR #1911: (1) removed redundant `as DocumentCacheEntry | undefined` cast on `DocumentCache.get()` which already returns that type, (2) removed unrelated `entities.json` and `mempalace.yaml` files from the branch via `git rm` + amend + force push, (3) added `## Linked Issue` section with `closes #649` to the PR body.
+
+## Key Files Changed
+- packages/pike-lsp-server/src/features/diagnostics/diagnostics-processor.ts: Removed redundant `as DocumentCacheEntry | undefined` cast and its now-unused import

--- a/packages/pike-lsp-server/src/features/diagnostics/diagnostics-processor.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/diagnostics-processor.ts
@@ -10,7 +10,7 @@
 import type { Connection, TextDocuments } from 'vscode-languageserver/node.js';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Services } from '../../services/index.js';
-import type { CoreDiagnostic, DocumentCacheEntry } from '../../core/types.js';
+import type { CoreDiagnostic } from '../../core/types.js';
 import { Logger } from '@pike-lsp/core';
 import type { RequestScheduler } from '../../services/request-scheduler.js';
 import { detectRoxenModule, provideRoxenDiagnostics } from '../roxen/index.js';
@@ -287,7 +287,7 @@ export async function processAnalysisResults(
       const introspectionForSemantic = introspectData.success
         ? introspectData
         : analysisMode === 'typing'
-          ? (services.documentCache.get(uri) as DocumentCacheEntry | undefined)?.introspection
+          ? services.documentCache.get(uri)?.introspection
           : undefined;
 
       // Skip undefined-symbol detection in typing mode without introspection.

--- a/packages/pike-lsp-server/src/features/diagnostics/diagnostics-processor.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/diagnostics-processor.ts
@@ -10,7 +10,7 @@
 import type { Connection, TextDocuments } from 'vscode-languageserver/node.js';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Services } from '../../services/index.js';
-import type { CoreDiagnostic } from '../../core/types.js';
+import type { CoreDiagnostic, DocumentCacheEntry } from '../../core/types.js';
 import { Logger } from '@pike-lsp/core';
 import type { RequestScheduler } from '../../services/request-scheduler.js';
 import { detectRoxenModule, provideRoxenDiagnostics } from '../roxen/index.js';
@@ -242,7 +242,15 @@ export async function processAnalysisResults(
   }
 
   // --- Analyze diagnostics processing ---
-  processAnalyzeDiagnostics(diagnosticsData, diagnostics, services, uri, log, pushDiagnostic);
+  processAnalyzeDiagnostics(
+    diagnosticsData,
+    diagnostics,
+    services,
+    uri,
+    log,
+    pushDiagnostic,
+    analysisMode
+  );
 
   if (degradedFailureMessage) {
     pushDiagnostic({
@@ -274,16 +282,28 @@ export async function processAnalysisResults(
   // --- Semantic analysis integration (Issue #1196) ---
   try {
     if (isSemanticAnalysisEnabled(services.globalSettings)) {
+      // In typing mode, introspection wasn't run — use cached introspection
+      // from the document cache so inherited/imported symbols are known.
+      const introspectionForSemantic = introspectData.success
+        ? introspectData
+        : analysisMode === 'typing'
+          ? (services.documentCache.get(uri) as DocumentCacheEntry | undefined)?.introspection
+          : undefined;
+
+      // Skip undefined-symbol detection in typing mode without introspection.
+      // Transient parse errors make token streams unreliable.
+      const enableUndefined = analysisMode === 'full' || !!introspectionForSemantic;
+
       const semanticResult = analyzeSemantics(
         document,
         parseData.symbols,
-        introspectData.success ? introspectData : undefined,
+        introspectionForSemantic,
         tokenizeData,
         {
           maxProblems: services.globalSettings.maxNumberOfProblems - diagnostics.length,
-          enableUndefinedDetection: true,
-          enableTypeMismatch: true,
-          enableMissingCallbacks: true,
+          enableUndefinedDetection: enableUndefined,
+          enableTypeMismatch: analysisMode === 'full',
+          enableMissingCallbacks: analysisMode === 'full',
         }
       );
 
@@ -349,6 +369,8 @@ export async function processAnalysisResults(
 /**
  * Process analyze diagnostics (syntax errors, uninitialized warnings).
  * Suppresses cascade diagnostics when syntax errors are present.
+ * In typing mode, suppresses syntax errors entirely — they're transient
+ * artifacts of incomplete code during active editing.
  */
 function processAnalyzeDiagnostics(
   diagnosticsData: AnalysisResults['diagnosticsData'],
@@ -356,7 +378,8 @@ function processAnalyzeDiagnostics(
   services: Services,
   uri: string,
   log: Logger,
-  pushDiagnostic: (d: CoreDiagnostic) => void
+  pushDiagnostic: (d: CoreDiagnostic) => void,
+  analysisMode: 'typing' | 'full' = 'full'
 ): void {
   const rawDiagData = diagnosticsData;
   const hasSyntaxErrors =
@@ -364,6 +387,17 @@ function processAnalyzeDiagnostics(
       const msg = d.message?.toLowerCase() ?? '';
       return msg.includes('syntax error') || msg.includes('unexpected tok_');
     }) ?? false;
+
+  // In typing mode, suppress syntax errors — they're transient artifacts
+  // of incomplete code. Full mode (on save/open) will catch real ones.
+  if (analysisMode === 'typing' && hasSyntaxErrors) {
+    log.debug('Suppressing transient syntax errors in typing mode', {
+      uri,
+      count: rawDiagData.diagnostics?.length ?? 0,
+    });
+    return;
+  }
+
   const diagnosticsToProcess = hasSyntaxErrors
     ? {
         diagnostics:

--- a/packages/pike-lsp-server/src/tests/scenarios/diagnostic-pipeline-scenario.test.ts
+++ b/packages/pike-lsp-server/src/tests/scenarios/diagnostic-pipeline-scenario.test.ts
@@ -472,7 +472,7 @@ describe('Scenario: document edit → diagnostics update', () => {
     );
   });
 
-  it('should produce error diagnostics when introducing a syntax error', async () => {
+  it('should suppress transient syntax errors in typing mode but show them in full mode', async () => {
     const harness = createPipelineHarness();
     harness.configure({ diagnosticDelay: 0 });
 
@@ -484,7 +484,7 @@ describe('Scenario: document edit → diagnostics update', () => {
     harness.openDocument(v1);
     await harness.waitForSettle(200);
 
-    // Step 2: Introduce error
+    // Step 2: Introduce error via typing (changeDocument)
     const brokenCode = 'int x = ;\n';
     const v2 = TextDocument.create(uri, 'pike', 2, brokenCode);
     harness.notifyChange(uri, 2, [
@@ -496,11 +496,26 @@ describe('Scenario: document edit → diagnostics update', () => {
     harness.changeDocument(v2);
     await harness.waitForSettle(200);
 
+    // Typing mode should suppress syntax errors (transient artifacts)
     const afterBreakDiags = harness.publishedDiagnostics.filter(d => d.uri === uri);
     const lastDiag = afterBreakDiags[afterBreakDiags.length - 1]!;
+    // Syntax errors from incomplete code during typing are suppressed.
+    // They'll appear on next full validation (save/open).
+    const hasSyntaxError = lastDiag.diagnostics.some(
+      d =>
+        d.message?.toLowerCase().includes('syntax') ||
+        d.message?.toLowerCase().includes('unexpected')
+    );
+    assert.ok(!hasSyntaxError, 'Typing mode should suppress transient syntax errors');
+
+    // Step 3: Full validation (simulating save) should show the error
+    harness.openDocument(v2); // re-open triggers full validation
+    await harness.waitForSettle(200);
+    const afterFullDiags = harness.publishedDiagnostics.filter(d => d.uri === uri);
+    const fullDiag = afterFullDiags[afterFullDiags.length - 1]!;
     assert.ok(
-      lastDiag.diagnostics.length > 0,
-      'Should have error diagnostics after introducing error'
+      fullDiag.diagnostics.length > 0,
+      'Full mode should show error diagnostics for broken code'
     );
   });
 


### PR DESCRIPTION
## Summary
Fix two diagnostic problems during active editing:

1. **"Undefined symbol" false positives** on imported/inherited symbols (e.g. `Stdio.File`, `write`, symbols from `inherit "foo.pike"`)
2. **Fake syntax errors** from Pike parser on incomplete code during typing

## Linked Issue

closes #649

## Changes
- `diagnostics-processor.ts`: In typing mode, use cached introspection from document cache for semantic analysis instead of skipping it entirely. Suppress syntax errors in typing mode (transient artifacts). Only run type-mismatch and missing-callback checks in full mode.
- `diagnostic-pipeline-scenario.test.ts`: Updated test to verify typing mode suppresses syntax errors while full mode shows them.

## Root Cause
During typing, the LSP runs `"typing"` mode which only does `parse` + `diagnostics` (no introspection). Without introspection, the semantic analyzer has no knowledge of imported/inherited symbols, so it flags them all as "Undefined symbol". Meanwhile, Pike's parser reports syntax errors on incomplete code (e.g. `int x = ;` mid-edit), which get shown as real errors.

## Verification
- 2868 pass, 66 fail (same baseline as main)
- All 26 diagnostic pipeline scenario tests pass
- No new type errors

## Knowledge Base
- [x] Exempt: bug fix with test update
