### PR TITLE
fix: Gate auto-merge behind vote-approved label

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,7 +1,7 @@
 name: Enable Auto-merge
 on:
   pull_request:
-    types: [opened]
+    types: [labeled, opened]
 
 permissions:
   pull-requests: write
@@ -10,11 +10,14 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-24.04
+    # Only enable auto-merge when the vote-approved label is present
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'vote-approved')
     steps:
       - uses: actions/checkout@v4
 
       - name: Enable auto-merge
-        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           gh pr merge --auto --squash ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }}


### PR DESCRIPTION
Closes #N/A

## Summary

The `auto-merge.yml` workflow currently enables auto-merge on every PR
opened from the same repo. This causes PRs to merge as soon as CI passes,
bypassing the 3-agent merge voting system.

## Changes

- Workflow now triggers on `labeled` and `opened` events
- Auto-merge only enables when `vote-approved` label is present
- The orchestrator adds `vote-approved` after 3/3 merge vote passes
- If vote denies, the label is never added and the PR stays open for fixes

## Verification

- Workflow syntax is valid GitHub Actions YAML
- The `contains(labels.*.name, 'vote-approved')` condition is the standard pattern