### PR TITLE
feat(#2070): Replace as-unknown-as TextDocument cast with proper validati

### DIFF
--- a/.agent-knowledge/reference/KB-2070.md
+++ b/.agent-knowledge/reference/KB-2070.md
@@ -1,0 +1,17 @@
+---
+id: KB-AUTO-2070
+domain: REFACTOR
+date: 2026-04-16
+authors: [dga-coder]
+summary: Replaced as-unknown-as TextDocument cast in pike-identifier.ts getWordAtOffset with TextDocument.create()
+---
+
+# KB-2070: Replace as-unknown-as TextDocument cast with proper validation in pike-identifier
+
+## Summary
+
+`getWordAtOffset()` in `pike-identifier.ts` created a hand-rolled mock object with 3 methods (`getText`, `offsetAt`, `positionAt`) and cast it via `as unknown as TextDocument`. Replaced with `TextDocument.create()` from `vscode-languageserver-textdocument`, which returns a proper `TextDocument` instance with correct `uri`, `languageId`, and `version`. The import was changed from `import type` to a value import since `TextDocument` is now used as a constructor.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/features/utils/pike-identifier.ts: Changed `import type { TextDocument }` to `import { TextDocument }` and replaced 4-line mock object + `as unknown as TextDocument` cast with `TextDocument.create('file:///untitled.pike', 'pike', 0, text)`.

--- a/packages/pike-lsp-server/src/features/utils/pike-identifier.ts
+++ b/packages/pike-lsp-server/src/features/utils/pike-identifier.ts
@@ -4,7 +4,7 @@
  * Common utilities for parsing and handling Pike identifiers.
  */
 
-import type { TextDocument } from 'vscode-languageserver-textdocument';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Range, Position } from 'vscode-languageserver/node.js';
 import type { PikeSymbol } from '@pike-lsp/pike-bridge';
 
@@ -175,11 +175,7 @@ export function getWordAtOffset(
     return null;
   }
 
-  const mockDocument = {
-    getText: () => text,
-    offsetAt: (pos: { line: number; character: number }) => pos.character,
-    positionAt: (o: number) => ({ line: 0, character: o }),
-  } as unknown as TextDocument;
+  const mockDocument = TextDocument.create('file:///untitled.pike', 'pike', 0, text);
 
   const result = getWordRangeAtPosition(mockDocument, { line: 0, character: offset });
   if (!result) {


### PR DESCRIPTION
Closes #2070

## Summary

The problem is clear. `getWordAtOffset` creates a mock object with only 3 methods and casts it via `as unknown as TextDocument`. The `getWordRangeAtPosition` function calls `getText()`, `offsetAt()`, and `positionAt()` — all of which are present. The fix is to use `TextDocument.create()` from `vscode-languageserver-textdocument` which returns a proper `TextDocument` instance.Now let me check what `TextDocument.create` signature looks like to ensure proper usage:Now I'll apply the fix. Replace the mock object + `as unknown as TextDocument` cast with `TextDocument.create()`, and add the `TextDocument` value import.Typecheck passes. Now run tests:All 68 tests pass. Now write the KB entry:Done. The `as unknown as TextDocument` cast in `getWordAtOffset()` was replaced with `TextDocument.create()`, which produces a proper `TextDocument` instance. The type import was promoted to a value import. Compilation and all 68 tests pass.

## Linked Issue

Closes #2070

## Root Cause

At : Replace as-unknown-as TextDocument cast with proper validation in pike-identifier

## Changes

- .agent-knowledge/reference/KB-2070.md: (see commit diffs)
- packages/pike-lsp-server/src/features/utils/pike-identifier.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-2070

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].