### PR TITLE
fix: preserve introspection in cache during typing-mode updates

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics/cache-builder.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/cache-builder.ts
@@ -311,7 +311,7 @@ export async function buildCacheParseOnly(
     contentHash,
     lineHashes,
     ...(analysisMode === 'typing' && previousEntry
-      ? { dependencies: previousEntry.dependencies, inherits: previousEntry.inherits }
+      ? { dependencies: previousEntry.dependencies, inherits: previousEntry.inherits, introspection: previousEntry.introspection }
       : {}),
     analysisState: {
       isStale: false,


### PR DESCRIPTION
## Summary
Fixes #1917

`buildCacheParseOnly()` constructs a new `DocumentCacheEntry` for typing mode but did not carry over the `introspection` field from the previous cache entry. This caused introspection to be lost on the first typing edit after a full validation, defeating the cached-introspection fallback added in PR #1911.

## Changes
- `cache-builder.ts`: Include `introspection: previousEntry.introspection` in the spread that already preserves `dependencies` and `inherits` during typing-mode cache writes.

## Root Cause
PR #1911 added code in `diagnostics-processor.ts` to read `services.documentCache.get(uri)?.introspection` as a fallback in typing mode. However, `buildCacheParseOnly()` replaces the cache entry with a fresh object that only preserves `dependencies` and `inherits` — not `introspection`. After the first keystroke, the introspection was gone.

## Verification
- All 49 diagnostic pipeline + semantic diagnostics tests pass
- Full suite: 2941 pass, 66 fail (same baseline as main — all pre-existing)
- No new type errors

## Acceptance Criteria
- [x] Typing-mode cache writes preserve introspection from previous entry
- [x] No test regressions
- [x] Linked issue #1917

## Knowledge Base
- [x] Exempt: follow-up fix to PR #1911, single-line change with test coverage through existing pipeline tests