### PR TITLE
fix(#2126): Probe for WaterfallTestClass directly in QE readiness check

### DIFF
--- a/packages/vscode-pike/src/test/integration/lsp-features.test.ts
+++ b/packages/vscode-pike/src/test/integration/lsp-features.test.ts
@@ -1813,21 +1813,21 @@ suite('Waterfall Loading E2E Tests', () => {
 	  15000
 	);
 
-	// Wait for completion QE to have indexed this file's symbols.
+	// Wait for completion QE to have indexed the entire file.
 	// The QE has its own indexing path independent of document symbols.
-	// We probe until a known local symbol (WATERFALL_TEST_CONSTANT) appears
-	// in completions — word-based fallback completions never include this
-	// identifier, so this ensures real symbol indexing has completed.
-	const probePosition = positionForRegex(doc, /int x = waterfall_test_value;/m);
+	// We probe at the WaterfallTestClass usage position until the class appears
+	// in completions — this ensures the QE has indexed past line 34 where
+	// the class is defined. Word-based fallback never includes this identifier.
+	const classProbePosition = positionForRegex(doc, /WaterfallTestClass obj =/m);
 	await waitFor(
-	  'completion QE readiness',
+	  'completion QE readiness (WaterfallTestClass)',
 	  () => vscode.commands.executeCommand<vscode.CompletionList>(
 	    'vscode.executeCompletionItemProvider',
 	    testDocumentUri,
-	    probePosition
+	    classProbePosition
 	  ),
-	  (completions) => !!completions && completions.items.some(item => labelOf(item) === 'WATERFALL_TEST_CONSTANT'),
-	  30000
+	  (completions) => !!completions && completions.items.some(item => labelOf(item) === 'WaterfallTestClass'),
+	  45000
 	);
   });
 


### PR DESCRIPTION
Fixes #2126

## Summary

The previous QE readiness probe checked for WATERFALL_TEST_CONSTANT (line 15), but the QE indexes incrementally — it found the constant without indexing the class at line 34. Now probes directly for WaterfallTestClass at the test position with 45s timeout.

## Root Cause

The completion QE indexes files incrementally (top-to-bottom). The probe checked for a constant defined early in the file (line 15), which passed before the class at line 34 was indexed. The subsequent test for WaterfallTestClass still failed because the QE hadn't reached that part of the file.

## Changes

- `packages/vscode-pike/src/test/integration/lsp-features.test.ts`: QE readiness probe now checks for `WaterfallTestClass` at the actual test position, with 45s timeout

## Knowledge Base

- [x] Exempt — test infrastructure fix, no behavior change