### PR TITLE
fix(#2015): Fix clipEditToRange duplicating text when multi-line edit cl

### DIFF
--- a/.agent-knowledge/reference/KB-2015.md
+++ b/.agent-knowledge/reference/KB-2015.md
@@ -1,0 +1,18 @@
+---
+id: KB-AUTO-2015
+domain: REFACTOR
+date: 2026-04-15
+authors: [dga-coder]
+summary: Fixed clipEditToRange duplicating text when a multi-line edit clips to a single visible line, by adding length guards on visibleLines
+---
+
+# KB-2015: Fix clipEditToRange duplicating text when multi-line edit clips to single line
+
+## Summary
+
+In `clipEditToRange` (formatting-service.ts), when a multi-line edit's newText was clipped so only one line remained visible, the firstLine/lastLine assembly referenced the same array element, producing duplicated text joined by `\n`. Added guards: `visibleLines.length === 0` returns empty string, `visibleLines.length === 1` applies both column clips to the single element directly, and the existing `>= 2` logic handles the normal case.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/services/formatting-service.ts: Added `visibleLines.length === 0` and `=== 1` guards in the else-branch of clipEditToRange, preventing crash on empty slice and duplication on single-element slice.
+- packages/pike-lsp-server/src/tests/services/formatting-service.test.ts: Added test verifying single-line range format does not produce multi-line newText (no newline in clipped output).

--- a/packages/pike-lsp-server/src/services/formatting-service.ts
+++ b/packages/pike-lsp-server/src/services/formatting-service.ts
@@ -172,14 +172,18 @@ function clipEditToRange(
     // Single-line edit
     clippedNewText = newTextLines[0]!.slice(clippedStartCol, clippedEndCol);
   } else {
-    // Multi-line edit: take from the adjusted start column on the first line
-    // to the adjusted end column on the last line
     const skipCount = edit.range.start.line < startLine ? startLine - edit.range.start.line : 0;
     const visibleLines = newTextLines.slice(skipCount);
-    const firstLine = visibleLines[0]!.slice(clippedStartCol);
-    const lastLine = visibleLines[visibleLines.length - 1]!.slice(0, clippedEndCol);
-    const middleLines = visibleLines.slice(1, -1);
-    clippedNewText = [firstLine, ...middleLines, lastLine].join('\n');
+    if (visibleLines.length === 0) {
+      clippedNewText = '';
+    } else if (visibleLines.length === 1) {
+      clippedNewText = visibleLines[0]!.slice(clippedStartCol, clippedEndCol);
+    } else {
+      const firstLine = visibleLines[0]!.slice(clippedStartCol);
+      const lastLine = visibleLines[visibleLines.length - 1]!.slice(0, clippedEndCol);
+      const middleLines = visibleLines.slice(1, -1);
+      clippedNewText = [firstLine, ...middleLines, lastLine].join('\n');
+    }
   }
 
   return TextEdit.replace({ start: startPos, end: endPos }, clippedNewText);

--- a/packages/pike-lsp-server/src/tests/services/formatting-service.test.ts
+++ b/packages/pike-lsp-server/src/tests/services/formatting-service.test.ts
@@ -190,6 +190,32 @@ describe('FormattingService', () => {
       }
     });
 
+    it('does not duplicate text when multi-line edit clips to a single line', () => {
+      const service = new FormattingService();
+      const text = [
+        'class Foo {', // line 0
+        '  int a;', // line 1
+        '  int b;', // line 2
+        '  int c;', // line 3
+        '  int d;', // line 4
+        '  int e;', // line 5
+        '}', // line 6
+      ].join('\n');
+
+      // Request a single-line range deep in the document.
+      // If the formatter produces a multi-line edit that gets clipped,
+      // the clipped newText must not contain duplicated lines.
+      const edits = service.formatRange(text, 5, 5, {});
+      for (const edit of edits) {
+        assert.strictEqual(edit.range.start.line, 5, 'Edit start must be on line 5');
+        assert.strictEqual(edit.range.end.line, 5, 'Edit end must be on line 5');
+        assert.ok(
+          !edit.newText.includes('\n'),
+          `Single-line clipped edit should not contain newlines, got: "${edit.newText}"`
+        );
+      }
+    });
+
     it('skips correct number of initial newText lines when edit starts before range', () => {
       // Directly test the line-skipping behavior by constructing a scenario
       // where formatRange clips a multi-line indent edit that starts before the range.


### PR DESCRIPTION
Closes #2015

## Summary

Now I have both files. The bug is clear at lines 174-183 of the service file. Let me apply the fix and add the test.Now add the test. I'll insert it after the existing `handles startLine === endLine range correctly` test (line 191):Now run typecheck and tests:All 22 tests pass (21 existing + 1 new). Now write the KB entry:Done. The fix adds two guards in the `clipEditToRange` else-branch: - **`visibleLines.length === 0`**: Returns `''` (defensive, prevents crash on `visibleLines[0]!`) - **`visibleLines.length === 1`**: Applies both `clippedStartCol` and `clippedEndCol` to the single visible line via `slice(clippedStartCol, clippedEndCol)`, avoiding the firstLine/lastLine duplication

## Linked Issue

Closes #2015

## Root Cause

In clipEditToRange, when a multi-line edit's newText is clipped so that only one line remains visible (skipCount = newTextLines.length - 1), both firstLine and lastLine reference the same array element. The result joins them with '\n', producing duplicated text. For example, an edit spanning lines 3-10 clipped to line 10 yields 'lineC\nlineC' instead of just 'lineC'.

## Changes

- .agent-knowledge/reference/KB-2015.md: (see commit diffs)
- packages/pike-lsp-server/src/services/formatting-service.ts: (see commit diffs)
- packages/pike-lsp-server/src/tests/services/formatting-service.test.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-2015

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].