### PR TITLE
fix(#2016): Make parseFileSymbols throw on null bridge like other Bridge

### DIFF
--- a/.agent-knowledge/reference/KB-2016.md
+++ b/.agent-knowledge/reference/KB-2016.md
@@ -1,0 +1,18 @@
+---
+id: KB-AUTO-2016
+domain: REFACTOR
+date: 2026-04-15
+authors: [dga-coder]
+summary: Fixed parseFileSymbols to throw on null bridge via requireBridge(), matching all other BridgeManager delegation methods
+---
+
+# KB-2016: Make parseFileSymbols throw on null bridge
+
+## Summary
+
+`parseFileSymbols` was the only public BridgeManager method that silently returned `[]` when `this.bridge` was null. Every other delegation method calls `this.requireBridge()` which throws a descriptive error. This inconsistency masked bridge startup failures — callers could not distinguish "bridge not started" from "file has zero symbols". Replaced the `if (!this.bridge) { return []; }` guard with `this.requireBridge()` and updated the corresponding test.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/services/bridge-manager.ts: Replaced 3-line null guard with `this.requireBridge()` in parseFileSymbols
+- packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts: Updated test from asserting `[]` return to asserting throw with `Bridge not available` message

--- a/packages/pike-lsp-server/src/services/bridge-manager.ts
+++ b/packages/pike-lsp-server/src/services/bridge-manager.ts
@@ -490,9 +490,7 @@ export class BridgeManager {
    *         can distinguish I/O failures from empty-symbol results.
    */
   async parseFileSymbols(filePath: string): Promise<PikeSymbol[]> {
-    if (!this.bridge) {
-      return [];
-    }
+    this.requireBridge();
 
     let content: string;
     try {

--- a/packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts
+++ b/packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts
@@ -220,10 +220,16 @@ describe('BridgeManager parseFileSymbols', () => {
     }
   });
 
-  it('returns [] when bridge is null', async () => {
+  it('throws when bridge is null', async () => {
     const manager = new BridgeManager(null, createMockLogger());
-    const result = await manager.parseFileSymbols('/any/path.pike');
-    assert.deepEqual(result, []);
+    await assert.rejects(
+      () => manager.parseFileSymbols('/any/path.pike'),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /Bridge not available/);
+        return true;
+      }
+    );
   });
 });
 


### PR DESCRIPTION
Closes #2016

## Summary

Implements fix: Make parseFileSymbols throw on null bridge like other BridgeManager methods

## Linked Issue

Closes #2016

## Root Cause

parseFileSymbols returns an empty array when this.bridge is null, while every other BridgeManager method (parse, tokenize, findOccurrences, etc.) calls requireBridge() which throws a descriptive Error. This inconsistency means callers of parseFileSymbols cannot distinguish 'bridge not started' from 'file parsed successfully with zero symbols', silently masking bridge startup failures.

## Changes

- .agent-knowledge/reference/KB-2016.md: (see commit diffs)
- packages/pike-lsp-server/src/services/bridge-manager.ts: (see commit diffs)
- packages/pike-lsp-server/src/tests/services/bridge-manager.test.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-2016

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].