### PR TITLE
fix(#2033): Fix clipEditToRange using original text line length for newT

### DIFF
--- a/.agent-knowledge/reference/KB-2033.md
+++ b/.agent-knowledge/reference/KB-2033.md
@@ -1,0 +1,18 @@
+---
+id: KB-AUTO-2033
+domain: REFACTOR
+date: 2026-04-16
+authors: [dga-coder]
+summary: Fixed clipEditToRange using original text line length instead of newText line length when clipping edits that extend beyond the format range
+---
+
+# KB-2033: Fix clipEditToRange truncating newText at original text line length
+
+## Summary
+
+`clipEditToRange()` in `formatting-service.ts` used `endLineLen` (the original document's line length) to slice the last visible `newText` line when an edit extended beyond `endLine`. When the formatter's newText had longer lines than the original (e.g., operator spacing `a+b` → `a + b`), the extra characters were silently dropped. Fixed by using the last `newText` line's actual length instead of `endLineLen`.
+
+## Key Files Changed
+
+- `packages/pike-lsp-server/src/services/formatting-service.ts`: Moved `newTextLines` declaration before `clippedEndCol`; changed `clippedEndCol` to use `newTextLines[newTextLines.length - 1]?.length` instead of `endLineLen` when `edit.range.end.line > endLine`
+- `packages/pike-lsp-server/src/tests/services/formatting-service.test.ts`: Added test verifying range-formatted output matches full-document formatting when newText lines are longer than original

--- a/packages/pike-lsp-server/src/services/formatting-service.ts
+++ b/packages/pike-lsp-server/src/services/formatting-service.ts
@@ -164,8 +164,11 @@ function clipEditToRange(
 
   // Compute the portion of newText that falls within the clipped range
   const clippedStartCol = edit.range.start.line < startLine ? 0 : edit.range.start.character;
-  const clippedEndCol = edit.range.end.line > endLine ? endLineLen : edit.range.end.character;
   const newTextLines = edit.newText.split('\n');
+  const clippedEndCol =
+    edit.range.end.line > endLine
+      ? (newTextLines[newTextLines.length - 1]?.length ?? 0)
+      : edit.range.end.character;
   let clippedNewText: string;
 
   if (edit.range.start.line === edit.range.end.line) {

--- a/packages/pike-lsp-server/src/tests/services/formatting-service.test.ts
+++ b/packages/pike-lsp-server/src/tests/services/formatting-service.test.ts
@@ -249,6 +249,75 @@ describe('FormattingService', () => {
         `Multi-line edit spans ${editLineSpan} lines but newText has ${fullNewTextLines.length} lines`
       );
     });
+
+    it('does not truncate last visible newText line when edit extends beyond endLine', () => {
+      const service = new FormattingService();
+      const text = [
+        'class Foo {', // line 0
+        '  int a=1+2;', // line 1 — operator spacing will widen this
+        '  int b=3+4;', // line 2
+        '}', // line 3
+      ].join('\n');
+
+      // Request range [0, 1]. Operator spacing edits span the full document.
+      // The edit replacing lines 0-3 has newText where line 1 content is wider
+      // than the original (e.g., '  int a = 1 + 2;' vs '  int a=1+2;').
+      // The clipped edit's newText must not be truncated.
+      const rangeEdits = service.formatRange(text, 0, 1, {});
+      const fullEdits = service.formatDocument(text, {});
+
+      // Simulate applying edits: the result for lines 0-1 must match what
+      // full-document formatting produces for those same lines.
+      const lines = text.split('\n');
+      let rangeResult = lines.slice(0, 2).join('\n');
+      // Apply range edits in reverse to preserve positions
+      const sortedRangeEdits = [...rangeEdits].sort(
+        (a, b) =>
+          b.range.start.line - a.range.start.line ||
+          b.range.start.character - a.range.start.character
+      );
+      for (const edit of sortedRangeEdits) {
+        const resultLines = rangeResult.split('\n');
+        if (edit.range.start.line === edit.range.end.line) {
+          const line = resultLines[edit.range.start.line] ?? '';
+          resultLines[edit.range.start.line] =
+            line.slice(0, edit.range.start.character) +
+            edit.newText +
+            line.slice(edit.range.end.character);
+          rangeResult = resultLines.join('\n');
+        }
+      }
+
+      // Full-format the first two lines independently for comparison
+      let fullResult = lines.slice(0, 2).join('\n');
+      const fullEditsInRange = fullEdits.filter(
+        e => e.range.start.line <= 1 && e.range.end.line >= 0
+      );
+      const sortedFullEdits = [...fullEditsInRange].sort(
+        (a, b) =>
+          b.range.start.line - a.range.start.line ||
+          b.range.start.character - a.range.start.character
+      );
+      for (const edit of sortedFullEdits) {
+        const resultLines = fullResult.split('\n');
+        if (edit.range.start.line <= 1 && edit.range.end.line <= 1) {
+          const line = resultLines[edit.range.start.line] ?? '';
+          const endChar =
+            edit.range.end.line === edit.range.start.line
+              ? Math.min(edit.range.end.character, line.length)
+              : line.length;
+          resultLines[edit.range.start.line] =
+            line.slice(0, edit.range.start.character) + edit.newText + line.slice(endChar);
+          fullResult = resultLines.join('\n');
+        }
+      }
+
+      assert.strictEqual(
+        rangeResult.split('\n')[1],
+        fullResult.split('\n')[1],
+        'Range-formatted line 1 must match fully-formatted line 1 (not truncated)'
+      );
+    });
   });
 
   describe('formatDocument', () => {


### PR DESCRIPTION
Closes #2033

## Summary

Now I have a clear picture of the bug and the fix. Let me implement it. **Edit 1: Fix `clippedEndCol` in formatting-service.ts****Edit 2: Add the test case**Now run typecheck and tests:All 23 tests pass (22 existing + 1 new). Now write the KB entry:Done. The fix changes `clippedEndCol` from using `endLineLen` (original text) to `newTextLines[newTextLines.length - 1]?.length` (the actual newText line) when an edit extends beyond the format range. This prevents silent truncation of formatted output that is wider than the original text (e.g., operator spacing).

## Linked Issue

Closes #2033

## Root Cause

In clipEditToRange(), when an edit extends beyond endLine, clippedEndCol is set to endLineLen which is the length of the original text's line at endLine. This value is then used to slice the last visible newText line: `visibleLines[...].slice(0, clippedEndCol)`. If the formatter's newText has longer lines than the original text (e.g., operator spacing adds spaces), those extra characters are silently dropped. This causes the clipped edit to produce incorrect output — the resulting text at endLine would be truncated.

## Changes

- .agent-knowledge/reference/KB-2033.md: (see commit diffs)
- packages/pike-lsp-server/src/services/formatting-service.ts: (see commit diffs)
- packages/pike-lsp-server/src/tests/services/formatting-service.test.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-2033

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].