### PR TITLE
refactor(#2081): Replace connection.console.log with Logger in code lens

### DIFF
--- a/.agent-knowledge/reference/KB-2081.md
+++ b/.agent-knowledge/reference/KB-2081.md
@@ -1,0 +1,17 @@
+---
+id: KB-AUTO-2081
+domain: REFACTOR
+date: 2026-04-16
+authors: [dga-coder]
+summary: Replaced two connection.console.log() calls with structured log.debug() in code-lens.ts for consistency with the rest of the file
+---
+
+# KB-2081: Replace connection.console.log with Logger in code lens
+
+## Summary
+
+Lines 211 and 343 in `code-lens.ts` used `connection.console.log()` for diagnostic output while every other log statement in the file used `log.debug()` with structured payloads. Both calls were replaced with `log.debug()` carrying structured fields (`uri`, `count`/`version` for generation; `uri`, `symbolName`, `refCount` for resolve). No import changes needed — `Logger` was already imported and instantiated.
+
+## Key Files Changed
+
+- packages/pike-lsp-server/src/features/advanced/code-lens.ts: Replaced connection.console.log() at line 211 (code lens generation) and line 343 (code lens resolve) with log.debug() structured calls.

--- a/packages/pike-lsp-server/src/features/advanced/code-lens.ts
+++ b/packages/pike-lsp-server/src/features/advanced/code-lens.ts
@@ -208,9 +208,11 @@ export function registerCodeLensHandlers(
           // Cache the lenses for this document version
           codeLensCache.set(uri, { version: cache.version, lenses });
 
-          connection.console.log(
-            `[CODE_LENS] Generated ${lenses.length} lenses (cached for v${cache.version})`
-          );
+          log.debug('Generated code lenses', {
+            uri,
+            count: lenses.length,
+            version: cache.version,
+          });
           return lenses;
         },
       });
@@ -340,9 +342,11 @@ export function registerCodeLensHandlers(
 
           lens.command = buildCodeLensCommand(refCount, data.uri, data.position, data.symbolName);
 
-          connection.console.log(
-            `[CODE_LENS] Resolved lens for "${data.symbolName}": ${refCount} refs`
-          );
+          log.debug('Resolved code lens', {
+            uri: data.uri,
+            symbolName: data.symbolName,
+            refCount,
+          });
           maybeLogLensSchedulerMetrics(data.uri, 'resolved');
           return lens;
         },


### PR DESCRIPTION
Closes #2081

## Summary

Now check if `connection` import is still used elsewhere in the file, so we know whether to clean up the import.Good — `connection` is still used for `onCodeLens` and `onCodeLensResolve`. No import cleanup needed. Now compile and test.TypeScript compiles clean. Now run tests:All 35 code lens tests pass. Now write the KB entry and report.Done. Replaced both `connection.console.log()` calls with structured `log.debug()` calls in `code-lens.ts`. TypeScript compiles clean and all 35 code lens tests pass.

## Linked Issue

Closes #2081

## Root Cause

Lines 211 and 343 use connection.console.log() for debugging output instead of Logger, reducing visibility in production logs.

## Changes

- .agent-knowledge/reference/KB-2081.md: (see commit diffs)
- packages/pike-lsp-server/src/features/advanced/code-lens.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-2081

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].