### PR TITLE
fix: remove skip-path diagnostic filtering hack

### DIFF
--- a/packages/pike-lsp-server/src/features/diagnostics/__tests__/stale-diagnostics.scenario.test.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/__tests__/stale-diagnostics.scenario.test.ts
@@ -1,20 +1,26 @@
 /**
  * Stale Diagnostics Scenario Tests
  *
- * Tests that prove error diagnostics are cleared when the user fixes code,
- * without overwhelming the engine with forced re-validation.
+ * Tests the skip-path validation behavior: when change-detection classifies
+ * a change as semantically irrelevant (canSkip=true), diagnostics are
+ * republished as-is without any line-based filtering.
+ *
+ * The ±1 line proximity filtering was removed because diagnostics queries
+ * now always use mode:'latest' (PR #1942), which eliminates stale snapshot
+ * issues. Change-detection's canSkip=true already confirms no semantic
+ * change occurred, so filtering by line proximity is unnecessary.
  */
 
 import { describe, it } from 'bun:test';
 import assert from 'node:assert/strict';
 
 describe('Stale Diagnostics Scenario', () => {
-  it('should clear errors on changed lines when skipping validation', () => {
+  it('should republish all diagnostics unchanged when skipping validation', () => {
     // Simulate the scenario:
-    // 1. Document has error on line 5
-    // 2. User types on line 5
+    // 1. Document has error on line 5 and warning on line 10
+    // 2. User types whitespace on line 3
     // 3. Change detection says "skip" (semantic unchanged)
-    // 4. Error on line 5 should be cleared
+    // 4. All diagnostics are republished as-is
 
     const cachedDiagnostics = [
       {
@@ -29,29 +35,19 @@ describe('Stale Diagnostics Scenario', () => {
       },
     ];
 
-    const changeRange = { start: { line: 5, character: 2 }, end: { line: 5, character: 3 } };
+    // Skip-path: no filtering applied, diagnostics pass through unchanged
+    const diagnosticsToSend = cachedDiagnostics;
 
-    // Filter logic (same as in index.ts)
-    const changeStartLine = changeRange.start.line;
-    const changeEndLine = changeRange.end.line;
-
-    const filteredDiagnostics = cachedDiagnostics.filter(d => {
-      if (d.severity !== 1) return true; // Keep warnings
-      const errorLine = d.range.start.line;
-      return errorLine < changeStartLine - 1 || errorLine > changeEndLine + 1;
-    });
-
-    // Error on line 5 should be cleared
-    assert.strictEqual(filteredDiagnostics.length, 1, 'Should have 1 diagnostic left');
-    assert.strictEqual(filteredDiagnostics[0]?.severity, 2, 'Only warning should remain');
-    assert.strictEqual(
-      filteredDiagnostics[0]?.range.start.line,
-      10,
-      'Warning on line 10 should remain'
-    );
+    assert.strictEqual(diagnosticsToSend.length, 2, 'Should republish all diagnostics');
+    assert.strictEqual(diagnosticsToSend[0]?.severity, 1, 'Error should be preserved');
+    assert.strictEqual(diagnosticsToSend[1]?.severity, 2, 'Warning should be preserved');
   });
 
-  it('should keep errors on unchanged lines', () => {
+  it('should not filter errors on changed lines when skipping', () => {
+    // Previous behavior filtered errors ±1 line from change. Now we trust
+    // change-detection: if it says canSkip, the change was semantically
+    // irrelevant and ALL diagnostics are correct as-is.
+
     const cachedDiagnostics = [
       {
         severity: 1,
@@ -65,71 +61,17 @@ describe('Stale Diagnostics Scenario', () => {
       },
     ];
 
-    const changeRange = { start: { line: 5, character: 2 }, end: { line: 5, character: 3 } };
+    // Even if the change was on line 5, skip-path doesn't filter
+    const diagnosticsToSend = cachedDiagnostics;
 
-    const changeStartLine = changeRange.start.line;
-    const changeEndLine = changeRange.end.line;
-
-    const filteredDiagnostics = cachedDiagnostics.filter(d => {
-      if (d.severity !== 1) return true;
-      const errorLine = d.range.start.line;
-      return errorLine < changeStartLine - 1 || errorLine > changeEndLine + 1;
-    });
-
-    // Error on line 5 cleared, error on line 20 kept
-    assert.strictEqual(filteredDiagnostics.length, 1, 'Should have 1 diagnostic left');
-    assert.strictEqual(
-      filteredDiagnostics[0]?.range.start.line,
-      20,
-      'Error on line 20 should remain'
+    assert.strictEqual(diagnosticsToSend.length, 2, 'Both errors preserved');
+    assert.ok(
+      diagnosticsToSend.every(d => d.severity === 1),
+      'All errors should be preserved'
     );
   });
 
-  it('should clear adjacent errors (one line buffer)', () => {
-    const cachedDiagnostics = [
-      {
-        severity: 1,
-        range: { start: { line: 4, character: 0 }, end: { line: 4, character: 10 } },
-        message: 'Error above',
-      },
-      {
-        severity: 1,
-        range: { start: { line: 5, character: 0 }, end: { line: 5, character: 10 } },
-        message: 'Error on line',
-      },
-      {
-        severity: 1,
-        range: { start: { line: 6, character: 0 }, end: { line: 6, character: 10 } },
-        message: 'Error below',
-      },
-      {
-        severity: 1,
-        range: { start: { line: 10, character: 0 }, end: { line: 10, character: 10 } },
-        message: 'Far error',
-      },
-    ];
-
-    const changeRange = { start: { line: 5, character: 2 }, end: { line: 5, character: 3 } };
-
-    const changeStartLine = changeRange.start.line;
-    const changeEndLine = changeRange.end.line;
-
-    const filteredDiagnostics = cachedDiagnostics.filter(d => {
-      if (d.severity !== 1) return true;
-      const errorLine = d.range.start.line;
-      return errorLine < changeStartLine - 1 || errorLine > changeEndLine + 1;
-    });
-
-    // Lines 4, 5, 6 should be cleared (adjacent), line 10 kept
-    assert.strictEqual(filteredDiagnostics.length, 1, 'Should have 1 diagnostic left');
-    assert.strictEqual(
-      filteredDiagnostics[0]?.range.start.line,
-      10,
-      'Error on line 10 should remain'
-    );
-  });
-
-  it('should keep warnings on changed lines', () => {
+  it('should preserve warnings, errors, and info equally', () => {
     const cachedDiagnostics = [
       {
         severity: 1,
@@ -148,80 +90,27 @@ describe('Stale Diagnostics Scenario', () => {
       },
     ];
 
-    const changeRange = { start: { line: 5, character: 2 }, end: { line: 5, character: 3 } };
+    const diagnosticsToSend = cachedDiagnostics;
 
-    const changeStartLine = changeRange.start.line;
-    const changeEndLine = changeRange.end.line;
-
-    const filteredDiagnostics = cachedDiagnostics.filter(d => {
-      if (d.severity !== 1) return true; // Keep warnings and info
-      const errorLine = d.range.start.line;
-      return errorLine < changeStartLine - 1 || errorLine > changeEndLine + 1;
-    });
-
-    // Error cleared, warning and info kept
-    assert.strictEqual(filteredDiagnostics.length, 2, 'Should have 2 diagnostics left');
-    assert.ok(
-      filteredDiagnostics.every(d => d.severity !== 1),
-      'No errors should remain'
-    );
+    assert.strictEqual(diagnosticsToSend.length, 3, 'All diagnostics preserved');
+    assert.strictEqual(diagnosticsToSend[0]?.severity, 1);
+    assert.strictEqual(diagnosticsToSend[1]?.severity, 2);
+    assert.strictEqual(diagnosticsToSend[2]?.severity, 3);
   });
 
-  it('should handle multi-line changes', () => {
-    const cachedDiagnostics = [
-      {
-        severity: 1,
-        range: { start: { line: 3, character: 0 }, end: { line: 3, character: 10 } },
-        message: 'Above range',
-      },
-      {
-        severity: 1,
-        range: { start: { line: 5, character: 0 }, end: { line: 5, character: 10 } },
-        message: 'In range',
-      },
-      {
-        severity: 1,
-        range: { start: { line: 10, character: 0 }, end: { line: 10, character: 10 } },
-        message: 'In range 2',
-      },
-      {
-        severity: 1,
-        range: { start: { line: 15, character: 0 }, end: { line: 15, character: 10 } },
-        message: 'Below range',
-      },
-    ];
+  it('should handle empty diagnostics gracefully', () => {
+    const cachedDiagnostics: Array<{ severity: number; range: { start: { line: number; character: number }; end: { line: number; character: number } }; message: string }> = [];
 
-    // Multi-line change from line 5 to line 10
-    const changeRange = { start: { line: 5, character: 0 }, end: { line: 10, character: 5 } };
+    const diagnosticsToSend = cachedDiagnostics;
 
-    const changeStartLine = changeRange.start.line;
-    const changeEndLine = changeRange.end.line;
+    assert.strictEqual(diagnosticsToSend.length, 0, 'Empty diagnostics pass through');
+  });
 
-    const filteredDiagnostics = cachedDiagnostics.filter(d => {
-      if (d.severity !== 1) return true;
-      const errorLine = d.range.start.line;
-      // Keep errors that are more than 1 line away from change
-      return errorLine < changeStartLine - 1 || errorLine > changeEndLine + 1;
-    });
+  it('should fallback to empty array when no cache entry exists', () => {
+    const cachedEntry = undefined;
 
-    // Line 3: 3 < 5-1=4? YES (kept - more than 1 line above)
-    // Line 5: in range (cleared)
-    // Line 10: in range (cleared)
-    // Line 15: 15 > 10+1=11? YES (kept - more than 1 line below)
-    assert.strictEqual(
-      filteredDiagnostics.length,
-      2,
-      'Should have 2 diagnostics left (lines 3 and 15)'
-    );
-    assert.strictEqual(
-      filteredDiagnostics[0]?.range.start.line,
-      3,
-      'Error on line 3 should remain'
-    );
-    assert.strictEqual(
-      filteredDiagnostics[1]?.range.start.line,
-      15,
-      'Error on line 15 should remain'
-    );
+    const diagnosticsToSend = cachedEntry?.diagnostics ?? [];
+
+    assert.strictEqual(diagnosticsToSend.length, 0, 'No crash on missing cache');
   });
 });

--- a/packages/pike-lsp-server/src/features/diagnostics/debounced-validation.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/debounced-validation.ts
@@ -2,9 +2,8 @@
  * Debounced Validation
  *
  * Handles debounced document validation triggered by content changes.
- * Implements version tracking to prevent stale validations, incremental
- * change classification to skip unnecessary re-parses, and diagnostic
- * filtering for skipped validations.
+ * Implements version tracking to prevent stale validations and incremental
+ * change classification to skip unnecessary re-parses.
  *
  * Extracted from index.ts for maintainability (Issue #1289).
  */
@@ -114,34 +113,11 @@ export function createDebouncedValidation(deps: DebouncedValidationDeps): {
         // Clear the pending change range
         pendingChangeStates.delete(uri);
 
-        // When skipping, filter out error diagnostics that overlap with the change range.
-        // This prevents stale error diagnostics from persisting after the user fixes code.
-        // We only clear errors on lines that actually changed - other errors are kept.
-        let diagnosticsToSend = cachedEntry?.diagnostics ?? [];
-        if (changeState?.range && cachedEntry?.diagnostics?.length) {
-          const changeStartLine = changeState.range.start.line;
-          const changeEndLine = changeState.range.end.line;
-
-          // Filter out errors (severity 1) that overlap the change range
-          diagnosticsToSend = cachedEntry.diagnostics.filter(d => {
-            if (d.severity !== 1) return true; // Keep warnings/hints
-            const errorLine = d.range.start.line;
-            // Clear errors that overlap or are adjacent to the change
-            return errorLine < changeStartLine - 1 || errorLine > changeEndLine + 1;
-          });
-        }
-
-        // #1066: Persist filtered diagnostics to cache so subsequent skip-path
-        // validations don't re-send stale errors that were already filtered.
-        if (cachedEntry) {
-          const hadErrorDiagnostics = cachedEntry.diagnostics.some(d => d.severity === 1);
-          cachedEntry.diagnostics = diagnosticsToSend;
-          cachedEntry.analysisState = {
-            ...(cachedEntry.analysisState ?? { isStale: false, parseFailed: false }),
-            hasErrorDiagnostics:
-              hadErrorDiagnostics || diagnosticsToSend.some(d => d.severity === 1),
-          };
-        }
+        // Republish existing diagnostics without filtering.
+        // With mode:'latest' always used for diagnostics queries (PR #1942),
+        // the skip-path only fires when change-detection confirms no semantic
+        // change — filtering by line proximity is unnecessary.
+        const diagnosticsToSend = cachedEntry?.diagnostics ?? [];
 
         connection.sendDiagnostics({
           uri,


### PR DESCRIPTION
Closes #1289

## Problem

The skip-path validation in `debounced-validation.ts` applied a ±1 line proximity filter to error diagnostics near edit locations. This suppressed legitimate errors that happened to be on or adjacent to lines the user just edited.

## Root Cause

The filtering was a workaround for stale snapshot diagnostics — when `engineChangeDocument` hadn't completed before the debounce timer fired, the query engine could return diagnostics for wrong document content. The ±1 filter tried to hide those stale errors.

## Fix

Since PR #1942 made diagnostics queries always use `mode:'latest'`, the query engine always parses fresh content. Stale snapshots can no longer produce diagnostics for wrong content in the diagnostics path.

When `change-detection` says `canSkip=true` (no semantic change detected), the existing diagnostics are correct as-is. Line proximity filtering is unnecessary and harmful — it suppresses real errors.

## Changes

- **Removed** ±1 line proximity filter from `debounced-validation.ts` (lines 117-144)
- **Removed** cache mutation that persisted filtered diagnostics (causing progressive diagnostic loss)
- **Rewrote** `stale-diagnostics.scenario.test.ts` to test new behavior
- **Updated** module docstring to reflect current behavior

## Testing

- 5 unit tests pass (`stale-diagnostics.scenario.test.ts`)
- Skip-path now republishes diagnostics unchanged when `canSkip=true`