### PR TITLE
perf(#1950): Avoid spreading queueWaitMs arrays on every snapshotMetrics(

### DIFF
--- a/.agent-knowledge/reference/KB-1950.md
+++ b/.agent-knowledge/reference/KB-1950.md
@@ -1,0 +1,17 @@
+---
+id: KB-AUTO-1950
+domain: REFACTOR
+date: 2026-04-15
+authors: [dga-coder]
+summary: Removed array spread copies in snapshotMetrics() queueWaitMs, returning arrays by reference instead
+---
+
+# KB-1950: Avoid spreading queueWaitMs arrays on every snapshotMetrics() call
+
+## Summary
+
+`snapshotMetrics()` in `request-scheduler.ts` was spreading three `queueWaitMs` arrays (typing, interactive, background — up to 256 elements each) on every call, creating up to 768 shallow copies per LSP request. Removed the spread operators and returned the arrays by reference. Safe because no callers mutate these arrays (verified via codebase search).
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/services/request-scheduler.ts: Replaced `[...this.metrics.queueWaitMs.typing]` etc. with `queueWaitMs: this.metrics.queueWaitMs` in snapshotMetrics().


### PR DESCRIPTION
Closes #1950

## Summary

The queueWaitMs spread removal in `request-scheduler.ts` `snapshotMetrics()` was already merged via PR #1882 (commit `1f62ca4`). This PR adds the missing knowledge base entry documenting the change.

## Linked Issue

Closes #1950

## Root Cause

PR #1950 was filed to remove unnecessary array spread copies in `snapshotMetrics()`. The code change was already applied by PR #1882 but the KB entry was never created.

## Changes

- `.agent-knowledge/reference/KB-1950.md`: Added KB entry documenting the removal of `[...this.metrics.queueWaitMs.typing]` etc. in `snapshotMetrics()`, returning arrays by reference instead. Safe because no callers mutate these arrays.

## Verification

```
$ bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json
(No errors — only KB file changed, no source code touched)
```

## Checklist

- [x] Knowledge base entry added
- [x] Branch rebased onto clean main (1 file in diff)
- [x] Commit message describes the actual change
