### PR TITLE
fix(#1982): Fix lost-wakeup semaphore in processBatch concurrency limite

### DIFF
--- a/.agent-knowledge/reference/KB-1982.md
+++ b/.agent-knowledge/reference/KB-1982.md
@@ -1,0 +1,30 @@
+---
+id: KB-AUTO-1982
+domain: BUGFIX
+date: 2026-04-15
+authors: [dga-coder]
+summary: Fixed lost-wakeup bug in processBatch concurrency semaphore by replacing single-resolver variable with a queue and fixing slot handoff logic
+---
+
+# KB-1982: Fix lost-wakeup semaphore in processBatch concurrency limiter
+
+## Summary
+
+The inline semaphore in `WorkspaceDiagnosticsManager.processBatch()` used a single `onSlot` variable to track one waiting promise resolver. When `batch.size > MAX_CONCURRENT (10)` and multiple `readFile` calls called `acquire()` while the semaphore was saturated, only the last waiter's resolver was stored — earlier promises were overwritten and never resolved. This caused `Promise.all` to hang indefinitely, stalling the background diagnostics pipeline.
+
+## Root Cause
+
+Two bugs in the original semaphore:
+
+1. **Single-resolver overwrite**: `let onSlot: (() => void) | null = null` stored only one waiter. Subsequent waiters replaced the previous resolver, which would never be called.
+2. **Incorrect slot handoff**: `release()` decremented `active` then called the waiter, but the waiter's promise resolved without re-incrementing `active`. This caused `active` to go negative and the concurrency limit to become meaningless.
+
+## Fix
+
+1. Replaced `let onSlot` with `const queue: Array<() => void> = []`. Waiters push onto the queue; release shifts the first.
+2. Changed `release()` to hand off the slot directly: if a waiter exists, call it (keeping `active` unchanged); otherwise decrement `active`. This avoids the decrement-then-re-increment race.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/services/workspace-diagnostics.ts: Replaced single `onSlot` variable with a `queue` array, fixed `release()` slot handoff logic
+- packages/pike-lsp-server/src/scenarios/processBatch-semaphore-queue.test.ts: New test file with 3 tests covering multi-waiter queue, max concurrent enforcement, and chain handoff with 20 waiters

--- a/packages/pike-lsp-server/src/scenarios/processBatch-semaphore-queue.test.ts
+++ b/packages/pike-lsp-server/src/scenarios/processBatch-semaphore-queue.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Scenario: processBatch concurrency limiter semaphore queue (Issue #1982)
+ *
+ * Verifies that the inline semaphore in processBatch correctly queues
+ * multiple waiters instead of overwriting a single resolver, which caused
+ * lost wakeups and hangs when batch.size > MAX_CONCURRENT.
+ */
+
+import { describe, it } from 'bun:test';
+import assert from 'node:assert/strict';
+
+/**
+ * Reproduces the semaphore pattern from processBatch.
+ * When a waiter is released, the slot is handed off directly (active stays the same)
+ * rather than decrementing and re-incrementing.
+ */
+function makeSemaphore(maxConcurrent: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  const acquire = () => {
+    if (active < maxConcurrent) {
+      active++;
+      return Promise.resolve();
+    }
+    return new Promise<void>(r => {
+      queue.push(r);
+    });
+  };
+  const release = () => {
+    const next = queue.shift();
+    if (next) {
+      next();
+    } else {
+      active--;
+    }
+  };
+  return { acquire, release, getActive: () => active, getQueueLength: () => queue.length };
+}
+
+describe('processBatch concurrency semaphore', () => {
+  it('should queue multiple waiters and resolve all of them', async () => {
+    const sem = makeSemaphore(2);
+    const completed: number[] = [];
+
+    const tasks = Array.from({ length: 5 }, (_, i) => async () => {
+      await sem.acquire();
+      completed.push(i);
+      await new Promise<void>(r => setTimeout(r, 10));
+      sem.release();
+    });
+
+    await Promise.all(tasks.map(t => t()));
+
+    assert.strictEqual(completed.length, 5, 'all 5 tasks should have completed');
+    assert.strictEqual(sem.getQueueLength(), 0, 'no waiters should remain');
+    assert.strictEqual(sem.getActive(), 0, 'no slots should remain active');
+    assert.deepStrictEqual(
+      completed.sort((a, b) => a - b),
+      [0, 1, 2, 3, 4],
+      'all tasks should have acquired a slot'
+    );
+  });
+
+  it('should not exceed max concurrent', async () => {
+    const MAX_CONCURRENT = 3;
+    let maxObserved = 0;
+    let currentActive = 0;
+
+    let active = 0;
+    const queue: Array<() => void> = [];
+    const acquire = () => {
+      if (active < MAX_CONCURRENT) {
+        active++;
+        currentActive = active;
+        maxObserved = Math.max(maxObserved, currentActive);
+        return Promise.resolve();
+      }
+      return new Promise<void>(r => {
+        queue.push(r);
+      });
+    };
+    const release = () => {
+      const next = queue.shift();
+      if (next) {
+        next();
+      } else {
+        active--;
+      }
+    };
+
+    const tasks = Array.from({ length: 10 }, () => async () => {
+      await acquire();
+      await new Promise<void>(r => setTimeout(r, 5));
+      release();
+    });
+
+    await Promise.all(tasks.map(t => t()));
+
+    assert.ok(
+      maxObserved <= MAX_CONCURRENT,
+      `max concurrent ${maxObserved} should not exceed ${MAX_CONCURRENT}`
+    );
+    assert.strictEqual(active, 0);
+  });
+
+  it('should not lose wakeups when many waiters queue simultaneously', async () => {
+    const sem = makeSemaphore(1);
+    let completed = 0;
+    const TOTAL = 20;
+
+    // Block the single slot first
+    await sem.acquire();
+
+    // Queue all others
+    const promises = Array.from({ length: TOTAL - 1 }, () =>
+      sem.acquire().then(() => {
+        completed++;
+        sem.release();
+      })
+    );
+
+    // Release the initial slot, starting the handoff chain
+    sem.release();
+
+    await Promise.all(promises);
+
+    assert.strictEqual(completed, TOTAL - 1, 'all queued waiters should have completed');
+    assert.strictEqual(sem.getActive(), 0);
+  });
+});

--- a/packages/pike-lsp-server/src/services/workspace-diagnostics.ts
+++ b/packages/pike-lsp-server/src/services/workspace-diagnostics.ts
@@ -245,20 +245,23 @@ export class WorkspaceDiagnosticsManager {
           // Concurrency-limited file reads to avoid I/O stampede
           const MAX_CONCURRENT = 10;
           let active = 0;
-          let onSlot: (() => void) | null = null;
+          const queue: Array<() => void> = [];
           const acquire = () => {
             if (active < MAX_CONCURRENT) {
               active++;
               return Promise.resolve();
             }
             return new Promise<void>(r => {
-              onSlot = r;
+              queue.push(r);
             });
           };
           const release = () => {
-            active--;
-            onSlot?.();
-            onSlot = null;
+            const next = queue.shift();
+            if (next) {
+              next();
+            } else {
+              active--;
+            }
           };
 
           type ItemResult =


### PR DESCRIPTION
Closes #1982

## Summary

Bug confirmed: `onSlot` is a single variable, so concurrent waiters overwrite each other. Fix is to use a queue.Wait — I see a duplicate `let active = 0;` in the diff. Let me check the file.Duplicate line. Remove it.Now let me check for existing tests related to this file, then typecheck and run tests.The edit removed both `let active = 0;` lines. Let me fix.Typecheck passes. Now run the relevant tests.No test files for workspace-diagnostics in that directory. Let me check the test directories.All existing tests pass. Now write a test for the semaphore fix. Let me check the existing test file for patterns.Now let me write a focused unit test for the semaphore fix. I'll add it to the existing scenarios directory since that's the project convention.Bug in the test — the `release()` in the second test decrements `active` but the waiter from `queue.shift()` doesn't increment it. The real code calls `acquire()` first which increments. But in my test, when `release()` calls the waiter, that waiter's promise resolves but the task that was waiting was already past the `await acquire()` call — the issue is that when the queued resolver fires, the code after `await acquire()` runs, but `active` was decremented. I need to fix the semaphore to increment `active` when a queued waiter is released.The production code has the same bug: `release()` decrements `active` then calls the next waiter, but the waiter's `acquire()` promise resolves without incrementing `active`. The original code had the same issue because `onSlot?.()` would resolve the promise, but `active++` only happens inside the `if (active < MAX_CONCURRENT)` branch. When a queued waiter is woken, `active` was decremented but not re-incremented. This is actually a pre-existing issue with the original code too — but the original code only had one waiter, so it was less likely to manifest. Let me fix the production `release()` to properly hand off the slot.Now fix the test to match the corrected logic:Typecheck clean, all 3 new tests pass. Let me also verify the existing diagnostics tests still pass.All passing. Now write the KB entry.Done. The fix replaced the single-resolver `onSlot` variable with a `queue` array and corrected the `release()` handoff logic. Two bugs were present: (1) waiter overwrite causing lost wakeups, and (2) `release()` decrementing `active` before waking a waiter without re-incrementing, which would cause `active` to go negative. The new `release()` either hands the slot directly to the next waiter (keeping `active` unchanged) or decrements `active` if the queue is empty.

## Linked Issue

Closes #1982

## Root Cause

The inline semaphore uses a single onSlot variable to track one waiting promise. When batch.size > MAX_CONCURRENT (10) and multiple readFile calls call acquire() while the semaphore is saturated, only the last waiter's resolver is stored — earlier promises are overwritten and never resolve. This causes the Promise.all to hang indefinitely, stalling the entire background diagnostics pipeline.

## Changes

- .agent-knowledge/reference/KB-1982.md: (see commit diffs)
- packages/pike-lsp-server/src/scenarios/processBatch-semaphore-queue.test.ts: (see commit diffs)
- packages/pike-lsp-server/src/services/workspace-diagnostics.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-1982

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].