### PR TITLE
feat: integrate PUnit testing framework for Pike code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,6 +193,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Check forbidden lockfiles
         run: bash scripts/check-lockfiles.sh
@@ -300,6 +302,9 @@ jobs:
 
       - name: Run Pike Tests
         run: ./scripts/run-pike-tests.sh
+
+      - name: Run PUnit Tests
+        run: ./scripts/run-punit-tests.sh --ci
 
       - name: Cross-version test summary
         if: always()

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/lib/punit"]
+	path = test/lib/punit
+	url = https://github.com/TheSmuks/punit.git

--- a/scripts/run-punit-tests.sh
+++ b/scripts/run-punit-tests.sh
@@ -39,8 +39,6 @@ if [ ! -d "$TEST_DIR" ]; then
     exit 1
 fi
 
-# Build module path: PUnit + pike-scripts (for LSP.pmod imports)
-MODULE_PATH="$PUNIT_DIR:$PIKE_SCRIPTS"
 
 # Parse options
 RUNNER_ARGS=()
@@ -68,5 +66,5 @@ echo "============================================"
 echo ""
 
 # Run PUnit test runner
-# -M adds module paths (colon-separated for Pike)
-pike -M "$MODULE_PATH" "$PUNIT_DIR/run_tests.pike" "${RUNNER_ARGS[@]}" "$TEST_DIR"
+# Each -M adds a module path (Pike does not support colon-separated -M on all versions)
+pike -M "$PUNIT_DIR" -M "$PIKE_SCRIPTS" "$PUNIT_DIR/run_tests.pike" "${RUNNER_ARGS[@]}" "$TEST_DIR"

--- a/scripts/run-punit-tests.sh
+++ b/scripts/run-punit-tests.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# PUnit Test Runner
+# Runs PUnit-based Pike tests for pike-lsp
+#
+# Usage: ./scripts/run-punit-tests.sh [options]
+# Options:
+#   --tap       Output TAP v13 format
+#   --junit=FILE  Write JUnit XML report to FILE
+#   -v          Verbose output
+#   -t TAG      Run only tests with this tag
+#   -e TAG      Exclude tests with this tag
+#   --ci        CI mode: TAP output + strict validation
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PUNIT_DIR="$PROJECT_ROOT/test/lib/punit"
+PIKE_SCRIPTS="$PROJECT_ROOT/pike-scripts"
+TEST_DIR="$PROJECT_ROOT/test/punit"
+
+cd "$PROJECT_ROOT"
+
+# Verify Pike is available
+if ! command -v pike &> /dev/null; then
+    echo "Error: Pike not found in PATH" >&2
+    exit 1
+fi
+
+# Verify PUnit submodule is present
+if [ ! -f "$PUNIT_DIR/PUnit.pmod/module.pmod" ]; then
+    echo "Error: PUnit submodule not found. Run: git submodule update --init test/lib/punit" >&2
+    exit 1
+fi
+
+# Verify test directory exists
+if [ ! -d "$TEST_DIR" ]; then
+    echo "Error: No PUnit tests found in $TEST_DIR" >&2
+    exit 1
+fi
+
+# Build module path: PUnit + pike-scripts (for LSP.pmod imports)
+MODULE_PATH="$PUNIT_DIR:$PIKE_SCRIPTS"
+
+# Parse options
+RUNNER_ARGS=()
+CI_MODE=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --ci)
+            CI_MODE=true
+            RUNNER_ARGS+=("--tap" "--strict")
+            ;;
+        *)
+            RUNNER_ARGS+=("$arg")
+            ;;
+    esac
+done
+
+echo "============================================"
+echo "      PUnit Test Suite (pike-lsp)         "
+echo "============================================"
+echo "Pike: $(pike --version 2>&1 || echo unknown)"
+echo "PUnit: $PUNIT_DIR"
+echo "Tests: $TEST_DIR"
+echo "============================================"
+echo ""
+
+# Run PUnit test runner
+# -M adds module paths (colon-separated for Pike)
+pike -M "$MODULE_PATH" "$PUNIT_DIR/run_tests.pike" "${RUNNER_ARGS[@]}" "$TEST_DIR"

--- a/test/punit/foundation-tests.pike
+++ b/test/punit/foundation-tests.pike
@@ -1,0 +1,190 @@
+#pragma strict_types
+
+//! LSP Foundation Tests (PUnit)
+//!
+//! Unit tests for LSP.pmod foundation modules:
+//! - Compat.pmod: Version detection and polyfills
+//! - Cache.pmod: LRU caching with statistics
+//!
+//! Run with: pike -M test/lib/punit -M pike-scripts run_tests.pike test/punit/foundation-tests.pike
+
+#include <PUnit.pmod/macros.h>
+import PUnit;
+inherit PUnit.TestCase;
+
+constant test_tags = ([
+	"test_compat_pike_version": ({"compat", "version"}),
+	"test_compat_pi_version_constant": ({"compat", "version"}),
+	"test_compat_trim_whites_basic": ({"compat", "trim"}),
+	"test_compat_trim_whites_tabs_and_newlines": ({"compat", "trim"}),
+	"test_compat_trim_whites_empty": ({"compat", "trim"}),
+	"test_compat_trim_whites_preserves_internal": ({"compat", "trim"}),
+	"test_cache_program_put_get": ({"cache", "lru"}),
+	"test_cache_stdlib_put_get": ({"cache"}),
+	"test_cache_clear": ({"cache"}),
+	"test_cache_program_lru_eviction": ({"cache", "lru"}),
+	"test_cache_statistics": ({"cache", "stats"}),
+	"test_cache_set_limits": ({"cache"}),
+	"test_cache_clear_all": ({"cache"}),
+]);
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+private mixed get_compat() {
+	return master()->resolv("LSP.Compat");
+}
+
+private mixed get_cache() {
+	return master()->resolv("LSP.Cache");
+}
+
+void setup() {
+	// Ensure pike-scripts/ is on the module path
+	string base = __FILE__;
+	for (int i = 0; i < 10; i++) {
+		base = dirname(base);
+		if (basename(base) == "pike-lsp") break;
+	}
+	string pike_scripts = combine_path(base, "pike-scripts");
+	master()->add_module_path(pike_scripts);
+}
+
+// ─── Compat.pmod Tests ────────────────────────────────────────────
+
+void test_compat_pike_version() {
+	mixed compat = get_compat();
+	array version = compat->pike_version();
+	assert_gte(sizeof(version), 3);
+	assert_gte(version[0], 7);
+	// Must be 7.6, 7.8, or 8.x
+	assert_true(
+		(version[0] == 7 && (version[1] == 6 || version[1] == 8)) ||
+		version[0] == 8
+	);
+}
+
+void test_compat_pi_version_constant() {
+	mixed compat = get_compat();
+	string version_str = compat->PIKE_VERSION_STRING;
+	assert_true(stringp(version_str) && sizeof(version_str) > 0);
+	assert_match("^[0-9]+\\.[0-9]+$", version_str);
+}
+
+void test_compat_trim_whites_basic() {
+	mixed compat = get_compat();
+	assert_equal("test", compat->trim_whites("  test"));
+	assert_equal("test", compat->trim_whites("test  "));
+	assert_equal("test", compat->trim_whites("  test  "));
+}
+
+void test_compat_trim_whites_tabs_and_newlines() {
+	mixed compat = get_compat();
+	assert_equal("test", compat->trim_whites("\ttest\t"));
+	assert_equal("test", compat->trim_whites("\ntest\n"));
+	assert_equal("test", compat->trim_whites(" \n\t test \t\n "));
+}
+
+void test_compat_trim_whites_empty() {
+	mixed compat = get_compat();
+	assert_equal("", compat->trim_whites(""));
+	assert_equal("", compat->trim_whites("   "));
+}
+
+void test_compat_trim_whites_preserves_internal() {
+	mixed compat = get_compat();
+	assert_equal("hello  world", compat->trim_whites("  hello  world  "));
+}
+
+// ─── Cache.pmod Tests ─────────────────────────────────────────────
+
+void test_cache_program_put_get() {
+	mixed cache = get_cache();
+	cache->clear("program_cache");
+
+	cache->put("program_cache", "key1", "program1");
+	assert_equal("program1", cache->get("program_cache", "key1"));
+	assert_null(cache->get("program_cache", "nonexistent"));
+}
+
+void test_cache_stdlib_put_get() {
+	mixed cache = get_cache();
+	cache->clear("stdlib_cache");
+
+	mapping data = (["symbols": (["foo": "bar"])]);
+	cache->put("stdlib_cache", "module1", data);
+	mixed result = cache->get("stdlib_cache", "module1");
+	assert_true(mappingp(result));
+	assert_equal("bar", result->symbols->foo);
+}
+
+void test_cache_clear() {
+	mixed cache = get_cache();
+	cache->clear("program_cache");
+
+	cache->put("program_cache", "key1", "value1");
+	cache->put("program_cache", "key2", "value2");
+	cache->clear("program_cache");
+
+	assert_null(cache->get("program_cache", "key1"));
+	assert_null(cache->get("program_cache", "key2"));
+}
+
+void test_cache_program_lru_eviction() {
+	mixed cache = get_cache();
+	cache->clear("program_cache");
+	cache->set_limits(3, 50);
+
+	cache->put("program_cache", "key1", "value1");
+	cache->put("program_cache", "key2", "value2");
+	cache->put("program_cache", "key3", "value3");
+
+	// Access key1 to make it recently used (key2 becomes LRU)
+	cache->get("program_cache", "key1");
+
+	// Add one more — should evict key2
+	cache->put("program_cache", "key4", "value4");
+
+	assert_null(cache->get("program_cache", "key2"));
+	assert_equal("value1", cache->get("program_cache", "key1"));
+	assert_equal("value3", cache->get("program_cache", "key3"));
+	assert_equal("value4", cache->get("program_cache", "key4"));
+}
+
+void test_cache_statistics() {
+	mixed cache = get_cache();
+	cache->clear("program_cache");
+	cache->clear("stdlib_cache");
+
+	mapping stats = cache->get_stats();
+	assert_equal(0, stats->program_size);
+
+	cache->put("program_cache", "key1", "value1");
+	cache->put("program_cache", "key2", "value2");
+	cache->get("program_cache", "key1");   // hit
+	cache->get("program_cache", "missing"); // miss
+
+	stats = cache->get_stats();
+	assert_equal(2, stats->program_size);
+	assert_gte(stats->program_hits, 1);
+	assert_gte(stats->program_misses, 1);
+}
+
+void test_cache_set_limits() {
+	mixed cache = get_cache();
+	cache->set_limits(5, 10);
+	mapping stats = cache->get_stats();
+	assert_equal(5, stats->program_max);
+	assert_equal(10, stats->stdlib_max);
+}
+
+void test_cache_clear_all() {
+	mixed cache = get_cache();
+	cache->put("program_cache", "key1", "value1");
+	cache->put("stdlib_cache", "module1", (["data": "test"]));
+
+	cache->clear("all");
+
+	mapping stats = cache->get_stats();
+	assert_equal(0, stats->program_size);
+	assert_equal(0, stats->stdlib_size);
+}


### PR DESCRIPTION
## Summary

Integrates [PUnit](https://github.com/TheSmuks/punit) as the testing framework for the Pike-side LSP implementation (`pike-scripts/LSP.pmod/`).

## Changes

- **PUnit submodule** at `test/lib/punit/` (TheSmuks/punit v1.0.0-2)
- **Migrated foundation tests** — `test/punit/foundation-tests.pike` converts all Compat.pmod + Cache.pmod hand-rolled tests to PUnit format with proper assertions, tags, setup/teardown
- **Runner script** — `scripts/run-punit-tests.sh` with `-v` (verbose), `--tap`/`--ci` (CI mode), `-t`/`-e` (tag filtering)
- **CI integration** — `pike-test` job now checks out submodules and runs PUnit tests against both Pike 8.0.1116 and latest

## Acceptance

- [x] `scripts/run-punit-tests.sh -v` passes locally (13 foundation tests)
- [x] CI `pike-test` matrix will validate against both Pike versions
- [x] Existing `run-pike-tests.sh` tests remain unchanged
- [x] Submodule properly configured in `.gitmodules`
- [x] PUnit test step runs after legacy Pike tests in CI

## Knowledge Base

- [x] Exempt — infrastructure PR (submodule + CI config), no behavioral change to document

resolves #2197