### PR TITLE
feat: dynamically discover Pike modules from module_path directories

### DIFF
--- a/packages/pike-lsp-server/src/runtime/server-runtime.ts
+++ b/packages/pike-lsp-server/src/runtime/server-runtime.ts
@@ -215,6 +215,18 @@ export function registerServerRuntimeHandlers(args: RegisterServerRuntimeHandler
           setStdlibIndex(stdlibIndex);
           updateServices({ stdlibIndex });
 
+          // Discover available modules from Pike's module_path directories.
+          // This finds user-added custom modules via -M or PIKE_MODULE_PATH
+          // that the hardcoded KNOWN_STDLIB_MODULES list doesn't cover.
+          try {
+            const paths = await bridgeManager.bridge.getPikePaths();
+            if (paths.module_paths?.length) {
+              stdlibIndex.scanModulePaths(paths.module_paths);
+            }
+          } catch (err) {
+            log(`Module discovery skipped: ${err instanceof Error ? err.message : String(err)}`);
+          }
+
           bridgeManager.on('stderr', (msg: unknown) => {
             log(`[Pike STDERR] ${String(msg)}`);
           });

--- a/packages/pike-lsp-server/src/stdlib-index.ts
+++ b/packages/pike-lsp-server/src/stdlib-index.ts
@@ -12,6 +12,8 @@ import type { PikeBridge } from '@pike-lsp/pike-bridge';
 import type { IntrospectedSymbol, InheritanceInfo } from '@pike-lsp/pike-bridge';
 import { Logger } from '@pike-lsp/core';
 import { MAX_STDLIB_MODULES } from './constants/index.js';
+import { readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
 
 const log = new Logger('StdlibIndex');
 
@@ -150,6 +152,9 @@ export class StdlibIndexManager {
   /** Memory tracking */
   private currentMemoryBytes = 0;
 
+  /** Discovered module paths from filesystem scanning */
+  private discoveredModules = new Set<string>();
+
   /** Statistics */
   private stats = {
     hits: 0,
@@ -227,6 +232,13 @@ export class StdlibIndexManager {
    */
   getAvailableModules(): string[] {
     const paths = new Set<string>(this.modules.keys());
+    // Discovered modules take priority — they're confirmed to exist on disk
+    for (const modulePath of this.discoveredModules) {
+      if (!this.negativeCache.has(modulePath)) {
+        paths.add(modulePath);
+      }
+    }
+    // Hardcoded list is fallback for modules not yet scanned
     for (const modulePath of KNOWN_STDLIB_MODULES) {
       if (!this.negativeCache.has(modulePath)) {
         paths.add(modulePath);
@@ -234,6 +246,87 @@ export class StdlibIndexManager {
     }
     return [...paths];
   }
+
+  /**
+   * Scan filesystem module paths to discover available Pike modules.
+   * Called once at startup with module_paths from bridge.getPikePaths().
+   * Finds .pmod directories, .pike files, and .so files, converting
+   * directory structure to module paths (e.g. Parser/Pike.pmod → Parser.Pike).
+   */
+  scanModulePaths(modulePaths: string[]): void {
+    for (const basePath of modulePaths) {
+      if (!existsSync(basePath)) continue;
+      try {
+        this.walkModuleDir(basePath, '');
+      } catch (err) {
+        log.debug('Module path scan failed', {
+          basePath,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    log.debug('Module discovery complete', {
+      discoveredCount: this.discoveredModules.size,
+    });
+  }
+
+  /**
+   * Recursively walk a module directory, collecting .pmod/.pike/.so entries.
+   * Converts directory structure to Pike module paths using '.' separators.
+   */
+  private walkModuleDir(dirPath: string, prefix: string): void {
+    let entries;
+    try {
+      entries = readdirSync(dirPath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      // Skip hidden files, test files, object files
+      if (entry.name.startsWith('.') || entry.name.endsWith('.o') || entry.name.includes('.test')) {
+        continue;
+      }
+
+      if (entry.isDirectory()) {
+        if (entry.name.endsWith('.pmod')) {
+          // Foo.pmod directory → Foo module
+          const modName = entry.name.slice(0, -'.pmod'.length);
+          const modPath = prefix ? `${prefix}.${modName}` : modName;
+          this.discoveredModules.add(modPath);
+          // Recurse into the .pmod directory for sub-modules
+          this.walkModuleDir(join(dirPath, entry.name), modPath);
+        } else {
+          // Regular directory — recurse (might contain .pmod/.pike files)
+          this.walkModuleDir(join(dirPath, entry.name), prefix);
+        }
+      } else if (entry.isFile()) {
+        if (entry.name.endsWith('.pike')) {
+          const modName = entry.name.slice(0, -'.pike'.length);
+          if (modName === 'module') {
+            // module.pike inside a directory = parent module implementation
+            if (prefix) this.discoveredModules.add(prefix);
+          } else {
+            const modPath = prefix ? `${prefix}.${modName}` : modName;
+            this.discoveredModules.add(modPath);
+          }
+        } else if (entry.name.endsWith('.so')) {
+          // Skip underscore-prefixed .so files (internal C modules)
+          if (entry.name.startsWith('_')) continue;
+          const modName = entry.name.slice(0, -'.so'.length);
+          const modPath = prefix ? `${prefix}.${modName}` : modName;
+          this.discoveredModules.add(modPath);
+        } else if (entry.name.endsWith('.pmod') && !entry.isDirectory()) {
+          // Single-file .pmod (rare but valid)
+          const modName = entry.name.slice(0, -'.pmod'.length);
+          const modPath = prefix ? `${prefix}.${modName}` : modName;
+          this.discoveredModules.add(modPath);
+        }
+      }
+    }
+  }
+
+  /**
 
   /**
    * Get cache statistics

--- a/packages/pike-lsp-server/src/tests/stdlib-index.test.ts
+++ b/packages/pike-lsp-server/src/tests/stdlib-index.test.ts
@@ -15,6 +15,9 @@ import { describe, it, beforeAll, afterAll } from 'bun:test';
 import * as assert from 'node:assert/strict';
 import { StdlibIndexManager } from '../stdlib-index.js';
 import type { PikeBridge } from '@pike-lsp/pike-bridge';
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 // ============================================================================
 // Mock PikeBridge
@@ -727,5 +730,123 @@ describe('StdlibIndexManager - getAvailableModules', () => {
 
     // Assert
     assert.equal(stdioCount, 1, 'Stdio should appear exactly once (no duplicates)');
+  });
+});
+
+// ============================================================================
+// Module Discovery Tests
+// ============================================================================
+
+describe('StdlibIndexManager - Module Discovery', () => {
+  let tempDir: string;
+
+  // Helper to create a mock bridge for discovery tests
+  const noopBridge = {
+    introspectModule: async () => ({ success: false }),
+  } as unknown as PikeBridge;
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'pike-test-mods-'));
+  });
+
+  afterAll(() => {
+    try {
+      rmSync(tempDir, { recursive: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('discovers .pmod directory as module', () => {
+    mkdirSync(join(tempDir, 'MyMod.pmod'), { recursive: true });
+    const manager = new StdlibIndexManager(noopBridge);
+    manager.scanModulePaths([tempDir]);
+
+    const modules = manager.getAvailableModules();
+    assert.ok(modules.includes('MyMod'), `Expected MyMod in ${modules}`);
+  });
+
+  it('discovers .pike file as module', () => {
+    writeFileSync(join(tempDir, 'Helper.pike'), '// test');
+    const manager = new StdlibIndexManager(noopBridge);
+    manager.scanModulePaths([tempDir]);
+
+    const modules = manager.getAvailableModules();
+    assert.ok(modules.includes('Helper'), `Expected Helper in ${modules}`);
+  });
+
+  it('discovers .so file as module (not underscore-prefixed)', () => {
+    writeFileSync(join(tempDir, 'NativeMod.so'), 'binary');
+    const manager = new StdlibIndexManager(noopBridge);
+    manager.scanModulePaths([tempDir]);
+
+    const modules = manager.getAvailableModules();
+    assert.ok(modules.includes('NativeMod'), `Expected NativeMod in ${modules}`);
+  });
+
+  it('skips underscore-prefixed .so files', () => {
+    writeFileSync(join(tempDir, '_Internal.so'), 'binary');
+    writeFileSync(join(tempDir, '_CustomInternal.so'), 'binary');
+    const manager = new StdlibIndexManager(noopBridge);
+    manager.scanModulePaths([tempDir]);
+
+    const modules = manager.getAvailableModules();
+    assert.ok(!modules.includes('_Internal'), `Should not include _Internal`);
+    assert.ok(!modules.includes('_CustomInternal'), `Should not include _CustomInternal`);
+  });
+
+  it('discovers nested modules inside .pmod directories', () => {
+    mkdirSync(join(tempDir, 'TopLevel.pmod', 'SubMod.pmod'), { recursive: true });
+    const manager = new StdlibIndexManager(noopBridge);
+    manager.scanModulePaths([tempDir]);
+
+    const modules = manager.getAvailableModules();
+    assert.ok(modules.includes('TopLevel'), `Expected TopLevel in ${modules}`);
+    assert.ok(modules.includes('TopLevel.SubMod'), `Expected TopLevel.SubMod in ${modules}`);
+  });
+
+  it('discovers module.pike inside directory as parent module', () => {
+    const modDir = join(tempDir, 'FooBar.pmod');
+    mkdirSync(modDir, { recursive: true });
+    writeFileSync(join(modDir, 'module.pike'), '// parent impl');
+    const manager = new StdlibIndexManager(noopBridge);
+    manager.scanModulePaths([tempDir]);
+
+    const modules = manager.getAvailableModules();
+    assert.ok(modules.includes('FooBar'), `Expected FooBar from module.pike`);
+  });
+
+  it('merges discovered modules with hardcoded list', () => {
+    mkdirSync(join(tempDir, 'CustomLib.pmod'), { recursive: true });
+    const manager = new StdlibIndexManager(noopBridge);
+    manager.scanModulePaths([tempDir]);
+
+    const modules = manager.getAvailableModules();
+    // Custom discovered module
+    assert.ok(modules.includes('CustomLib'), `Expected CustomLib`);
+    // Hardcoded module from KNOWN_STDLIB_MODULES
+    assert.ok(modules.includes('Stdio'), `Expected Stdio from hardcoded list`);
+  });
+
+  it('handles non-existent module path gracefully', () => {
+    const manager = new StdlibIndexManager(noopBridge);
+    // Should not throw
+    manager.scanModulePaths(['/nonexistent/path/that/does/not/exist']);
+    const modules = manager.getAvailableModules();
+    // Should still have hardcoded modules
+    assert.ok(modules.includes('Stdio'));
+  });
+
+  it('skips .o files and test files', () => {
+    mkdirSync(join(tempDir, 'Real.pmod'), { recursive: true });
+    writeFileSync(join(tempDir, 'Real.pike'), '// ok');
+    writeFileSync(join(tempDir, 'Junk.o'), 'object');
+    mkdirSync(join(tempDir, 'Skip.test.pmod'), { recursive: true });
+    const manager = new StdlibIndexManager(noopBridge);
+    manager.scanModulePaths([tempDir]);
+
+    const modules = manager.getAvailableModules();
+    assert.ok(modules.includes('Real'), `Expected Real`);
+    assert.ok(!modules.some(m => m.includes('Junk')), `Should not include .o files`);
   });
 });


### PR DESCRIPTION
## Summary

Dynamically discover Pike modules from module_path directories at server startup. Scans filesystem for .pmod, .pike, and .so files and merges discovered modules with the hardcoded KNOWN_STDLIB_MODULES fallback list.

## Problem

Users who add custom Pike modules via `-M` flag or `PIKE_MODULE_PATH` environment variable do not get completion or hover for those modules. The stdlib index only knows about the hardcoded `KNOWN_STDLIB_MODULES` list.

## Implementation

- Added `scanModulePaths(modulePaths: string[])` to `StdlibIndexManager`
- Added `walkModuleDir(dirPath, prefix)` private recursive directory walker
- Added `discoveredModules` Set field
- Updated `getAvailableModules()` to include discovered modules before hardcoded list
- Wired into `server-runtime.ts` after bridge init via `bridge.getPikePaths()`

## Skip Rules

- `.o` files (compiled objects)
- `.test` files
- Hidden files (dot prefix)
- Underscore-prefixed `.so` files (internal C modules)

Closes #1945

## Testing

- 9 new tests covering: directory scanning, sub-modules, file types, skip rules, merging, error handling
- Full suite: 38 pass, 1 fail (pre-existing PikeBridge integration — no pike binary locally)
- TypeScript compiles clean

## Acceptance Criteria

- [x] `scanModulePaths()` walks module_path directories recursively
- [x] Discovers .pmod dirs, .pike files, .so files as module paths
- [x] Skips .o files, .test files, hidden files, underscore-prefixed .so
- [x] Merges discovered modules with KNOWN_STDLIB_MODULES
- [x] Wired into server-runtime.ts after bridge init
- [x] Tests for all discovery scenarios

## Knowledge Base

- [x] Exempt: Feature addition following existing patterns in stdlib-index.ts. No new architectural concepts.
