### PR TITLE
fix(#2126): Use waitFor retry for WaterfallTestClass completion test

### DIFF
--- a/packages/vscode-pike/src/test/integration/lsp-features.test.ts
+++ b/packages/vscode-pike/src/test/integration/lsp-features.test.ts
@@ -1847,31 +1847,36 @@ suite('Waterfall Loading E2E Tests', () => {
 
   /**
    * Test: Completion shows class definitions from current file
+   *
+   * This test retries because the completion provider may not have indexed
+   * the file yet when the first completion request arrives. The suiteSetup
+   * waits for document symbols, but the completion pipeline has its own
+   * indexing path that can lag behind. Retry until WaterfallTestClass appears
+   * or timeout (15s).
    */
   test('Completion shows class definitions', async function () {
     this.timeout(30000);
 
     const position = positionForRegex(document, /WaterfallTestClass obj =/m);
 
-    const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
-      'vscode.executeCompletionItemProvider',
-      testDocumentUri,
-      position
+    // Retry until the completion provider has indexed WaterfallTestClass.
+    // The provider may return word-based completions on first request while
+    // symbol indexing is still in progress.
+    const result = await waitFor(
+      'WaterfallTestClass in completions',
+      () => vscode.commands.executeCommand<vscode.CompletionList>(
+        'vscode.executeCompletionItemProvider',
+        testDocumentUri,
+        position
+      ),
+      (completions) => {
+        if (!completions || completions.items.length === 0) return false;
+        return completions.items.map(labelOf).includes('WaterfallTestClass');
+      },
+      15000
     );
 
-    assert.ok(completions, 'Should return completions');
-    assert.ok(completions!.items.length > 0, 'Should have completion items');
-
-    const completionLabels = completions!.items.map(labelOf);
-
-    // WaterfallTestClass should appear
-    const hasClass = completionLabels.includes('WaterfallTestClass');
-
-    assertWithLogs(
-      hasClass,
-      'Completion should show "WaterfallTestClass". Got: ' +
-        completionLabels.slice(0, 20).join(', ')
-    );
+    assert.ok(result, 'Should return completions');
   });
 
   /**


### PR DESCRIPTION
Closes #2126

## Summary

The `Completion shows class definitions` E2E test is flaky because the completion provider may not have indexed `WaterfallTestClass` when the first completion request arrives. When symbol indexing is slow, the provider falls back to word-based completions (alphabetical word list) instead of symbol-based completions.

## Root Cause

The test's `suiteSetup` waits for `executeDocumentSymbolProvider` to return non-empty results, but the completion pipeline has its own indexing path that can lag behind the document symbol provider. The completion request races against this indexing.

## Fix

Replace the single-shot completion assertion with a `waitFor` retry loop (15s timeout). This retries the completion request until `WaterfallTestClass` appears in the results, accommodating the indexing race without changing server behavior.

## Changes

- `packages/vscode-pike/src/test/integration/lsp-features.test.ts`: Replaced single-shot assertion with `waitFor` retry pattern

## Verification

- The test now retries for up to 15s, matching the `suiteSetup` wait duration
- Uses the same `waitFor` helper already used throughout the test suite

## Knowledge Base

- [x] Exempt: Test-only change, no production code affected