### PR TITLE
docs: mark pike-lsp as in maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **This project is in maintenance mode.** Its successor is [pike-language-server](https://github.com/TheSmuks/pike-language-server).
+
 # Pike LSP - Language Server for Pike
 
 [![CI Tests](https://github.com/TheSmuks/pike-lsp/workflows/Test/badge.svg)](https://github.com/TheSmuks/pike-lsp/actions/workflows/test.yml)


### PR DESCRIPTION
## Summary

Marks `pike-lsp` as in maintenance mode with `pike-language-server` as its official successor.

### Changes
- Add prominent deprecation notice to top of README.md
- PR opened from `maintenance-mode-notice` branch (required by branch protection rules)

### Notes
- Repo description update requires manual intervention or API call
- `deprecated` topic needs to be added manually to the repo settings