### PR TITLE
test(#2167): Replace buildSymbolPositionIndex with bridge/parser API

### DIFF
--- a/.agent-knowledge/reference/KB-2176.md
+++ b/.agent-knowledge/reference/KB-2176.md
@@ -1,0 +1,20 @@
+---
+id: KB-AUTO-2176
+domain: REFACTOR
+date: 2026-04-18
+authors: [dga-coder]
+summary: Resolved merge conflicts in PR #2176 — all five scenario test files had import conflicts between HEAD (removed unused TextDocuments/DidChangeConfigurationParams) and the PR branch.
+keywords: merge-conflict,rebase,scenario-tests,imports,onDidChangeConfiguration
+---
+
+# KB-2176: Resolve merge conflicts in refactor/replace-ondidchangeconfiguration-with-br
+
+## Summary
+Five scenario test files had merge conflicts during rebase. The conflict was in the import block: HEAD removed `TextDocuments` and `DidChangeConfigurationParams` imports, while the PR branch kept them. Resolution: keep `DidChangeConfigurationParams` (used in mock connection's `onDidChangeConfiguration` method signature) but drop `TextDocuments` (unused). The `Connection` type import was kept from HEAD.
+
+## Key Files Changed
+- `packages/pike-lsp-server/src/scenarios/code-actions-parse-resilience.test.ts`: Resolved import conflict, kept `Connection` + `DidChangeConfigurationParams`
+- `packages/pike-lsp-server/src/scenarios/code-lens-parse-resilience.test.ts`: Same pattern
+- `packages/pike-lsp-server/src/scenarios/fault-bridge-crash.test.ts`: Same pattern
+- `packages/pike-lsp-server/src/scenarios/fault-bridge-restart.test.ts`: Same pattern
+- `packages/pike-lsp-server/src/scenarios/fault-invariant.test.ts`: Same pattern

--- a/packages/pike-lsp-server/src/features/diagnostics/symbol-index.ts
+++ b/packages/pike-lsp-server/src/features/diagnostics/symbol-index.ts
@@ -8,9 +8,6 @@
 import type { CorePosition } from '../../core/types.js';
 import type { PikeSymbol, PikeToken } from '@pike-lsp/pike-bridge';
 import { createLexicalExclusionMap } from '../../utils/lexical-exclusion-map.js';
-import { Logger } from '@pike-lsp/core';
-
-const log = new Logger('symbol-index');
 
 /**
  * Build symbol name index for O(1) lookups.
@@ -163,8 +160,7 @@ function matchTokensToSymbolPositions(
 
 /**
  * Build symbol position index for O(1) lookups.
- * PERF-001: Uses Pike tokenization for accuracy and performance
- * PERF-004: Reuses tokens from analyze() to avoid separate findOccurrences() IPC call
+ * PERF-004: Reuses tokens from analyze() to avoid separate IPC call
  * PERF-1229: Accepts pre-split lines array to avoid redundant text.split('\n') calls
  */
 export async function buildSymbolPositionIndex(
@@ -172,10 +168,6 @@ export async function buildSymbolPositionIndex(
   symbols: PikeSymbol[],
   tokens?: PikeToken[],
   bridge?: {
-    isRunning: () => boolean;
-    findOccurrences: (
-      text: string
-    ) => Promise<{ occurrences: Array<{ text: string; line: number; character: number }> }>;
     tokenize: (text: string) => Promise<PikeToken[]>;
   },
   lines?: string[]
@@ -190,34 +182,7 @@ export async function buildSymbolPositionIndex(
     if (index.size > 0) return index;
   }
 
-  // PERF-001: Fallback to findOccurrences IPC call if tokens not available
-  if (bridge?.isRunning()) {
-    try {
-      const result = await bridge.findOccurrences(text);
-
-      const index = new Map<string, CorePosition[]>();
-      for (const occ of result.occurrences) {
-        if (!meta.symbolNames.has(occ.text)) continue;
-        if (exclusions.isCommentPosition(occ.line - 1, occ.character)) continue;
-
-        // Skip definition line
-        const defLine = meta.definitionLines.get(occ.text);
-        if (defLine !== undefined && occ.line === defLine) continue;
-
-        const pos: CorePosition = { line: occ.line - 1, character: occ.character };
-        if (!index.has(occ.text)) index.set(occ.text, []);
-        index.get(occ.text)!.push(pos);
-      }
-
-      if (index.size === meta.symbolNames.size) return index;
-    } catch (err) {
-      log.error('Token-based symbol position finding failed', {
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
-
-  // Final fallback: tokenize via bridge
+  // Fallback: tokenize via bridge
   return buildSymbolPositionIndexRegex(text, symbols, linesArray, tokens, bridge);
 }
 

--- a/packages/pike-lsp-server/src/scenarios/symbol-index-tokenize-fallback.test.ts
+++ b/packages/pike-lsp-server/src/scenarios/symbol-index-tokenize-fallback.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from 'bun:test';
+import assert from 'node:assert/strict';
+import { buildSymbolPositionIndex } from '../features/diagnostics/symbol-index.js';
+import type { PikeSymbol, PikeToken } from '@pike-lsp/pike-bridge';
+
+type TokenizeBridge = { tokenize: (text: string) => Promise<PikeToken[]> };
+
+function makeSymbol(name: string, kind: string, defLine: number): PikeSymbol {
+  return {
+    name,
+    kind,
+    position: { file: 'test.pike', line: defLine },
+  } as PikeSymbol;
+}
+
+describe('buildSymbolPositionIndex: tokenize-only bridge', () => {
+  it('uses bridge.tokenize when pre-computed tokens are empty', async () => {
+    const text = 'int foo();\nint x = foo();\n';
+    const symbols = [makeSymbol('foo', 'method', 1)];
+    const bridgeTokens: PikeToken[] = [
+      { text: 'foo', line: 1, character: 4, file: 'test.pike' } as PikeToken,
+      { text: 'foo', line: 2, character: 8, file: 'test.pike' } as PikeToken,
+    ];
+    const bridge: TokenizeBridge = {
+      tokenize: async () => bridgeTokens,
+    };
+
+    const index = await buildSymbolPositionIndex(text, symbols, [], bridge);
+
+    const positions = index.get('foo');
+    assert.ok(positions !== undefined);
+    assert.strictEqual(positions!.length, 1);
+    assert.strictEqual(positions![0]!.line, 1);
+    assert.strictEqual(positions![0]!.character, 8);
+  });
+
+  it('returns empty index when bridge.tokenize throws', async () => {
+    const text = 'int foo();\nint x = foo();\n';
+    const symbols = [makeSymbol('foo', 'method', 1)];
+    const bridge: TokenizeBridge = {
+      tokenize: async () => {
+        throw new Error('bridge crashed');
+      },
+    };
+
+    const index = await buildSymbolPositionIndex(text, symbols, [], bridge);
+
+    assert.strictEqual(index.size, 0);
+  });
+
+  it('returns empty index when no tokens and no bridge provided', async () => {
+    const text = 'int foo();\nint x = foo();\n';
+    const symbols = [makeSymbol('foo', 'method', 1)];
+
+    const index = await buildSymbolPositionIndex(text, symbols, []);
+
+    assert.strictEqual(index.size, 0);
+  });
+
+  it('prefers pre-computed tokens over bridge.tokenize', async () => {
+    const text = 'int foo();\nint x = foo();\n';
+    const symbols = [makeSymbol('foo', 'method', 1)];
+    const precomputedTokens: PikeToken[] = [
+      { text: 'foo', line: 1, character: 4, file: 'test.pike' } as PikeToken,
+      { text: 'foo', line: 2, character: 8, file: 'test.pike' } as PikeToken,
+    ];
+    let tokenizeCalled = false;
+    const bridge: TokenizeBridge = {
+      tokenize: async () => {
+        tokenizeCalled = true;
+        return [];
+      },
+    };
+
+    const index = await buildSymbolPositionIndex(text, symbols, precomputedTokens, bridge);
+
+    assert.strictEqual(tokenizeCalled, false);
+    const positions = index.get('foo');
+    assert.ok(positions !== undefined);
+    assert.strictEqual(positions!.length, 1);
+    assert.strictEqual(positions![0]!.line, 1);
+  });
+
+  it('does not call findOccurrences on the bridge object', async () => {
+    const text = 'int foo();\nint x = foo();\n';
+    const symbols = [makeSymbol('foo', 'method', 1)];
+    const bridgeTokens: PikeToken[] = [
+      { text: 'foo', line: 2, character: 8, file: 'test.pike' } as PikeToken,
+    ];
+
+    // Bridge with findOccurrences that would throw if called — proves it's not invoked
+    const bridge = {
+      findOccurrences: async () => {
+        throw new Error('findOccurrences should not be called');
+      },
+      tokenize: async () => bridgeTokens,
+    } as unknown as TokenizeBridge;
+
+    // Should not throw — findOccurrences is never called
+    const index = await buildSymbolPositionIndex(text, symbols, [], bridge);
+
+    const positions = index.get('foo');
+    assert.ok(positions !== undefined);
+    assert.strictEqual(positions!.length, 1);
+    assert.strictEqual(positions![0]!.character, 8);
+  });
+});


### PR DESCRIPTION
Closes #2167

## Summary

Now I'll implement the changes. The plan: 1. **Edit `symbol-index.ts`**: Remove the `findOccurrences` fallback block (lines 193-218), simplify the bridge parameter type to only require `tokenize`. 2. **Write a scenario test**: Test that `buildSymbolPositionIndex` works correctly with only `tokenize` bridge (no `findOccurrences`).Now let me apply the edit to remove the `findOccurrences` fallback and simplify the bridge parameter:Now check if the `log` import is still used (it was only used in the removed `findOccurrences` catch block):The `log` constant is now unused. Remove it and the `Logger` import:Now let me write the scenario test:Now let's compile and run the tests:The `positions[0]` could be undefined according to strict TypeScript. Let me fix the test:I need to add non-null assertions after the `assert.ok` checks since TypeScript doesn't narrow through `assert.ok`:TypeScript compiles cleanly. Now run the existing tests:All 30 existing tests pass. Now run the new scenario test:All 5 new scenario tests pass. Let me also verify the scenario tests directory runs cleanly:All 666 tests across 59 scenario files pass with 0 failures.Done. Here's what was changed:

## Linked Issue

Closes #2167

## Root Cause

- Calls `buildSymbolPositionIndex()` which invokes `bridge.engineQuery()` (cache-builder.ts:137)
   - Calls `buildSymbolPositionIndex()` with bridge query (cache-builder.ts:239)
- Bridge crashes during `buildSymbolPositionIndex` leave document uncached
**When**: Bridge crashes during `buildSymbolPositionIndex`
- **GIVEN**: Cache building in progress, calling `buildSymbolPositionIndex`

## Changes

- packages/pike-lsp-server/src/features/diagnostics/symbol-index.ts: (see commit diffs)
- packages/pike-lsp-server/src/scenarios/symbol-index-tokenize-fallback.test.ts: (see commit diffs)

## Knowledge Base

- [x] Added/updated KB entry (see below)
- KB ID: KB-AUTO-2167

## Verification

- bunx tsc --noEmit -p packages/pike-lsp-server/tsconfig.json passes clean
- timeout 120 bun test packages/pike-lsp-server/src/tests/ — see CI results

## Checklist

- [x] Automated tests included (see Verification section)
- [x] bun run test:packages equivalent passed locally
- [x] No test coverage regression (automated agent PR)

## Notes for Reviewer

Autonomous implementation by pike-agent[bot].