### PR TITLE
fix: disable fail-fast on E2E matrix to prevent cascade cancellation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -369,7 +369,7 @@ jobs:
     timeout-minutes: 25
     continue-on-error: ${{ matrix.optional }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - category: core-lsp


### PR DESCRIPTION
## Summary

Disable `fail-fast: true` on the `vscode-e2e-category` matrix job to prevent cascade cancellation.

## Problem

The `vscode-e2e-category` job uses `fail-fast: true` in its matrix strategy. When one E2E category (typically `performance`, which runs fastest) fails, GitHub Actions cancels all other in-progress matrix jobs (core-lsp, completion-navigation, reliability-workflows).

This means a single flaky performance test (which uses tight timing thresholds on shared CI runners) blocks the entire PR, even when all other E2E categories would have passed.

## Fix

Set `fail-fast: false` so each E2E category runs to completion independently. The `vscode-e2e` gate job (L479-493) still checks the aggregate result of all categories and fails if any required category fails.

## Testing

- CI-only change, no production code affected
- The vscode-e2e gate job behavior is unchanged

## Acceptance Criteria

- [x] E2E categories run independently (no cascade cancellation)
- [x] The vscode-e2e gate still enforces required categories pass

## Knowledge Base

- [x] Exempt: CI workflow configuration change. No architectural impact.
