### PR TITLE
fix: use PikeFunctionType.arguments in hover snapshot fixture

### DIFF
--- a/packages/pike-lsp-server/src/stdlib-index.ts
+++ b/packages/pike-lsp-server/src/stdlib-index.ts
@@ -363,7 +363,10 @@ export class StdlibIndexManager {
 
       return moduleInfo;
     } catch (error) {
-      log.error(`Failed to load stdlib module ${modulePath}:`, error instanceof Error ? error : undefined);
+      log.error(
+        `Failed to load stdlib module ${modulePath}:`,
+        error instanceof Error ? error : undefined
+      );
       // Add to negative cache on error too
       this.negativeCache.add(modulePath);
       return null;

--- a/packages/pike-lsp-server/src/tests/navigation/hover-provider.snapshot.test.ts
+++ b/packages/pike-lsp-server/src/tests/navigation/hover-provider.snapshot.test.ts
@@ -46,11 +46,14 @@ Current request count"
     const symbol = createSymbol({
       name: 'sum',
       kind: 'method',
-      type: { kind: 'function', returnType: 'int' },
-      parameters: [
-        { name: 'left', type: 'int' },
-        { name: 'right', type: 'int' },
-      ],
+      type: {
+        kind: 'function',
+        returnType: 'int',
+        arguments: [
+          { name: 'left', type: 'int' },
+          { name: 'right', type: 'int' },
+        ],
+      },
       documentation:
         'Adds two values\n@param left left operand\n@param right right operand\n@returns sum',
     });
@@ -58,7 +61,7 @@ Current request count"
     const hover = buildHoverContent(symbol);
     expect(normalizeSnapshotValue(hover)).toMatchInlineSnapshot(`
 "\`\`\`pike
-int sum()
+int sum(int left, int right)
 \`\`\`
 
 ---


### PR DESCRIPTION
Closes #1933

## Problem

The hover snapshot test fixture used `parameters` (a non-existent field) instead of `PikeFunctionType.arguments`. After `buildMethodSignature()` was refactored to remove `Record` casts in #1925, this field was silently ignored, and the snapshot was updated to assert `int sum()` — confirming broken output as correct.

## Fix

- Updated fixture to use `type: { kind: 'function', returnType: 'int', arguments: [...] }`
- Restored snapshot to `int sum(int left, int right)`
- This proves hover parameter rendering actually works when given real bridge data

## Acceptance Criteria

- [x] Snapshot test fixture uses `type.arguments` instead of `parameters`
- [x] Snapshot asserts `int sum(int left, int right)`
- [x] All 80 hover tests pass locally