### PR TITLE
fix: Increase VSCode download timeout for CI stability

### DIFF
--- a/packages/vscode-pike/.vscode-test.mjs
+++ b/packages/vscode-pike/.vscode-test.mjs
@@ -23,6 +23,11 @@ export default defineConfig([
     files: 'dist/test/integration/*.test.js',
     version: 'stable',
     workspaceFolder: './test-workspace',
+    // Increase VSCode download idle timeout from default 15s — CI runners
+    // can be slow during 'Resolving version' (update.code.visualstudio.com API).
+    download: {
+      timeout: 60_000,
+    },
     mocha: {
       ui: 'tdd',
       timeout: 120000, // 120s timeout for LSP initialization with module path loading


### PR DESCRIPTION
## Summary

Increase `@vscode/test-electron` download idle timeout from the default 15s to 60s in `.vscode-test.mjs`. The 15s default causes intermittent CI failures when the VSCode version resolution API is slow to respond.

## Problem

The `vscode-e2e` CI checks fail intermittently with:
```
Error: @vscode/test-electron request timeout out after 15000ms
```

## Root Cause

`@vscode/test-electron@2.5.2` has a hardcoded 15s default idle timeout in its download function. The `@vscode/test-cli` config allows overriding this via `download.timeout`, but `.vscode-test.mjs` didn't set it.

## Fix

Add `download: { timeout: 60_000 }` to `.vscode-test.mjs`. This is an idle timeout (resets on each data chunk), not a total download timeout — successful runs are unaffected.

## Knowledge Base

- [x] Exempt: single-line CI config change, no behavioral impact on the extension

Closes #2078