### PR TITLE
fix(#2126): Fix QE readiness probe to check for specific symbol

### DIFF
--- a/packages/vscode-pike/src/test/integration/lsp-features.test.ts
+++ b/packages/vscode-pike/src/test/integration/lsp-features.test.ts
@@ -1813,9 +1813,11 @@ suite('Waterfall Loading E2E Tests', () => {
 	  15000
 	);
 
-	// Also wait for completion QE to be ready — the query engine has its own
-	// indexing path independent of document symbols. Probe until completions
-	// return non-empty results at a known completion position.
+	// Wait for completion QE to have indexed this file's symbols.
+	// The QE has its own indexing path independent of document symbols.
+	// We probe until a known local symbol (WATERFALL_TEST_CONSTANT) appears
+	// in completions — word-based fallback completions never include this
+	// identifier, so this ensures real symbol indexing has completed.
 	const probePosition = positionForRegex(doc, /int x = waterfall_test_value;/m);
 	await waitFor(
 	  'completion QE readiness',
@@ -1824,7 +1826,7 @@ suite('Waterfall Loading E2E Tests', () => {
 	    testDocumentUri,
 	    probePosition
 	  ),
-	  (completions) => !!completions && completions.items.length > 0,
+	  (completions) => !!completions && completions.items.some(item => labelOf(item) === 'WATERFALL_TEST_CONSTANT'),
 	  30000
 	);
   });


### PR DESCRIPTION
Fixes #2126

## Summary

The `reliability-workflows` E2E category's `WaterfallTestClass` completion test was flaky because the suite setup's QE readiness probe was too weak.

## Linked Issue

Fixes #2126 — WaterfallTestClass completion E2E test flaky

## Root Cause (documented per #2126 acceptance)

The completion provider has two indexing paths:
1. **Document symbols** — used by outline, navigation, etc.
2. **Query engine (QE)** — used by completion, hover, etc.

The `suiteSetup` waited for both: document symbols (15s) and QE readiness (30s). But the QE readiness probe only checked for non-empty completions. VS Code's word-based suggestion provider always returns non-empty results (it tokenizes document text), so the probe succeeded before the QE finished indexing. Subsequent completion requests then got empty QE results and fell through to the legacy path, which also had no symbols — only builtins + word-based completions.

## Changes

- `packages/vscode-pike/src/test/integration/lsp-features.test.ts`: QE readiness probe now checks for `WATERFALL_TEST_CONSTANT` instead of any non-empty result

## Verification

- [x] Root cause documented in code comments
- [x] Fix targets the actual indexing race condition
- [x] No test coverage regression — change is only in test infrastructure

## Checklist

- [x] No test coverage regression
- [x] Automated tests included (the fix IS the test fix)