### PR TITLE
fix(#2126): Wait for QE completion readiness in WaterfallTestClass suiteSetup

### DIFF
--- a/packages/vscode-pike/src/test/integration/lsp-features.test.ts
+++ b/packages/vscode-pike/src/test/integration/lsp-features.test.ts
@@ -1805,12 +1805,28 @@ suite('Waterfall Loading E2E Tests', () => {
 
     await vscode.window.showTextDocument(doc);
 
-    await waitFor(
-      'waterfall document symbols',
-      () => vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', testDocumentUri),
-      (symbols: any) => Array.isArray(symbols) && symbols.length > 0,
-      15000
-    );
+	// Wait for document symbols (legacy indexing path)
+	await waitFor(
+	  'waterfall document symbols',
+	  () => vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', testDocumentUri),
+	  (symbols: any) => Array.isArray(symbols) && symbols.length > 0,
+	  15000
+	);
+
+	// Also wait for completion QE to be ready — the query engine has its own
+	// indexing path independent of document symbols. Probe until completions
+	// return non-empty results at a known completion position.
+	const probePosition = positionForRegex(doc, /int x = waterfall_test_value;/m);
+	await waitFor(
+	  'completion QE readiness',
+	  () => vscode.commands.executeCommand<vscode.CompletionList>(
+	    'vscode.executeCompletionItemProvider',
+	    testDocumentUri,
+	    probePosition
+	  ),
+	  (completions) => !!completions && completions.items.length > 0,
+	  30000
+	);
   });
 
   suiteTeardown(async () => {
@@ -1851,8 +1867,8 @@ suite('Waterfall Loading E2E Tests', () => {
    * This test retries because the completion provider may not have indexed
    * the file yet when the first completion request arrives. The suiteSetup
    * waits for document symbols, but the completion pipeline has its own
-   * indexing path that can lag behind. Retry until WaterfallTestClass appears
-   * or timeout (15s).
+	 * indexing path that can lag behind. The suiteSetup now waits for
+	 * QE readiness, so this retry is a safety net. Timeout: 25s.
    */
   test('Completion shows class definitions', async function () {
     this.timeout(30000);
@@ -1873,7 +1889,7 @@ suite('Waterfall Loading E2E Tests', () => {
         if (!completions || completions.items.length === 0) return false;
         return completions.items.map(labelOf).includes('WaterfallTestClass');
       },
-      15000
+	  25000
     );
 
     assert.ok(result, 'Should return completions');


### PR DESCRIPTION
Closes #2126

## Summary

The `WaterfallTestClass` completion test was flaky because `suiteSetup` only waited for document symbols (legacy indexing path), but the completion query engine has its own independent indexing that can lag behind, especially in CI runners.

## Root Cause

The test's `suiteSetup` used `executeDocumentSymbolProvider` to wait for indexing, but the actual completion handler uses the query engine (`bridge.engineQuery`) which has its own indexing pipeline. When the QE isn't ready, completions return empty results, causing the `waitFor` retry to exhaust its 15s timeout.

## Changes

- **QE readiness probe in suiteSetup**: After document symbols are available, probe completions at a known position until they return non-empty results (30s timeout). This ensures the QE index is ready before any test runs.
- **Increased test waitFor timeout**: From 15s to 25s as a safety net.

## Knowledge Base

- [x] Exempt — test-only change, no KB entry needed

## Verification

- `bunx tsc --noEmit -p packages/vscode-pike/tsconfig.json` passes clean
- The probe position uses `positionForRegex(doc, /int x = waterfall_test_value;/m)` which is a valid completion context in the test fixture
