### PR TITLE
feat(#2127): Make reliability-workflows E2E category mandatory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -380,7 +380,7 @@ jobs:
             optional: false
           - category: reliability-workflows
             grep: 'Error Handling Tests|Responsiveness E2E Tests|E2E Workflow Tests|Waterfall Loading E2E Tests'
-            optional: true
+            optional: false
           - category: performance
             grep: 'Performance Benchmark Tests'
             optional: false


### PR DESCRIPTION
Closes #2127

## Summary

Changes `optional: true` to `optional: false` for the `reliability-workflows` E2E category in the CI workflow. The WaterfallTestClass flake (#2126) is now fixed — the QE readiness probe waits for full file indexing before tests run.

## Changes

- `.github/workflows/test.yml` line 383: `optional: true` → `optional: false`

## Knowledge Base

- [x] Exempt — one-line config change