### PR TITLE
feat(#2127): Make reliability-workflows E2E category mandatory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -380,7 +380,7 @@ jobs:
             optional: false
           - category: reliability-workflows
             grep: 'Error Handling Tests|Responsiveness E2E Tests|E2E Workflow Tests|Waterfall Loading E2E Tests'
-            optional: true
+            optional: false
           - category: performance
             grep: 'Performance Benchmark Tests'
             optional: false


### PR DESCRIPTION
Closes #2127

## Summary

Makes the `reliability-workflows` E2E category mandatory in CI. The flaky `WaterfallTestClass` test was fixed in #2135, so this category can now reliably gate merging.

## Root Cause

The `reliability-workflows` category was marked `optional: true` because the `WaterfallTestClass` completion test was flaky. Now that #2135 added a QE readiness probe to `suiteSetup`, the test is stable.

## Changes

- `.github/workflows/test.yml`: `optional: true` → `optional: false` for `reliability-workflows` category

## Knowledge Base

- [x] Exempt — single config line change

## Verification

- #2135 CI passed with `vscode-e2e (reliability-workflows)` succeeding
- All other categories already mandatory and passing
