### PR TITLE
fix: Allow legacy completion fallback when QE request is superseded

### DIFF
--- a/packages/pike-lsp-server/src/features/editing/completion-qe.ts
+++ b/packages/pike-lsp-server/src/features/editing/completion-qe.ts
@@ -365,7 +365,9 @@ export async function handleQueryEngineCompletion(
     cancellationDisposable?.dispose();
     if (err instanceof RequestSupersededError) {
       maybeLogCompletionSchedulerMetrics(uri, 'superseded');
-      return toCompletionList([]);
+      // Fall through to undefined so the legacy completion path can run.
+      // Returning toCompletionList([]) here blocks the legacy path,
+      // causing starvation when rapid retries cancel every QE request.
     }
     maybeLogCompletionSchedulerMetrics(uri, 'qe_fallback');
     services.logger.debug('Completion query fallback', {


### PR DESCRIPTION
Fixes #2127

## Summary

Fixes the `Completion shows class definitions` test in the WaterfallTestClass reliability-workflows E2E suite by allowing the legacy completion path to run when the QE request is cancelled by the request scheduler.

## Root Cause

The `handleQueryEngineCompletion` function in `completion-qe.ts` caught `RequestSupersededError` (thrown when the `RequestScheduler` cancels a previous completion request) and returned `toCompletionList([])` — an empty list. This is a truthy value, so the caller at `completion.ts` treated it as a valid result and skipped the legacy completion path entirely.

In the test's `waitFor()` loop (250ms retry interval):
1. Iteration N sends completion request → QE starts processing
2. 250ms later, iteration N+1 sends request → scheduler cancels iteration N's task
3. Iteration N returns `toCompletionList([])` (empty, blocking legacy)
4. Repeat until timeout — no request ever succeeds

The QE completion takes >250ms in CI due to bridge subprocess overhead, so every request is cancelled before completion.

## Changes

- `packages/pike-lsp-server/src/features/editing/completion-qe.ts`: When `RequestSupersededError` is caught, fall through to `return undefined` instead of `return toCompletionList([])`. This allows the caller to fall through to `collectGeneralCompletions` which uses `cached.symbols` — already populated by `suiteSetup`'s document symbol check.

## Why this is safe

- The LSP `CancellationToken` is checked separately at `completion.ts` line 155, so interactive cancellation (user typing new characters) still returns empty correctly.
- The legacy path is synchronous (no bridge calls) and completes in <1ms, well within the 250ms retry interval.
- Returning `undefined` is the existing behavior for other error cases (line 376).

## Knowledge Base

- [x] Exempt — fixing a regression in the completion request cancellation handler