### PR TITLE
fix(#2126): Fix QE readiness probe to check for specific symbol

### DIFF
--- a/packages/vscode-pike/src/test/integration/lsp-features.test.ts
+++ b/packages/vscode-pike/src/test/integration/lsp-features.test.ts
@@ -1813,9 +1813,11 @@ suite('Waterfall Loading E2E Tests', () => {
 	  15000
 	);
 
-	// Also wait for completion QE to be ready — the query engine has its own
-	// indexing path independent of document symbols. Probe until completions
-	// return non-empty results at a known completion position.
+	// Wait for completion QE to have indexed this file's symbols.
+	// The QE has its own indexing path independent of document symbols.
+	// We probe until a known local symbol (WATERFALL_TEST_CONSTANT) appears
+	// in completions — word-based fallback completions never include this
+	// identifier, so this ensures real symbol indexing has completed.
 	const probePosition = positionForRegex(doc, /int x = waterfall_test_value;/m);
 	await waitFor(
 	  'completion QE readiness',
@@ -1824,7 +1826,7 @@ suite('Waterfall Loading E2E Tests', () => {
 	    testDocumentUri,
 	    probePosition
 	  ),
-	  (completions) => !!completions && completions.items.length > 0,
+	  (completions) => !!completions && completions.items.some(item => labelOf(item) === 'WATERFALL_TEST_CONSTANT'),
 	  30000
 	);
   });


### PR DESCRIPTION
Fixes #2126

## Summary

The WaterfallTestClass completion E2E test was flaky because the QE readiness probe checked for any non-empty completions, which passed with VS Code's word-based suggestions. Now checks for a specific symbol (WATERFALL_TEST_CONSTANT) that only appears after real symbol indexing.

## Root Cause

The completion QE has its own indexing path separate from document symbols. The probe checked `items.length > 0`, but VS Code's word-based suggestion provider always returns non-empty results. The QE hadn't indexed the file, so WaterfallTestClass never appeared.

## Changes

- `packages/vscode-pike/src/test/integration/lsp-features.test.ts`: QE readiness probe checks for `WATERFALL_TEST_CONSTANT` instead of any non-empty result

## Knowledge Base

- [x] Exempt — test infrastructure fix, no behavior change